### PR TITLE
fix: inventory detail buttons, quantity display, footer redesign

### DIFF
--- a/src/components/molecules/ItemCard.tsx
+++ b/src/components/molecules/ItemCard.tsx
@@ -64,11 +64,7 @@ export const ItemCard = ({ item, categoryName, locationName, warningDays }: Item
             {isEmpty ? (
               <span className="text-muted-foreground">{t("emptyStock")}</span>
             ) : (
-              <span>
-                {item.units}
-                {t("common:all") ? "" : ""}{" "}
-                <span className="text-xs text-muted-foreground">{item.content_unit}</span>
-              </span>
+              <span>{t("unitsDisplay", { units: item.units })}</span>
             )}
           </span>
           <ExpiryBadge expiryDate={item.expiry_date} warningDays={warningDays} />

--- a/src/locales/ja/shopping.json
+++ b/src/locales/ja/shopping.json
@@ -11,7 +11,7 @@
   "markPurchased": "購入完了",
   "noItems": "買い物リストは空です",
   "noPurchased": "購入済みアイテムはありません",
-  "restock": "補充",
+  "restock": "再購入",
   "purchaseComplete": "購入完了にする",
   "purchaseDialog": "購入完了 — 在庫に追加",
   "createItemFromPurchase": "在庫に追加",

--- a/src/routes/_auth.items.$itemId.tsx
+++ b/src/routes/_auth.items.$itemId.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import {
   ArrowLeft,
   Calendar,
@@ -133,28 +133,31 @@ const ItemDetailPage = () => {
           <ArrowLeft className="h-5 w-5" />
         </Button>
         <div className="flex gap-2">
-          <Link to="/items/$itemId/consume" params={{ itemId }}>
-            <Button variant="outline" size="sm" disabled={isEmpty}>
-              <Zap className="mr-1 h-4 w-4" />
-              {t("consume")}
-            </Button>
-          </Link>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={isEmpty}
+            onClick={() => void navigate({ to: "/items/$itemId/consume", params: { itemId } })}
+          >
+            <Zap className="mr-1 h-4 w-4" />
+            {t("consume")}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void handleRestock()}
+            disabled={upsertShopping.isPending}
+          >
+            <RefreshCw className="h-4 w-4" />
+            {t("shopping:restock")}
+          </Button>
           <Button
             variant="outline"
             size="icon"
-            onClick={() => {
-              void handleRestock();
-            }}
-            disabled={upsertShopping.isPending}
-            title={t("shopping:restock")}
+            onClick={() => void navigate({ to: "/items/$itemId/edit", params: { itemId } })}
           >
-            <RefreshCw className="h-4 w-4" />
+            <Edit className="h-4 w-4" />
           </Button>
-          <Link to="/items/$itemId/edit" params={{ itemId }}>
-            <Button variant="outline" size="icon">
-              <Edit className="h-4 w-4" />
-            </Button>
-          </Link>
           <Button
             variant="destructive"
             size="icon"

--- a/src/routes/_auth.items.$itemId.tsx
+++ b/src/routes/_auth.items.$itemId.tsx
@@ -129,7 +129,12 @@ const ItemDetailPage = () => {
 
       {/* Header */}
       <div className="flex items-center justify-between">
-        <Button variant="ghost" size="icon" onClick={() => void navigate({ to: "/" })}>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label={tc("back")}
+          onClick={() => void navigate({ to: "/" })}
+        >
           <ArrowLeft className="h-5 w-5" />
         </Button>
         <div className="flex gap-2">
@@ -139,7 +144,7 @@ const ItemDetailPage = () => {
             disabled={isEmpty}
             onClick={() => void navigate({ to: "/items/$itemId/consume", params: { itemId } })}
           >
-            <Zap className="mr-1 h-4 w-4" />
+            <Zap className="h-4 w-4" />
             {t("consume")}
           </Button>
           <Button
@@ -154,6 +159,7 @@ const ItemDetailPage = () => {
           <Button
             variant="outline"
             size="icon"
+            aria-label={tc("edit")}
             onClick={() => void navigate({ to: "/items/$itemId/edit", params: { itemId } })}
           >
             <Edit className="h-4 w-4" />
@@ -161,6 +167,7 @@ const ItemDetailPage = () => {
           <Button
             variant="destructive"
             size="icon"
+            aria-label={tc("delete")}
             onClick={() => setShowDeleteConfirm(true)}
             disabled={deleteItem.isPending}
           >

--- a/src/routes/_auth.tsx
+++ b/src/routes/_auth.tsx
@@ -63,17 +63,27 @@ const AuthLayout = () => {
             <Package className="h-5 w-5" />
             Housekeeper
           </Link>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => {
-              void handleSignOut();
-            }}
-            title="Sign out"
-            aria-label="Sign out"
-          >
-            <LogOut className="h-5 w-5" />
-          </Button>
+          <div className="flex items-center gap-1">
+            <Link
+              to="/settings"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              title="Settings"
+              aria-label="Settings"
+            >
+              <Settings className="h-5 w-5" />
+            </Link>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => {
+                void handleSignOut();
+              }}
+              title="Sign out"
+              aria-label="Sign out"
+            >
+              <LogOut className="h-5 w-5" />
+            </Button>
+          </div>
         </div>
       </header>
 
@@ -87,16 +97,39 @@ const AuthLayout = () => {
       {/* Mobile bottom navigation */}
       <nav className="sticky bottom-0 border-t bg-background lg:hidden">
         <div className="mx-auto flex max-w-2xl items-center justify-around px-4 py-2">
-          {NAV_ITEMS.map(({ to, icon: Icon, label }) => (
-            <Link
-              key={to}
-              to={to}
-              className="flex flex-col items-center gap-1 text-xs text-muted-foreground [&.active]:text-primary"
-            >
-              <Icon className="h-5 w-5" />
-              <span>{label}</span>
-            </Link>
-          ))}
+          <Link
+            to="/"
+            className="flex flex-col items-center gap-1 text-xs text-muted-foreground [&.active]:text-primary"
+          >
+            <Home className="h-5 w-5" />
+            <span>Home</span>
+          </Link>
+          <Link
+            to="/shopping"
+            className="flex flex-col items-center gap-1 text-xs text-muted-foreground [&.active]:text-primary"
+          >
+            <ShoppingCart className="h-5 w-5" />
+            <span>Shopping</span>
+          </Link>
+          {/* Add Item — centered blue circle button */}
+          <Link
+            to="/items/new"
+            className="flex flex-col items-center gap-1 text-xs text-muted-foreground [&.active]:text-primary"
+          >
+            <div className="-mt-5 flex h-14 w-14 items-center justify-center rounded-full bg-primary shadow-lg">
+              <Plus className="h-6 w-6 text-primary-foreground" />
+            </div>
+            <span>Add Item</span>
+          </Link>
+          <Link
+            to="/stats"
+            className="flex flex-col items-center gap-1 text-xs text-muted-foreground [&.active]:text-primary"
+          >
+            <BarChart2 className="h-5 w-5" />
+            <span>Stats</span>
+          </Link>
+          {/* Invisible spacer to keep Add Item centered (5th element = 50% with justify-around) */}
+          <div className="w-10 opacity-0" aria-hidden="true" />
         </div>
       </nav>
     </div>

--- a/src/routes/_auth.tsx
+++ b/src/routes/_auth.tsx
@@ -66,7 +66,7 @@ const AuthLayout = () => {
           <div className="flex items-center gap-1">
             <Link
               to="/settings"
-              className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground [&.active]:bg-accent [&.active]:text-primary"
               title="Settings"
               aria-label="Settings"
             >


### PR DESCRIPTION
- Fix "使う" and "編集" buttons by replacing invalid <Link><Button> nesting
  with useNavigate onClick handlers (button-inside-anchor is invalid HTML)
- Add "再購入" text label to the restock button (was icon-only)
- Fix ItemCard quantity showing "1g" → now shows "1点" via unitsDisplay key
- Move Settings from mobile footer to header (left of logout icon)
- Make Add Item footer button centered with blue circle background

https://claude.ai/code/session_01E8tj7s2V7AzHuRgKFyjSJR