### PR TITLE
fix: resolve PR #123 conflicts in items locales

### DIFF
--- a/src/locales/ja/items.json
+++ b/src/locales/ja/items.json
@@ -75,7 +75,7 @@
   "restockSuccess": "買い物リストに追加しました",
   "consumeHistory": "消費履歴",
   "noHistory": "消費履歴がありません",
-  "itemNotFound": "アイテムが見つかりません",
+  "itemNotFound": "在庫が見つかりません",
   "loadError": "読み込みに失敗しました。再読み込みしてください。",
   "hideEmpty": "使い切り在庫を隠す",
   "urgentBanner": "{{count}}件の在庫が期限切れまたは期限間近です",


### PR DESCRIPTION
### Motivation
- Resolve the merge conflict in locale files for PR #123 and standardize the Japanese wording to match the inventory domain.

### Description
- Updated `src/locales/ja/items.json` to change `itemNotFound` from `"アイテムが見つかりません"` to `"在庫が見つかりません"` to match terminology.

### Testing
- Ran `bun run format:check` which completed successfully.
- Ran `bun run check` (lint + typecheck) which exited successfully; eslint produced 21 unrelated warnings not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0098c5454c8330830ac62e4e7995da)