### PR TITLE
feat: 会員登録強化・パスワードリセット（秘密の質問）機能追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,11 @@ a personal home inventory web app.
 3. Always install the latest version of libraries.
 4. No backend server. Supabase is accessed client-side only.
 5. Never write `any` in TypeScript. Use `unknown` + Zod.
-6. Run `bunx oxlint .` before marking a task complete.
+6. Before marking any task complete, run all three checks and fix every error/warning:
+   - `bun run format:check` — format check (oxfmt)
+   - `bun run lint` — lint (oxlint + eslint)
+   - `bun run typecheck` — type check (tsc --noEmit)
+   - Combined shorthand: `bun run format:check && bun run check`
 7. 新しいコンポーネントは `docs/specs/architecture.md` のAtomicDesign分類に従い配置する
 8. `atoms/molecules/organisms` を実装したら、必ず対応する`.stories.tsx` を作成する
 9. Storybook規約は `docs/specs/storybook.md` に従う
@@ -30,9 +34,11 @@ a personal home inventory web app.
 
 ## Testing a Task
 
-After completing a task:
+After completing a task, all of the following must pass:
 
-1. `bun run build` must succeed with zero errors
-2. `bunx oxlint .` must return no errors
-3. Confirm the changed files match the spec in docs/specs/
-4. Check the success of this command: `bun run build-storybook`
+1. `bun run format:check` — zero warnings (run `bun run format` to auto-fix)
+2. `bun run lint` — zero errors and zero warnings
+3. `bun run typecheck` — zero errors
+4. `bun run build` — succeeds with zero errors
+5. Confirm the changed files match the spec in docs/specs/
+6. `bun run build-storybook` — succeeds if Storybook stories were added/changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,10 +62,14 @@ Read the relevant spec file before implementing any feature.
 
 ## Commands
 
-- Dev: bun run dev
-- Build: bun run build
-- Lint: bunx oxlint .
-- Format: bunx oxfmt .
+- Dev: `bun run dev`
+- Build: `bun run build`
+- Lint: `bun run lint` (oxlint + eslint)
+- Typecheck: `bun run typecheck` (tsc --noEmit)
+- Format check: `bun run format:check` (oxfmt --check)
+- Format (fix): `bun run format` (oxfmt .)
+- **全チェック（コミット前に必ず実行）**: `bun run format:check && bun run check`
+  - `bun run check` は lint + typecheck をまとめて実行する
 
 ## Code Style
 

--- a/src/components/atoms/PasswordStrength.stories.tsx
+++ b/src/components/atoms/PasswordStrength.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { PasswordStrength } from "./PasswordStrength";
+
+const meta = {
+  component: PasswordStrength,
+  tags: ["autodocs"],
+} satisfies Meta<typeof PasswordStrength>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  args: { password: "" },
+};
+
+export const TooShort: Story = {
+  args: { password: "Ab1!" },
+};
+
+export const OnlyLowercase: Story = {
+  args: { password: "abcdefgh" },
+};
+
+export const TwoTypes: Story = {
+  args: { password: "abcdef12" },
+};
+
+export const ThreeTypes: Story = {
+  args: { password: "Abcdef12" },
+};
+
+export const AllFourTypes: Story = {
+  args: { password: "Abcdef1!" },
+};

--- a/src/components/atoms/PasswordStrength.tsx
+++ b/src/components/atoms/PasswordStrength.tsx
@@ -1,0 +1,32 @@
+interface PasswordStrengthProps {
+  password: string;
+}
+
+const PasswordStrength = ({ password }: PasswordStrengthProps) => {
+  if (!password) return null;
+
+  const checks = {
+    length: password.length >= 8,
+    lower: /[a-z]/.test(password),
+    upper: /[A-Z]/.test(password),
+    number: /[0-9]/.test(password),
+    symbol: /[-_!?#@$%^&*()+={}[\]|;:'",.<>\\/~`]/.test(password),
+  };
+  const typeCount = [checks.lower, checks.upper, checks.number, checks.symbol].filter(
+    Boolean,
+  ).length;
+
+  return (
+    <ul className="mt-1 space-y-0.5 text-xs text-muted-foreground">
+      <li className={checks.length ? "text-green-600" : "text-destructive"}>
+        {checks.length ? "✓" : "✗"} 8文字以上
+      </li>
+      <li className={typeCount >= 3 ? "text-green-600" : "text-destructive"}>
+        {typeCount >= 3 ? "✓" : "✗"} 大文字・小文字・数字・記号のうち3種類以上（現在: {typeCount}
+        種類）
+      </li>
+    </ul>
+  );
+};
+
+export { PasswordStrength };

--- a/src/lib/auth.test.ts
+++ b/src/lib/auth.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test } from "bun:test";
+
+import { loginSchema, passwordSchema, sha256hex, signupSchema, translateAuthError } from "./auth";
+
+// ---------------------------------------------------------------------------
+// translateAuthError
+// ---------------------------------------------------------------------------
+
+describe("translateAuthError", () => {
+  test("rate limit error (over_email_send_rate_limit)", () => {
+    expect(translateAuthError("over_email_send_rate_limit")).toContain(
+      "メールの送信回数が上限に達しました",
+    );
+  });
+
+  test("rate limit error (email rate limit)", () => {
+    expect(translateAuthError("email rate limit exceeded")).toContain(
+      "メールの送信回数が上限に達しました",
+    );
+  });
+
+  test("already registered (User already registered)", () => {
+    expect(translateAuthError("User already registered")).toBe(
+      "このメールアドレスはすでに登録されています。",
+    );
+  });
+
+  test("already registered (user_already_exists)", () => {
+    expect(translateAuthError("user_already_exists")).toBe(
+      "このメールアドレスはすでに登録されています。",
+    );
+  });
+
+  test("already registered (already been registered)", () => {
+    expect(translateAuthError("Email has already been registered")).toBe(
+      "このメールアドレスはすでに登録されています。",
+    );
+  });
+
+  test("invalid credentials (Invalid login credentials)", () => {
+    expect(translateAuthError("Invalid login credentials")).toBe(
+      "メールアドレスまたはパスワードが正しくありません。",
+    );
+  });
+
+  test("invalid credentials (invalid_credentials)", () => {
+    expect(translateAuthError("invalid_credentials")).toBe(
+      "メールアドレスまたはパスワードが正しくありません。",
+    );
+  });
+
+  test("email not confirmed", () => {
+    expect(translateAuthError("Email not confirmed")).toContain(
+      "メールアドレスが確認されていません",
+    );
+  });
+
+  test("password too short (Supabase message)", () => {
+    expect(translateAuthError("Password should be at least 6 characters")).toContain(
+      "パスワードが短すぎます",
+    );
+  });
+
+  test("unknown error is returned as-is", () => {
+    const msg = "Some unexpected error";
+    expect(translateAuthError(msg)).toBe(msg);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// passwordSchema
+// ---------------------------------------------------------------------------
+
+describe("passwordSchema — 長さ", () => {
+  test("7文字は失敗", () => {
+    expect(passwordSchema.safeParse("Abcd1!x").success).toBe(false);
+  });
+
+  test("8文字は成功（他の条件を満たす場合）", () => {
+    expect(passwordSchema.safeParse("Abcd1!xy").success).toBe(true);
+  });
+});
+
+describe("passwordSchema — 使用可能文字", () => {
+  test("全角文字は失敗", () => {
+    expect(passwordSchema.safeParse("Ａｂｃｄ1!xy").success).toBe(false);
+  });
+
+  test("スペースは失敗", () => {
+    expect(passwordSchema.safeParse("Abcd 1!xy").success).toBe(false);
+  });
+});
+
+describe("passwordSchema — 3種類以上ルール", () => {
+  test("小文字のみ8文字は失敗（1種類）", () => {
+    expect(passwordSchema.safeParse("abcdefgh").success).toBe(false);
+  });
+
+  test("小文字＋数字のみは失敗（2種類）", () => {
+    expect(passwordSchema.safeParse("abcdef12").success).toBe(false);
+  });
+
+  test("小文字＋大文字＋数字は成功（3種類）", () => {
+    expect(passwordSchema.safeParse("abcdEF12").success).toBe(true);
+  });
+
+  test("小文字＋大文字＋記号は成功（3種類）", () => {
+    expect(passwordSchema.safeParse("abcdEFGH!").success).toBe(true);
+  });
+
+  test("小文字＋数字＋記号は成功（3種類）", () => {
+    expect(passwordSchema.safeParse("abcdef1!").success).toBe(true);
+  });
+
+  test("大文字＋数字＋記号は成功（3種類）", () => {
+    expect(passwordSchema.safeParse("ABCDEF1!").success).toBe(true);
+  });
+
+  test("4種類すべては成功", () => {
+    expect(passwordSchema.safeParse("Abcdef1!").success).toBe(true);
+  });
+});
+
+describe("passwordSchema — エラーメッセージ", () => {
+  test("短すぎる場合のメッセージ", () => {
+    const result = passwordSchema.safeParse("Ab1!");
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.message.includes("8文字以上"))).toBe(true);
+    }
+  });
+
+  test("種類不足の場合のメッセージ", () => {
+    const result = passwordSchema.safeParse("abcdefgh");
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.message.includes("3種類以上"))).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loginSchema
+// ---------------------------------------------------------------------------
+
+describe("loginSchema", () => {
+  test("正常なメール＋パスワードは成功", () => {
+    expect(loginSchema.safeParse({ email: "user@example.com", password: "anypass" }).success).toBe(
+      true,
+    );
+  });
+
+  test("不正なメール形式は失敗", () => {
+    expect(loginSchema.safeParse({ email: "not-an-email", password: "anypass" }).success).toBe(
+      false,
+    );
+  });
+
+  test("空パスワードは失敗", () => {
+    expect(loginSchema.safeParse({ email: "user@example.com", password: "" }).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signupSchema — パスワード一致チェック
+// ---------------------------------------------------------------------------
+
+describe("signupSchema — confirmPassword", () => {
+  const base = {
+    email: "user@example.com",
+    password: "Abcdef1!",
+    securityQuestion: "初めて飼ったペットの名前は？",
+    securityAnswer: "ポチ",
+  };
+
+  test("パスワードが一致すれば成功", () => {
+    expect(signupSchema.safeParse({ ...base, confirmPassword: "Abcdef1!" }).success).toBe(true);
+  });
+
+  test("パスワードが不一致なら失敗", () => {
+    const result = signupSchema.safeParse({ ...base, confirmPassword: "Different1!" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.message.includes("一致しません"))).toBe(true);
+    }
+  });
+
+  test("秘密の質問が空なら失敗", () => {
+    expect(
+      signupSchema.safeParse({ ...base, confirmPassword: "Abcdef1!", securityQuestion: "" })
+        .success,
+    ).toBe(false);
+  });
+
+  test("秘密の答えが空なら失敗", () => {
+    expect(
+      signupSchema.safeParse({ ...base, confirmPassword: "Abcdef1!", securityAnswer: "" }).success,
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sha256hex
+// ---------------------------------------------------------------------------
+
+describe("sha256hex", () => {
+  test("同じ入力は常に同じハッシュを返す", async () => {
+    const a = await sha256hex("hello");
+    const b = await sha256hex("hello");
+    expect(a).toBe(b);
+  });
+
+  test("異なる入力は異なるハッシュを返す", async () => {
+    const a = await sha256hex("hello");
+    const b = await sha256hex("world");
+    expect(a).not.toBe(b);
+  });
+
+  test("大文字小文字は区別される（正規化は呼び出し側の責務）", async () => {
+    const lower = await sha256hex("hello");
+    const upper = await sha256hex("HELLO");
+    expect(lower).not.toBe(upper);
+  });
+
+  test("出力は64文字の16進数文字列", async () => {
+    const hash = await sha256hex("test");
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("既知のハッシュ値（hello の SHA-256）", async () => {
+    const hash = await sha256hex("hello");
+    expect(hash).toBe("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const SECURITY_QUESTIONS = [
+  "初めて飼ったペットの名前は？",
+  "幼少期に住んでいた街の名前は？",
+  "母親の旧姓は？",
+  "最初に通った小学校の名前は？",
+  "子どもの頃の親友の名前は？",
+  "好きな本や映画のタイトルは？",
+  "初めての車のメーカーは？",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Password validation
+// ---------------------------------------------------------------------------
+
+const ALLOWED_CHARS = /^[a-zA-Z0-9\-_!?#@$%^&*()+={}[\]|;:'",.<>\\/~`]+$/;
+
+export const passwordSchema = z
+  .string()
+  .min(8, "8文字以上で入力してください")
+  .regex(ALLOWED_CHARS, "半角英数字と記号のみ使用できます")
+  .refine((val) => {
+    let types = 0;
+    if (/[a-z]/.test(val)) types++;
+    if (/[A-Z]/.test(val)) types++;
+    if (/[0-9]/.test(val)) types++;
+    if (/[-_!?#@$%^&*()+={}[\]|;:'",.<>\\/~`]/.test(val)) types++;
+    return types >= 3;
+  }, "大文字・小文字・数字・記号のうち3種類以上を使用してください");
+
+export const loginSchema = z.object({
+  email: z.string().email("有効なメールアドレスを入力してください"),
+  password: z.string().min(1, "パスワードを入力してください"),
+});
+
+export const signupSchema = z
+  .object({
+    email: z.string().email("有効なメールアドレスを入力してください"),
+    password: passwordSchema,
+    confirmPassword: z.string(),
+    securityQuestion: z.string().min(1, "秘密の質問を選択してください"),
+    securityAnswer: z.string().min(1, "答えを入力してください"),
+  })
+  .refine((d) => d.password === d.confirmPassword, {
+    message: "パスワードが一致しません",
+    path: ["confirmPassword"],
+  });
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+export const sha256hex = async (text: string): Promise<string> => {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+};
+
+export const translateAuthError = (message: string): string => {
+  if (message.includes("over_email_send_rate_limit") || message.includes("email rate limit")) {
+    return "メールの送信回数が上限に達しました。しばらく時間をおいてからお試しください。";
+  }
+  if (
+    message.includes("User already registered") ||
+    message.includes("user_already_exists") ||
+    message.includes("already been registered")
+  ) {
+    return "このメールアドレスはすでに登録されています。";
+  }
+  if (message.includes("Invalid login credentials") || message.includes("invalid_credentials")) {
+    return "メールアドレスまたはパスワードが正しくありません。";
+  }
+  if (message.includes("Email not confirmed")) {
+    return "メールアドレスが確認されていません。確認メールをご確認ください。";
+  }
+  if (message.includes("Password should be at least")) {
+    return "パスワードが短すぎます。8文字以上で入力してください。";
+  }
+  return message;
+};

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -263,6 +263,32 @@ export interface Database {
         };
         Relationships: [];
       };
+      user_security_questions: {
+        Row: {
+          user_id: string;
+          email: string;
+          question: string;
+          answer_hash: string;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          user_id: string;
+          email: string;
+          question: string;
+          answer_hash: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          user_id?: string;
+          email?: string;
+          question?: string;
+          answer_hash?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       shopping_list_items: {
         Row: {
           id: string;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from "./routes/__root";
+import { Route as ForgotPasswordRouteImport } from "./routes/forgot-password";
 import { Route as LoginRouteImport } from "./routes/login";
 import { Route as AuthRouteImport } from "./routes/_auth";
 import { Route as AuthIndexRouteImport } from "./routes/_auth.index";
@@ -22,6 +23,11 @@ import { Route as AuthItemsItemIdRouteImport } from "./routes/_auth.items.$itemI
 import { Route as AuthItemsItemIdEditRouteImport } from "./routes/_auth.items.$itemId.edit";
 import { Route as AuthItemsItemIdConsumeRouteImport } from "./routes/_auth.items.$itemId.consume";
 
+const ForgotPasswordRoute = ForgotPasswordRouteImport.update({
+  id: "/forgot-password",
+  path: "/forgot-password",
+  getParentRoute: () => rootRouteImport,
+} as any);
 const LoginRoute = LoginRouteImport.update({
   id: "/login",
   path: "/login",
@@ -84,6 +90,7 @@ const AuthItemsItemIdConsumeRoute = AuthItemsItemIdConsumeRouteImport.update({
 
 export interface FileRoutesByFullPath {
   "/": typeof AuthIndexRoute;
+  "/forgot-password": typeof ForgotPasswordRoute;
   "/login": typeof LoginRoute;
   "/settings": typeof AuthSettingsRouteWithChildren;
   "/shopping": typeof AuthShoppingRoute;
@@ -96,6 +103,7 @@ export interface FileRoutesByFullPath {
   "/items/$itemId/edit": typeof AuthItemsItemIdEditRoute;
 }
 export interface FileRoutesByTo {
+  "/forgot-password": typeof ForgotPasswordRoute;
   "/login": typeof LoginRoute;
   "/settings": typeof AuthSettingsRouteWithChildren;
   "/shopping": typeof AuthShoppingRoute;
@@ -111,6 +119,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport;
   "/_auth": typeof AuthRouteWithChildren;
+  "/forgot-password": typeof ForgotPasswordRoute;
   "/login": typeof LoginRoute;
   "/_auth/settings": typeof AuthSettingsRouteWithChildren;
   "/_auth/shopping": typeof AuthShoppingRoute;
@@ -127,6 +136,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath;
   fullPaths:
     | "/"
+    | "/forgot-password"
     | "/login"
     | "/settings"
     | "/shopping"
@@ -139,6 +149,7 @@ export interface FileRouteTypes {
     | "/items/$itemId/edit";
   fileRoutesByTo: FileRoutesByTo;
   to:
+    | "/forgot-password"
     | "/login"
     | "/settings"
     | "/shopping"
@@ -153,6 +164,7 @@ export interface FileRouteTypes {
   id:
     | "__root__"
     | "/_auth"
+    | "/forgot-password"
     | "/login"
     | "/_auth/settings"
     | "/_auth/shopping"
@@ -168,11 +180,19 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   AuthRoute: typeof AuthRouteWithChildren;
+  ForgotPasswordRoute: typeof ForgotPasswordRoute;
   LoginRoute: typeof LoginRoute;
 }
 
 declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
+    "/forgot-password": {
+      id: "/forgot-password";
+      path: "/forgot-password";
+      fullPath: "/forgot-password";
+      preLoaderRoute: typeof ForgotPasswordRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     "/login": {
       id: "/login";
       path: "/login";
@@ -308,6 +328,7 @@ const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren);
 
 const rootRouteChildren: RootRouteChildren = {
   AuthRoute: AuthRouteWithChildren,
+  ForgotPasswordRoute: ForgotPasswordRoute,
   LoginRoute: LoginRoute,
 };
 export const routeTree = rootRouteImport

--- a/src/routes/forgot-password.tsx
+++ b/src/routes/forgot-password.tsx
@@ -141,7 +141,7 @@ const Step2 = ({ email, question, onBack }: Step2Props) => {
 
     const pwResult = newPasswordSchema.safeParse(newPassword);
     if (!pwResult.success) {
-      setFieldErrors({ newPassword: pwResult.error.issues[0].message });
+      setFieldErrors({ newPassword: pwResult.error.issues[0]?.message ?? "バリデーションエラー" });
       return;
     }
     if (newPassword !== confirmPassword) {

--- a/src/routes/forgot-password.tsx
+++ b/src/routes/forgot-password.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, redirect, useNavigate } from "@tanstack/react-router";
 import { ArrowLeft, Eye, EyeOff, Loader2, Package } from "lucide-react";
-import { useState } from "react";
+import { type FormEvent, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -14,11 +14,16 @@ import { supabase } from "@/lib/supabase";
 // ---------------------------------------------------------------------------
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY as string;
 
 const callEdge = async <T,>(fn: string, body: unknown): Promise<T> => {
   const res = await fetch(`${SUPABASE_URL}/functions/v1/${fn}`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+    },
     body: JSON.stringify(body),
   });
   const data = (await res.json()) as T & { error?: string };
@@ -39,15 +44,19 @@ const Step1 = ({ onNext }: Step1Props) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (!email) return;
     setError(null);
     setIsLoading(true);
     try {
-      const { question } = await callEdge<{ question: string }>("get-security-question", {
+      const { question } = await callEdge<{ question: string | null }>("get-security-question", {
         email,
       });
+      if (!question) {
+        setError("登録情報が見つかりません");
+        return;
+      }
       onNext(email, question);
     } catch (err) {
       setError(err instanceof Error ? err.message : "エラーが発生しました");
@@ -119,7 +128,7 @@ const Step2 = ({ email, question, onBack }: Step2Props) => {
 
   const confirmMismatch = confirmPassword.length > 0 && confirmPassword !== newPassword;
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
     setFieldErrors({});
@@ -214,7 +223,6 @@ const Step2 = ({ email, question, onBack }: Step2Props) => {
                 type="button"
                 onClick={() => setShowNew((v) => !v)}
                 className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                tabIndex={-1}
                 aria-label={showNew ? "パスワードを隠す" : "パスワードを表示"}
               >
                 {showNew ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
@@ -243,7 +251,6 @@ const Step2 = ({ email, question, onBack }: Step2Props) => {
                 type="button"
                 onClick={() => setShowConfirm((v) => !v)}
                 className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                tabIndex={-1}
                 aria-label={showConfirm ? "パスワードを隠す" : "パスワードを表示"}
               >
                 {showConfirm ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}

--- a/src/routes/forgot-password.tsx
+++ b/src/routes/forgot-password.tsx
@@ -1,0 +1,346 @@
+import { createFileRoute, Link, redirect, useNavigate } from "@tanstack/react-router";
+import { ArrowLeft, Eye, EyeOff, Loader2, Package } from "lucide-react";
+import { useState } from "react";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { supabase } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// Constants & helpers
+// ---------------------------------------------------------------------------
+
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+
+const callEdge = async <T,>(fn: string, body: unknown): Promise<T> => {
+  const res = await fetch(`${SUPABASE_URL}/functions/v1/${fn}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = (await res.json()) as T & { error?: string };
+  if (!res.ok) throw new Error((data as { error?: string }).error ?? "エラーが発生しました");
+  return data;
+};
+
+const ALLOWED_CHARS = /^[a-zA-Z0-9\-_!?#@$%^&*()+={}[\]|;:'",.<>\\/~`]+$/;
+
+const newPasswordSchema = z
+  .string()
+  .min(8, "8文字以上で入力してください")
+  .regex(ALLOWED_CHARS, "半角英数字と記号のみ使用できます")
+  .refine((val) => {
+    let types = 0;
+    if (/[a-z]/.test(val)) types++;
+    if (/[A-Z]/.test(val)) types++;
+    if (/[0-9]/.test(val)) types++;
+    if (/[-_!?#@$%^&*()+={}[\]|;:'",.<>\\/~`]/.test(val)) types++;
+    return types >= 3;
+  }, "大文字・小文字・数字・記号のうち3種類以上を使用してください");
+
+// ---------------------------------------------------------------------------
+// Step 1: Email entry
+// ---------------------------------------------------------------------------
+
+interface Step1Props {
+  onNext: (email: string, question: string) => void;
+}
+
+const Step1 = ({ onNext }: Step1Props) => {
+  const [email, setEmail] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email) return;
+    setError(null);
+    setIsLoading(true);
+    try {
+      const { question } = await callEdge<{ question: string }>("get-security-question", {
+        email,
+      });
+      onNext(email, question);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <CardHeader className="pb-4">
+        <CardTitle>パスワードをリセット</CardTitle>
+        <CardDescription>
+          登録済みのメールアドレスを入力してください
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form
+          onSubmit={(e) => {
+            void handleSubmit(e);
+          }}
+          className="space-y-4"
+        >
+          {error && (
+            <div className="rounded-md border border-destructive bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+          <div className="space-y-1">
+            <Label htmlFor="email">メールアドレス</Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              required
+              autoComplete="email"
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            次へ
+          </Button>
+        </form>
+      </CardContent>
+    </>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Step 2: Answer + new password
+// ---------------------------------------------------------------------------
+
+interface Step2Props {
+  email: string;
+  question: string;
+  onBack: () => void;
+}
+
+const Step2 = ({ email, question, onBack }: Step2Props) => {
+  const navigate = useNavigate();
+  const [answer, setAnswer] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showNew, setShowNew] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  const confirmMismatch = confirmPassword.length > 0 && confirmPassword !== newPassword;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setFieldErrors({});
+
+    const pwResult = newPasswordSchema.safeParse(newPassword);
+    if (!pwResult.success) {
+      setFieldErrors({ newPassword: pwResult.error.issues[0].message });
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setFieldErrors({ confirmPassword: "パスワードが一致しません" });
+      return;
+    }
+    if (!answer.trim()) {
+      setFieldErrors({ answer: "答えを入力してください" });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await callEdge("verify-security-answer", {
+        email,
+        answer: answer.trim(),
+        new_password: newPassword,
+      });
+      alert("パスワードを変更しました。新しいパスワードでサインインしてください。");
+      void navigate({ to: "/login" });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <CardHeader className="pb-4">
+        <CardTitle>秘密の質問に回答</CardTitle>
+        <CardDescription>
+          登録時に設定した秘密の質問に答え、新しいパスワードを設定してください
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form
+          onSubmit={(e) => {
+            void handleSubmit(e);
+          }}
+          className="space-y-4"
+        >
+          {error && (
+            <div className="rounded-md border border-destructive bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          )}
+
+          {/* Secret question (read-only) */}
+          <div className="space-y-1">
+            <Label>秘密の質問</Label>
+            <p className="rounded-md border bg-muted/50 px-3 py-2 text-sm">{question}</p>
+          </div>
+
+          {/* Answer */}
+          <div className="space-y-1">
+            <Label htmlFor="answer">答え</Label>
+            <Input
+              id="answer"
+              type="text"
+              value={answer}
+              onChange={(e) => setAnswer(e.target.value)}
+              placeholder="登録時に入力した答え"
+              autoComplete="off"
+              required
+            />
+            {fieldErrors.answer && (
+              <p className="text-xs text-destructive">{fieldErrors.answer}</p>
+            )}
+          </div>
+
+          {/* New password */}
+          <div className="space-y-1">
+            <Label htmlFor="newPassword">新しいパスワード</Label>
+            <div className="relative">
+              <Input
+                id="newPassword"
+                type={showNew ? "text" : "password"}
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                placeholder="••••••••"
+                required
+                autoComplete="new-password"
+                className="pr-10"
+              />
+              <button
+                type="button"
+                onClick={() => setShowNew((v) => !v)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                tabIndex={-1}
+                aria-label={showNew ? "パスワードを隠す" : "パスワードを表示"}
+              >
+                {showNew ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
+            {fieldErrors.newPassword && (
+              <p className="text-xs text-destructive">{fieldErrors.newPassword}</p>
+            )}
+          </div>
+
+          {/* Confirm new password */}
+          <div className="space-y-1">
+            <Label htmlFor="confirmPassword">新しいパスワード（確認）</Label>
+            <div className="relative">
+              <Input
+                id="confirmPassword"
+                type={showConfirm ? "text" : "password"}
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                placeholder="••••••••"
+                required
+                autoComplete="new-password"
+                className="pr-10"
+              />
+              <button
+                type="button"
+                onClick={() => setShowConfirm((v) => !v)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                tabIndex={-1}
+                aria-label={showConfirm ? "パスワードを隠す" : "パスワードを表示"}
+              >
+                {showConfirm ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
+            {confirmMismatch && (
+              <p className="text-xs text-destructive">パスワードが一致しません</p>
+            )}
+            {fieldErrors.confirmPassword && !confirmMismatch && (
+              <p className="text-xs text-destructive">{fieldErrors.confirmPassword}</p>
+            )}
+          </div>
+
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            パスワードを変更する
+          </Button>
+
+          <Button type="button" variant="ghost" className="w-full" onClick={onBack}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            メールアドレス入力に戻る
+          </Button>
+        </form>
+      </CardContent>
+    </>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+const ForgotPasswordPage = () => {
+  const [step, setStep] = useState<1 | 2>(1);
+  const [email, setEmail] = useState("");
+  const [question, setQuestion] = useState("");
+
+  const handleStep1Next = (resolvedEmail: string, resolvedQuestion: string) => {
+    setEmail(resolvedEmail);
+    setQuestion(resolvedQuestion);
+    setStep(2);
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-muted/30 px-4">
+      <div className="mb-8 flex flex-col items-center">
+        <div className="flex items-center gap-2 text-2xl font-bold text-primary">
+          <Package className="h-8 w-8" />
+          Housekeeper
+        </div>
+      </div>
+
+      <Card className="w-full max-w-sm">
+        {step === 1 ? (
+          <Step1 onNext={handleStep1Next} />
+        ) : (
+          <Step2 email={email} question={question} onBack={() => setStep(1)} />
+        )}
+
+        <div className="px-6 pb-6 text-center">
+          <Link
+            to="/login"
+            className="text-xs text-muted-foreground underline-offset-4 hover:underline"
+          >
+            サインインに戻る
+          </Link>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export const Route = createFileRoute("/forgot-password")({
+  beforeLoad: async () => {
+    const { data } = await supabase.auth.getSession();
+    if (data.session) {
+      throw redirect({ to: "/" });
+    }
+  },
+  component: ForgotPasswordPage,
+});

--- a/src/routes/forgot-password.tsx
+++ b/src/routes/forgot-password.tsx
@@ -1,12 +1,12 @@
 import { createFileRoute, Link, redirect, useNavigate } from "@tanstack/react-router";
 import { ArrowLeft, Eye, EyeOff, Loader2, Package } from "lucide-react";
 import { useState } from "react";
-import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { passwordSchema } from "@/lib/auth";
 import { supabase } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
@@ -25,21 +25,6 @@ const callEdge = async <T,>(fn: string, body: unknown): Promise<T> => {
   if (!res.ok) throw new Error((data as { error?: string }).error ?? "エラーが発生しました");
   return data;
 };
-
-const ALLOWED_CHARS = /^[a-zA-Z0-9\-_!?#@$%^&*()+={}[\]|;:'",.<>\\/~`]+$/;
-
-const newPasswordSchema = z
-  .string()
-  .min(8, "8文字以上で入力してください")
-  .regex(ALLOWED_CHARS, "半角英数字と記号のみ使用できます")
-  .refine((val) => {
-    let types = 0;
-    if (/[a-z]/.test(val)) types++;
-    if (/[A-Z]/.test(val)) types++;
-    if (/[0-9]/.test(val)) types++;
-    if (/[-_!?#@$%^&*()+={}[\]|;:'",.<>\\/~`]/.test(val)) types++;
-    return types >= 3;
-  }, "大文字・小文字・数字・記号のうち3種類以上を使用してください");
 
 // ---------------------------------------------------------------------------
 // Step 1: Email entry
@@ -139,7 +124,7 @@ const Step2 = ({ email, question, onBack }: Step2Props) => {
     setError(null);
     setFieldErrors({});
 
-    const pwResult = newPasswordSchema.safeParse(newPassword);
+    const pwResult = passwordSchema.safeParse(newPassword);
     if (!pwResult.success) {
       setFieldErrors({ newPassword: pwResult.error.issues[0]?.message ?? "バリデーションエラー" });
       return;

--- a/src/routes/forgot-password.tsx
+++ b/src/routes/forgot-password.tsx
@@ -75,9 +75,7 @@ const Step1 = ({ onNext }: Step1Props) => {
     <>
       <CardHeader className="pb-4">
         <CardTitle>パスワードをリセット</CardTitle>
-        <CardDescription>
-          登録済みのメールアドレスを入力してください
-        </CardDescription>
+        <CardDescription>登録済みのメールアドレスを入力してください</CardDescription>
       </CardHeader>
       <CardContent>
         <form
@@ -210,9 +208,7 @@ const Step2 = ({ email, question, onBack }: Step2Props) => {
               autoComplete="off"
               required
             />
-            {fieldErrors.answer && (
-              <p className="text-xs text-destructive">{fieldErrors.answer}</p>
-            )}
+            {fieldErrors.answer && <p className="text-xs text-destructive">{fieldErrors.answer}</p>}
           </div>
 
           {/* New password */}

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -7,13 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { Select } from "@/components/ui/select";
 import { supabase } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
@@ -367,17 +361,18 @@ const LoginPage = () => {
                 {/* Secret question */}
                 <div className="space-y-1">
                   <Label htmlFor="securityQuestion">秘密の質問</Label>
-                  <Select value={securityQuestion} onValueChange={setSecurityQuestion}>
-                    <SelectTrigger id="securityQuestion">
-                      <SelectValue placeholder="質問を選択してください" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {SECURITY_QUESTIONS.map((q) => (
-                        <SelectItem key={q} value={q}>
-                          {q}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
+                  <Select
+                    id="securityQuestion"
+                    value={securityQuestion}
+                    onChange={(e) => setSecurityQuestion(e.target.value)}
+                    required
+                  >
+                    <option value="">質問を選択してください</option>
+                    {SECURITY_QUESTIONS.map((q) => (
+                      <option key={q} value={q}>
+                        {q}
+                      </option>
+                    ))}
                   </Select>
                   {fieldErrors.securityQuestion && (
                     <p className="text-xs text-destructive">{fieldErrors.securityQuestion}</p>

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,41 +1,253 @@
-import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
-import { Loader2, Package } from "lucide-react";
-import React, { useState } from "react";
+import { createFileRoute, Link, redirect, useNavigate } from "@tanstack/react-router";
+import { Eye, EyeOff, Loader2, Package } from "lucide-react";
+import { useState } from "react";
+import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { supabase } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SECURITY_QUESTIONS = [
+  "初めて飼ったペットの名前は？",
+  "幼少期に住んでいた街の名前は？",
+  "母親の旧姓は？",
+  "最初に通った小学校の名前は？",
+  "子どもの頃の親友の名前は？",
+  "好きな本や映画のタイトルは？",
+  "初めての車のメーカーは？",
+] as const;
+
+// ---------------------------------------------------------------------------
+// Validation schemas
+// ---------------------------------------------------------------------------
+
+const ALLOWED_CHARS = /^[a-zA-Z0-9\-_!?#@$%^&*()+={}[\]|;:'",.<>\\/~`]+$/;
+
+const passwordSchema = z
+  .string()
+  .min(8, "8文字以上で入力してください")
+  .regex(ALLOWED_CHARS, "半角英数字と記号のみ使用できます")
+  .refine((val) => {
+    let types = 0;
+    if (/[a-z]/.test(val)) types++;
+    if (/[A-Z]/.test(val)) types++;
+    if (/[0-9]/.test(val)) types++;
+    if (/[-_!?#@$%^&*()+={}[\]|;:'",.<>\\/~`]/.test(val)) types++;
+    return types >= 3;
+  }, "大文字・小文字・数字・記号のうち3種類以上を使用してください");
+
+const signupSchema = z
+  .object({
+    email: z.string().email("有効なメールアドレスを入力してください"),
+    password: passwordSchema,
+    confirmPassword: z.string(),
+    securityQuestion: z.string().min(1, "秘密の質問を選択してください"),
+    securityAnswer: z.string().min(1, "答えを入力してください"),
+  })
+  .refine((d) => d.password === d.confirmPassword, {
+    message: "パスワードが一致しません",
+    path: ["confirmPassword"],
+  });
+
+const loginSchema = z.object({
+  email: z.string().email("有効なメールアドレスを入力してください"),
+  password: z.string().min(1, "パスワードを入力してください"),
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const sha256hex = async (text: string): Promise<string> => {
+  const buf = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(text),
+  );
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+};
+
+const translateAuthError = (message: string): string => {
+  if (message.includes("over_email_send_rate_limit") || message.includes("email rate limit")) {
+    return "メールの送信回数が上限に達しました。しばらく時間をおいてからお試しください。";
+  }
+  if (
+    message.includes("User already registered") ||
+    message.includes("user_already_exists") ||
+    message.includes("already been registered")
+  ) {
+    return "このメールアドレスはすでに登録されています。";
+  }
+  if (message.includes("Invalid login credentials") || message.includes("invalid_credentials")) {
+    return "メールアドレスまたはパスワードが正しくありません。";
+  }
+  if (message.includes("Email not confirmed")) {
+    return "メールアドレスが確認されていません。確認メールをご確認ください。";
+  }
+  if (message.includes("Password should be at least")) {
+    return "パスワードが短すぎます。8文字以上で入力してください。";
+  }
+  return message;
+};
+
+// ---------------------------------------------------------------------------
+// Password strength indicator
+// ---------------------------------------------------------------------------
+
+interface PasswordStrengthProps {
+  password: string;
+}
+
+const PasswordStrength = ({ password }: PasswordStrengthProps) => {
+  if (!password) return null;
+
+  const checks = {
+    length: password.length >= 8,
+    lower: /[a-z]/.test(password),
+    upper: /[A-Z]/.test(password),
+    number: /[0-9]/.test(password),
+    symbol: /[-_!?#@$%^&*()+={}[\]|;:'",.<>\\/~`]/.test(password),
+  };
+  const typeCount = [checks.lower, checks.upper, checks.number, checks.symbol].filter(Boolean)
+    .length;
+
+  return (
+    <ul className="mt-1 space-y-0.5 text-xs text-muted-foreground">
+      <li className={checks.length ? "text-green-600" : "text-destructive"}>
+        {checks.length ? "✓" : "✗"} 8文字以上
+      </li>
+      <li className={typeCount >= 3 ? "text-green-600" : "text-destructive"}>
+        {typeCount >= 3 ? "✓" : "✗"} 大文字・小文字・数字・記号のうち3種類以上（現在: {typeCount}種類）
+      </li>
+    </ul>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Page component
+// ---------------------------------------------------------------------------
 
 const LoginPage = () => {
   const navigate = useNavigate();
+  const [mode, setMode] = useState<"login" | "signup">("login");
+
+  // Common fields
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+
+  // Signup-only fields
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [securityQuestion, setSecurityQuestion] = useState("");
+  const [securityAnswer, setSecurityAnswer] = useState("");
+
+  // UI state
   const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [mode, setMode] = useState<"login" | "signup">("login");
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [globalError, setGlobalError] = useState<string | null>(null);
+
+  const clearErrors = () => {
+    setFieldErrors({});
+    setGlobalError(null);
+  };
+
+  const switchMode = (next: "login" | "signup") => {
+    setMode(next);
+    clearErrors();
+    setConfirmPassword("");
+    setSecurityQuestion("");
+    setSecurityAnswer("");
+  };
+
+  const handleLogin = async () => {
+    const result = loginSchema.safeParse({ email, password });
+    if (!result.success) {
+      const errs: Record<string, string> = {};
+      for (const issue of result.error.issues) errs[issue.path[0] as string] = issue.message;
+      setFieldErrors(errs);
+      return;
+    }
+
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) throw new Error(translateAuthError(error.message));
+    void navigate({ to: "/" });
+  };
+
+  const handleSignup = async () => {
+    const result = signupSchema.safeParse({
+      email,
+      password,
+      confirmPassword,
+      securityQuestion,
+      securityAnswer,
+    });
+    if (!result.success) {
+      const errs: Record<string, string> = {};
+      for (const issue of result.error.issues) errs[issue.path[0] as string] = issue.message;
+      setFieldErrors(errs);
+      return;
+    }
+
+    const { data, error } = await supabase.auth.signUp({ email, password });
+    if (error) throw new Error(translateAuthError(error.message));
+
+    if (!data.session) {
+      // Email confirmation required
+      setGlobalError(null);
+      setFieldErrors({});
+      alert("確認メールを送信しました。メールのリンクをクリックしてからログインしてください。");
+      switchMode("login");
+      return;
+    }
+
+    // Store security question (user is now authenticated)
+    const answerHash = await sha256hex(securityAnswer.toLowerCase().trim());
+    const { error: sqError } = await supabase.from("user_security_questions").upsert({
+      user_id: data.session.user.id,
+      email: email.toLowerCase().trim(),
+      question: securityQuestion,
+      answer_hash: answerHash,
+    });
+    if (sqError) console.error("Failed to save security question:", sqError);
+
+    void navigate({ to: "/" });
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    clearErrors();
     setIsLoading(true);
-    setError(null);
-
     try {
       if (mode === "login") {
-        const { error } = await supabase.auth.signInWithPassword({ email, password });
-        if (error) throw error;
+        await handleLogin();
       } else {
-        const { error } = await supabase.auth.signUp({ email, password });
-        if (error) throw error;
+        await handleSignup();
       }
-      void navigate({ to: "/" });
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Authentication failed");
+      setGlobalError(err instanceof Error ? err.message : "認証に失敗しました");
     } finally {
       setIsLoading(false);
     }
   };
+
+  // Real-time confirm password check
+  const confirmMismatch =
+    mode === "signup" && confirmPassword.length > 0 && confirmPassword !== password;
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-muted/30 px-4">
@@ -49,11 +261,11 @@ const LoginPage = () => {
 
       <Card className="w-full max-w-sm">
         <CardHeader className="pb-4">
-          <CardTitle>{mode === "login" ? "Sign in" : "Create account"}</CardTitle>
+          <CardTitle>{mode === "login" ? "サインイン" : "アカウント作成"}</CardTitle>
           <CardDescription>
             {mode === "login"
-              ? "Enter your credentials to continue"
-              : "Sign up to start tracking your inventory"}
+              ? "メールアドレスとパスワードでサインインします"
+              : "情報を入力してアカウントを作成してください"}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -63,13 +275,15 @@ const LoginPage = () => {
             }}
             className="space-y-4"
           >
-            {error && (
+            {globalError && (
               <div className="rounded-md border border-destructive bg-destructive/10 p-3 text-sm text-destructive">
-                {error}
+                {globalError}
               </div>
             )}
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
+
+            {/* Email */}
+            <div className="space-y-1">
+              <Label htmlFor="email">メールアドレス</Label>
               <Input
                 id="email"
                 type="email"
@@ -79,36 +293,147 @@ const LoginPage = () => {
                 required
                 autoComplete="email"
               />
+              {fieldErrors.email && (
+                <p className="text-xs text-destructive">{fieldErrors.email}</p>
+              )}
             </div>
-            <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
-              <Input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="••••••••"
-                required
-                autoComplete={mode === "login" ? "current-password" : "new-password"}
-              />
+
+            {/* Password */}
+            <div className="space-y-1">
+              <Label htmlFor="password">パスワード</Label>
+              <div className="relative">
+                <Input
+                  id="password"
+                  type={showPassword ? "text" : "password"}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="••••••••"
+                  required
+                  autoComplete={mode === "login" ? "current-password" : "new-password"}
+                  className="pr-10"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  tabIndex={-1}
+                  aria-label={showPassword ? "パスワードを隠す" : "パスワードを表示"}
+                >
+                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
+              {fieldErrors.password && (
+                <p className="text-xs text-destructive">{fieldErrors.password}</p>
+              )}
+              {mode === "signup" && <PasswordStrength password={password} />}
             </div>
+
+            {/* Signup-only fields */}
+            {mode === "signup" && (
+              <>
+                {/* Confirm password */}
+                <div className="space-y-1">
+                  <Label htmlFor="confirmPassword">パスワード（確認）</Label>
+                  <div className="relative">
+                    <Input
+                      id="confirmPassword"
+                      type={showConfirmPassword ? "text" : "password"}
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      placeholder="••••••••"
+                      required
+                      autoComplete="new-password"
+                      className="pr-10"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowConfirmPassword((v) => !v)}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                      tabIndex={-1}
+                      aria-label={showConfirmPassword ? "パスワードを隠す" : "パスワードを表示"}
+                    >
+                      {showConfirmPassword ? (
+                        <EyeOff className="h-4 w-4" />
+                      ) : (
+                        <Eye className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
+                  {confirmMismatch && (
+                    <p className="text-xs text-destructive">パスワードが一致しません</p>
+                  )}
+                  {fieldErrors.confirmPassword && !confirmMismatch && (
+                    <p className="text-xs text-destructive">{fieldErrors.confirmPassword}</p>
+                  )}
+                </div>
+
+                {/* Secret question */}
+                <div className="space-y-1">
+                  <Label htmlFor="securityQuestion">秘密の質問</Label>
+                  <Select value={securityQuestion} onValueChange={setSecurityQuestion}>
+                    <SelectTrigger id="securityQuestion">
+                      <SelectValue placeholder="質問を選択してください" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {SECURITY_QUESTIONS.map((q) => (
+                        <SelectItem key={q} value={q}>
+                          {q}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {fieldErrors.securityQuestion && (
+                    <p className="text-xs text-destructive">{fieldErrors.securityQuestion}</p>
+                  )}
+                </div>
+
+                {/* Secret answer */}
+                <div className="space-y-1">
+                  <Label htmlFor="securityAnswer">秘密の質問の答え</Label>
+                  <Input
+                    id="securityAnswer"
+                    type="text"
+                    value={securityAnswer}
+                    onChange={(e) => setSecurityAnswer(e.target.value)}
+                    placeholder="答えを入力"
+                    autoComplete="off"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    パスワードを忘れた際の本人確認に使用します
+                  </p>
+                  {fieldErrors.securityAnswer && (
+                    <p className="text-xs text-destructive">{fieldErrors.securityAnswer}</p>
+                  )}
+                </div>
+              </>
+            )}
+
             <Button type="submit" className="w-full" disabled={isLoading}>
               {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {mode === "login" ? "Sign in" : "Create account"}
+              {mode === "login" ? "サインイン" : "アカウント作成"}
             </Button>
+
             <Button
               type="button"
               variant="ghost"
               className="w-full"
-              onClick={() => {
-                setMode(mode === "login" ? "signup" : "login");
-                setError(null);
-              }}
+              onClick={() => switchMode(mode === "login" ? "signup" : "login")}
             >
               {mode === "login"
-                ? "Don't have an account? Sign up"
-                : "Already have an account? Sign in"}
+                ? "アカウントをお持ちでない方はこちら"
+                : "すでにアカウントをお持ちの方はこちら"}
             </Button>
+
+            {mode === "login" && (
+              <div className="text-center">
+                <Link
+                  to="/forgot-password"
+                  className="text-xs text-muted-foreground underline-offset-4 hover:underline"
+                >
+                  パスワードを忘れた方はこちら
+                </Link>
+              </div>
+            )}
           </form>
         </CardContent>
       </Card>

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,99 +1,20 @@
 import { createFileRoute, Link, redirect, useNavigate } from "@tanstack/react-router";
 import { Eye, EyeOff, Loader2, Package } from "lucide-react";
 import { useState } from "react";
-import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select } from "@/components/ui/select";
+import {
+  loginSchema,
+  SECURITY_QUESTIONS,
+  sha256hex,
+  signupSchema,
+  translateAuthError,
+} from "@/lib/auth";
 import { supabase } from "@/lib/supabase";
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const SECURITY_QUESTIONS = [
-  "初めて飼ったペットの名前は？",
-  "幼少期に住んでいた街の名前は？",
-  "母親の旧姓は？",
-  "最初に通った小学校の名前は？",
-  "子どもの頃の親友の名前は？",
-  "好きな本や映画のタイトルは？",
-  "初めての車のメーカーは？",
-] as const;
-
-// ---------------------------------------------------------------------------
-// Validation schemas
-// ---------------------------------------------------------------------------
-
-const ALLOWED_CHARS = /^[a-zA-Z0-9\-_!?#@$%^&*()+={}[\]|;:'",.<>\\/~`]+$/;
-
-const passwordSchema = z
-  .string()
-  .min(8, "8文字以上で入力してください")
-  .regex(ALLOWED_CHARS, "半角英数字と記号のみ使用できます")
-  .refine((val) => {
-    let types = 0;
-    if (/[a-z]/.test(val)) types++;
-    if (/[A-Z]/.test(val)) types++;
-    if (/[0-9]/.test(val)) types++;
-    if (/[-_!?#@$%^&*()+={}[\]|;:'",.<>\\/~`]/.test(val)) types++;
-    return types >= 3;
-  }, "大文字・小文字・数字・記号のうち3種類以上を使用してください");
-
-const signupSchema = z
-  .object({
-    email: z.string().email("有効なメールアドレスを入力してください"),
-    password: passwordSchema,
-    confirmPassword: z.string(),
-    securityQuestion: z.string().min(1, "秘密の質問を選択してください"),
-    securityAnswer: z.string().min(1, "答えを入力してください"),
-  })
-  .refine((d) => d.password === d.confirmPassword, {
-    message: "パスワードが一致しません",
-    path: ["confirmPassword"],
-  });
-
-const loginSchema = z.object({
-  email: z.string().email("有効なメールアドレスを入力してください"),
-  password: z.string().min(1, "パスワードを入力してください"),
-});
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-const sha256hex = async (text: string): Promise<string> => {
-  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
-  return Array.from(new Uint8Array(buf))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-};
-
-const translateAuthError = (message: string): string => {
-  if (message.includes("over_email_send_rate_limit") || message.includes("email rate limit")) {
-    return "メールの送信回数が上限に達しました。しばらく時間をおいてからお試しください。";
-  }
-  if (
-    message.includes("User already registered") ||
-    message.includes("user_already_exists") ||
-    message.includes("already been registered")
-  ) {
-    return "このメールアドレスはすでに登録されています。";
-  }
-  if (message.includes("Invalid login credentials") || message.includes("invalid_credentials")) {
-    return "メールアドレスまたはパスワードが正しくありません。";
-  }
-  if (message.includes("Email not confirmed")) {
-    return "メールアドレスが確認されていません。確認メールをご確認ください。";
-  }
-  if (message.includes("Password should be at least")) {
-    return "パスワードが短すぎます。8文字以上で入力してください。";
-  }
-  return message;
-};
 
 // ---------------------------------------------------------------------------
 // Password strength indicator
@@ -210,13 +131,12 @@ const LoginPage = () => {
 
     // Store security question (user is now authenticated)
     const answerHash = await sha256hex(securityAnswer.toLowerCase().trim());
-    const { error: sqError } = await supabase.from("user_security_questions").upsert({
+    await supabase.from("user_security_questions").upsert({
       user_id: data.session.user.id,
       email: email.toLowerCase().trim(),
       question: securityQuestion,
       answer_hash: answerHash,
     });
-    if (sqError) console.error("Failed to save security question:", sqError);
 
     void navigate({ to: "/" });
   };

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -72,10 +72,7 @@ const loginSchema = z.object({
 // ---------------------------------------------------------------------------
 
 const sha256hex = async (text: string): Promise<string> => {
-  const buf = await crypto.subtle.digest(
-    "SHA-256",
-    new TextEncoder().encode(text),
-  );
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
   return Array.from(new Uint8Array(buf))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
@@ -122,8 +119,9 @@ const PasswordStrength = ({ password }: PasswordStrengthProps) => {
     number: /[0-9]/.test(password),
     symbol: /[-_!?#@$%^&*()+={}[\]|;:'",.<>\\/~`]/.test(password),
   };
-  const typeCount = [checks.lower, checks.upper, checks.number, checks.symbol].filter(Boolean)
-    .length;
+  const typeCount = [checks.lower, checks.upper, checks.number, checks.symbol].filter(
+    Boolean,
+  ).length;
 
   return (
     <ul className="mt-1 space-y-0.5 text-xs text-muted-foreground">
@@ -131,7 +129,8 @@ const PasswordStrength = ({ password }: PasswordStrengthProps) => {
         {checks.length ? "✓" : "✗"} 8文字以上
       </li>
       <li className={typeCount >= 3 ? "text-green-600" : "text-destructive"}>
-        {typeCount >= 3 ? "✓" : "✗"} 大文字・小文字・数字・記号のうち3種類以上（現在: {typeCount}種類）
+        {typeCount >= 3 ? "✓" : "✗"} 大文字・小文字・数字・記号のうち3種類以上（現在: {typeCount}
+        種類）
       </li>
     </ul>
   );
@@ -293,9 +292,7 @@ const LoginPage = () => {
                 required
                 autoComplete="email"
               />
-              {fieldErrors.email && (
-                <p className="text-xs text-destructive">{fieldErrors.email}</p>
-              )}
+              {fieldErrors.email && <p className="text-xs text-destructive">{fieldErrors.email}</p>}
             </div>
 
             {/* Password */}

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, redirect, useNavigate } from "@tanstack/react-router";
 import { Eye, EyeOff, Loader2, Package } from "lucide-react";
-import { useState } from "react";
+import { type FormEvent, useState } from "react";
 
 import { PasswordStrength } from "@/components/atoms/PasswordStrength";
 import { Button } from "@/components/ui/button";
@@ -96,18 +96,24 @@ const LoginPage = () => {
     }
 
     // Store security question (user is now authenticated)
-    const answerHash = await sha256hex(securityAnswer.toLowerCase().trim());
-    await supabase.from("user_security_questions").upsert({
+    const answerHash = await sha256hex(
+      data.session.user.id + ":" + securityAnswer.toLowerCase().trim(),
+    );
+    const { error: sqError } = await supabase.from("user_security_questions").upsert({
       user_id: data.session.user.id,
       email: email.toLowerCase().trim(),
       question: securityQuestion,
       answer_hash: answerHash,
     });
+    if (sqError) {
+      await supabase.auth.signOut();
+      throw new Error("アカウントの初期設定に失敗しました。もう一度お試しください。");
+    }
 
     void navigate({ to: "/" });
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     clearErrors();
     setIsLoading(true);
@@ -193,7 +199,6 @@ const LoginPage = () => {
                   type="button"
                   onClick={() => setShowPassword((v) => !v)}
                   className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                  tabIndex={-1}
                   aria-label={showPassword ? "パスワードを隠す" : "パスワードを表示"}
                 >
                   {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
@@ -226,7 +231,6 @@ const LoginPage = () => {
                       type="button"
                       onClick={() => setShowConfirmPassword((v) => !v)}
                       className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                      tabIndex={-1}
                       aria-label={showConfirmPassword ? "パスワードを隠す" : "パスワードを表示"}
                     >
                       {showConfirmPassword ? (

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link, redirect, useNavigate } from "@tanstack/react-ro
 import { Eye, EyeOff, Loader2, Package } from "lucide-react";
 import { useState } from "react";
 
+import { PasswordStrength } from "@/components/atoms/PasswordStrength";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -15,41 +16,6 @@ import {
   translateAuthError,
 } from "@/lib/auth";
 import { supabase } from "@/lib/supabase";
-
-// ---------------------------------------------------------------------------
-// Password strength indicator
-// ---------------------------------------------------------------------------
-
-interface PasswordStrengthProps {
-  password: string;
-}
-
-const PasswordStrength = ({ password }: PasswordStrengthProps) => {
-  if (!password) return null;
-
-  const checks = {
-    length: password.length >= 8,
-    lower: /[a-z]/.test(password),
-    upper: /[A-Z]/.test(password),
-    number: /[0-9]/.test(password),
-    symbol: /[-_!?#@$%^&*()+={}[\]|;:'",.<>\\/~`]/.test(password),
-  };
-  const typeCount = [checks.lower, checks.upper, checks.number, checks.symbol].filter(
-    Boolean,
-  ).length;
-
-  return (
-    <ul className="mt-1 space-y-0.5 text-xs text-muted-foreground">
-      <li className={checks.length ? "text-green-600" : "text-destructive"}>
-        {checks.length ? "✓" : "✗"} 8文字以上
-      </li>
-      <li className={typeCount >= 3 ? "text-green-600" : "text-destructive"}>
-        {typeCount >= 3 ? "✓" : "✗"} 大文字・小文字・数字・記号のうち3種類以上（現在: {typeCount}
-        種類）
-      </li>
-    </ul>
-  );
-};
 
 // ---------------------------------------------------------------------------
 // Page component

--- a/supabase/functions/get-security-question/index.ts
+++ b/supabase/functions/get-security-question/index.ts
@@ -1,0 +1,44 @@
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+
+  try {
+    const { email } = (await req.json()) as { email?: string };
+
+    if (!email) return json({ error: "email is required" }, 400);
+
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    );
+
+    const { data, error } = await supabase
+      .from("user_security_questions")
+      .select("question")
+      .eq("email", email.toLowerCase().trim())
+      .single();
+
+    if (error || !data) {
+      // Intentionally vague to avoid email enumeration
+      return json({ error: "登録情報が見つかりません" }, 404);
+    }
+
+    return json({ question: data.question });
+  } catch (err) {
+    console.error(err);
+    return json({ error: "Internal server error" }, 500);
+  }
+});

--- a/supabase/functions/get-security-question/index.ts
+++ b/supabase/functions/get-security-question/index.ts
@@ -16,9 +16,9 @@ Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
 
   try {
-    const { email } = (await req.json()) as { email?: string };
+    const { email } = (await req.json()) as { email?: unknown };
 
-    if (!email) return json({ error: "email is required" }, 400);
+    if (typeof email !== "string" || !email) return json({ error: "email is required" }, 400);
 
     const supabase = createClient(
       Deno.env.get("SUPABASE_URL")!,
@@ -32,8 +32,8 @@ Deno.serve(async (req: Request) => {
       .single();
 
     if (error || !data) {
-      // Intentionally vague to avoid email enumeration
-      return json({ error: "登録情報が見つかりません" }, 404);
+      // Return null question instead of 404 to avoid email enumeration
+      return json({ question: null });
     }
 
     return json({ question: data.question });

--- a/supabase/functions/verify-security-answer/index.ts
+++ b/supabase/functions/verify-security-answer/index.ts
@@ -13,10 +13,7 @@ const json = (body: unknown, status = 200) =>
   });
 
 const sha256hex = async (text: string): Promise<string> => {
-  const buf = await crypto.subtle.digest(
-    "SHA-256",
-    new TextEncoder().encode(text),
-  );
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
   return Array.from(new Uint8Array(buf))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
@@ -56,10 +53,9 @@ Deno.serve(async (req: Request) => {
       return json({ error: "秘密の質問の答えが正しくありません" }, 401);
     }
 
-    const { error: updateError } = await supabase.auth.admin.updateUserById(
-      row.user_id,
-      { password: new_password },
-    );
+    const { error: updateError } = await supabase.auth.admin.updateUserById(row.user_id, {
+      password: new_password,
+    });
 
     if (updateError) {
       console.error(updateError);

--- a/supabase/functions/verify-security-answer/index.ts
+++ b/supabase/functions/verify-security-answer/index.ts
@@ -24,13 +24,19 @@ Deno.serve(async (req: Request) => {
 
   try {
     const { email, answer, new_password } = (await req.json()) as {
-      email?: string;
-      answer?: string;
-      new_password?: string;
+      email?: unknown;
+      answer?: unknown;
+      new_password?: unknown;
     };
 
-    if (!email || !answer || !new_password) {
-      return json({ error: "email, answer, new_password are required" }, 400);
+    if (typeof email !== "string" || !email) {
+      return json({ error: "email is required" }, 400);
+    }
+    if (typeof answer !== "string" || !answer) {
+      return json({ error: "answer is required" }, 400);
+    }
+    if (typeof new_password !== "string" || !new_password) {
+      return json({ error: "new_password is required" }, 400);
     }
 
     const supabase = createClient(
@@ -45,10 +51,11 @@ Deno.serve(async (req: Request) => {
       .single();
 
     if (fetchError || !row) {
-      return json({ error: "登録情報が見つかりません" }, 404);
+      // Return 401 (same as wrong answer) to avoid email enumeration
+      return json({ error: "秘密の質問の答えが正しくありません" }, 401);
     }
 
-    const hash = await sha256hex(answer.toLowerCase().trim());
+    const hash = await sha256hex(row.user_id + ":" + answer.toLowerCase().trim());
     if (hash !== row.answer_hash) {
       return json({ error: "秘密の質問の答えが正しくありません" }, 401);
     }

--- a/supabase/functions/verify-security-answer/index.ts
+++ b/supabase/functions/verify-security-answer/index.ts
@@ -1,0 +1,74 @@
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+const json = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+
+const sha256hex = async (text: string): Promise<string> => {
+  const buf = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(text),
+  );
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+};
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+
+  try {
+    const { email, answer, new_password } = (await req.json()) as {
+      email?: string;
+      answer?: string;
+      new_password?: string;
+    };
+
+    if (!email || !answer || !new_password) {
+      return json({ error: "email, answer, new_password are required" }, 400);
+    }
+
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    );
+
+    const { data: row, error: fetchError } = await supabase
+      .from("user_security_questions")
+      .select("user_id, answer_hash")
+      .eq("email", email.toLowerCase().trim())
+      .single();
+
+    if (fetchError || !row) {
+      return json({ error: "登録情報が見つかりません" }, 404);
+    }
+
+    const hash = await sha256hex(answer.toLowerCase().trim());
+    if (hash !== row.answer_hash) {
+      return json({ error: "秘密の質問の答えが正しくありません" }, 401);
+    }
+
+    const { error: updateError } = await supabase.auth.admin.updateUserById(
+      row.user_id,
+      { password: new_password },
+    );
+
+    if (updateError) {
+      console.error(updateError);
+      return json({ error: "パスワードの更新に失敗しました" }, 500);
+    }
+
+    return json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return json({ error: "Internal server error" }, 500);
+  }
+});

--- a/supabase/migrations/20260506000001_create_user_security_questions.sql
+++ b/supabase/migrations/20260506000001_create_user_security_questions.sql
@@ -1,0 +1,17 @@
+create table public.user_security_questions (
+  user_id   uuid primary key references auth.users(id) on delete cascade,
+  email     text not null,
+  question  text not null,
+  answer_hash text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.user_security_questions enable row level security;
+
+create policy "user_security_questions_owner_all" on public.user_security_questions for all
+  using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+create trigger user_security_questions_set_updated_at
+  before update on public.user_security_questions
+  for each row execute function public.set_updated_at();

--- a/supabase/migrations/20260506000002_fix_user_security_questions.sql
+++ b/supabase/migrations/20260506000002_fix_user_security_questions.sql
@@ -1,0 +1,9 @@
+-- Add unique constraint on email (case-insensitive) to prevent duplicate registrations
+create unique index user_security_questions_email_unique on public.user_security_questions (lower(email));
+
+-- Fix RLS with check to also verify email matches the authenticated user's JWT email
+drop policy "user_security_questions_owner_all" on public.user_security_questions;
+
+create policy "user_security_questions_owner_all" on public.user_security_questions for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id and lower(email) = lower(auth.email()));


### PR DESCRIPTION
- email rate limit / already registered エラーを日本語メッセージに変換
- サインアップ時にパスワード確認入力・強度チェック（8文字以上・3種類以上）を追加
- サインアップ時に秘密の質問/回答を登録（パスワードリセット用）
- /forgot-password ページ追加: 秘密の質問に正解でパスワード再設定
- Edge Functions: get-security-question / verify-security-answer
- DB migration: user_security_questions テーブル追加

https://claude.ai/code/session_01S1zh7yZKnYxx1FU3bgfnNQ