### PR TITLE
Make calendar dates tappable and show expiry items modal; improve summary readability

### DIFF
--- a/src/components/molecules/ExpiryCheckItem.stories.tsx
+++ b/src/components/molecules/ExpiryCheckItem.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ExpiryCheckItem } from "./ExpiryCheckItem";
+
+const baseItem = {
+  id: "item-1",
+  user_id: "user-1",
+  name: "特濃ヨーグルト 400g",
+  barcode: null,
+  category_id: null,
+  storage_location_id: null,
+  units: 1,
+  content_amount: 1,
+  content_unit: "個",
+  opened_remaining: null,
+  purchase_date: null,
+  expiry_date: "2026-05-20",
+  image_path: null,
+  notes: null,
+  created_at: "2026-05-01T00:00:00.000Z",
+  updated_at: "2026-05-01T00:00:00.000Z",
+  deleted_at: null,
+};
+
+const meta = {
+  component: ExpiryCheckItem,
+  tags: ["autodocs"],
+  args: {
+    onCheck: async () => {},
+  },
+} satisfies Meta<typeof ExpiryCheckItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    item: baseItem,
+    categoryColor: "#22c55e",
+  },
+};
+
+export const LongName: Story = {
+  args: {
+    item: {
+      ...baseItem,
+      id: "item-2",
+      name: "北海道産ミルク使用 プレミアム無糖ヨーグルト ファミリーサイズ たんぱく質強化タイプ",
+    },
+    categoryColor: "#3b82f6",
+  },
+};

--- a/src/components/molecules/ExpiryCheckItem.tsx
+++ b/src/components/molecules/ExpiryCheckItem.tsx
@@ -33,7 +33,7 @@ export const ExpiryCheckItem = ({ item, categoryColor, onCheck }: ExpiryCheckIte
   })();
 
   return (
-    <label className="flex cursor-pointer items-center gap-2 py-1">
+    <label className="flex cursor-pointer items-start gap-2 py-1">
       <input
         type="checkbox"
         checked={checked}
@@ -45,7 +45,10 @@ export const ExpiryCheckItem = ({ item, categoryColor, onCheck }: ExpiryCheckIte
       />
       <ColorDot color={categoryColor} />
       <span
-        className={cn("flex-1 truncate text-sm", checked && "text-muted-foreground line-through")}
+        className={cn(
+          "flex-1 text-sm leading-snug",
+          checked && "text-muted-foreground line-through",
+        )}
       >
         {item.name}
       </span>

--- a/src/components/organisms/ExpiryCalendar.stories.tsx
+++ b/src/components/organisms/ExpiryCalendar.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import type { Category, Item } from "@/types/item";
+
+import { ExpiryCalendar } from "./ExpiryCalendar";
+
+const categories: Category[] = [
+  {
+    id: "cat-1",
+    user_id: "user-1",
+    name: "乳製品",
+    color: "#22c55e",
+    created_at: "2026-05-01T00:00:00.000Z",
+    updated_at: "2026-05-01T00:00:00.000Z",
+  },
+  {
+    id: "cat-2",
+    user_id: "user-1",
+    name: "飲料",
+    color: "#3b82f6",
+    created_at: "2026-05-01T00:00:00.000Z",
+    updated_at: "2026-05-01T00:00:00.000Z",
+  },
+];
+
+const items: Item[] = [
+  {
+    id: "item-1",
+    user_id: "user-1",
+    name: "牛乳",
+    barcode: null,
+    category_id: "cat-1",
+    storage_location_id: null,
+    units: 1,
+    content_amount: 1,
+    content_unit: "個",
+    opened_remaining: null,
+    purchase_date: null,
+    expiry_date: "2026-05-12",
+    image_path: null,
+    notes: null,
+    created_at: "2026-05-01T00:00:00.000Z",
+    updated_at: "2026-05-01T00:00:00.000Z",
+    deleted_at: null,
+  },
+  {
+    id: "item-2",
+    user_id: "user-1",
+    name: "豆乳",
+    barcode: null,
+    category_id: "cat-2",
+    storage_location_id: null,
+    units: 1,
+    content_amount: 1,
+    content_unit: "個",
+    opened_remaining: null,
+    purchase_date: null,
+    expiry_date: "2026-05-12",
+    image_path: null,
+    notes: null,
+    created_at: "2026-05-01T00:00:00.000Z",
+    updated_at: "2026-05-01T00:00:00.000Z",
+    deleted_at: null,
+  },
+];
+
+const meta = {
+  component: ExpiryCalendar,
+  tags: ["autodocs"],
+  args: {
+    categories,
+    labels: {
+      close: "閉じる",
+      noItemsOnDate: "この日に期限を迎えるアイテムはありません",
+      expiryItemsOnDate: (date: string) => `${date} の期限アイテム`,
+    },
+  },
+} satisfies Meta<typeof ExpiryCalendar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    items,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    items: [],
+  },
+};

--- a/src/components/organisms/ExpiryCalendar.test.tsx
+++ b/src/components/organisms/ExpiryCalendar.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it } from "bun:test";
+
+import type { Category, Item } from "@/types/item";
+
+import { ExpiryCalendar } from "./ExpiryCalendar";
+
+const categories: Category[] = [
+  {
+    id: "cat-1",
+    user_id: "user-1",
+    name: "冷蔵",
+    color: "#22c55e",
+    created_at: "2026-05-01T00:00:00.000Z",
+    updated_at: "2026-05-01T00:00:00.000Z",
+  },
+];
+
+const item: Item = {
+  id: "item-1",
+  user_id: "user-1",
+  name: "ヨーグルト",
+  barcode: null,
+  category_id: "cat-1",
+  storage_location_id: null,
+  units: 1,
+  content_amount: 1,
+  content_unit: "個",
+  opened_remaining: null,
+  purchase_date: null,
+  expiry_date: "2026-05-15",
+  image_path: null,
+  notes: null,
+  created_at: "2026-05-01T00:00:00.000Z",
+  updated_at: "2026-05-01T00:00:00.000Z",
+  deleted_at: null,
+};
+
+const labels = {
+  close: "閉じる",
+  noItemsOnDate: "この日に期限を迎えるアイテムはありません",
+  expiryItemsOnDate: (date: string) => `${date} の期限アイテム`,
+};
+
+describe("ExpiryCalendar", () => {
+  it("opens date modal and shows items for selected day", () => {
+    const { getByRole, getByText } = render(
+      <ExpiryCalendar items={[item]} categories={categories} labels={labels} />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "15" }));
+
+    expect(getByText("2026-05-15 の期限アイテム")).toBeDefined();
+    expect(getByText("ヨーグルト")).toBeDefined();
+  });
+
+  it("shows empty message when selected day has no items", () => {
+    const { getByRole, getByText } = render(
+      <ExpiryCalendar items={[]} categories={categories} labels={labels} />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "1" }));
+
+    expect(getByText("この日に期限を迎えるアイテムはありません")).toBeDefined();
+  });
+});

--- a/src/components/organisms/ExpiryCalendar.tsx
+++ b/src/components/organisms/ExpiryCalendar.tsx
@@ -8,6 +8,11 @@ import type { Category, Item } from "@/types/item";
 interface ExpiryCalendarProps {
   items: Item[];
   categories: Category[];
+  labels: {
+    close: string;
+    noItemsOnDate: string;
+    expiryItemsOnDate: (date: string) => string;
+  };
 }
 
 const getDaysInMonth = (year: number, month: number) => new Date(year, month + 1, 0).getDate();
@@ -31,12 +36,13 @@ const MONTH_LABELS = [
   "12月",
 ];
 
-export const ExpiryCalendar = ({ items, categories }: ExpiryCalendarProps) => {
+export const ExpiryCalendar = ({ items, categories, labels }: ExpiryCalendarProps) => {
   const today = new Date();
   const [year, setYear] = useState(today.getFullYear());
   const [month, setMonth] = useState(today.getMonth());
   const [showPicker, setShowPicker] = useState(false);
   const [pickerYear, setPickerYear] = useState(today.getFullYear());
+  const [selectedDateKey, setSelectedDateKey] = useState<string | null>(null);
   const pickerRef = useRef<HTMLDivElement>(null);
 
   const prevMonth = () => {
@@ -83,6 +89,7 @@ export const ExpiryCalendar = ({ items, categories }: ExpiryCalendarProps) => {
   const firstDay = getFirstDayOfMonth(year, month);
 
   const todayKey = toDateKey(today);
+  const selectedItems = selectedDateKey ? (itemsByDate.get(selectedDateKey) ?? []) : [];
 
   const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
 
@@ -187,9 +194,11 @@ export const ExpiryCalendar = ({ items, categories }: ExpiryCalendarProps) => {
           const dow = (firstDay + i) % 7;
 
           return (
-            <div
+            <button
               key={day}
-              className={`flex min-h-[48px] flex-col items-center border-t pt-1 ${isToday ? "bg-primary/5" : ""}`}
+              type="button"
+              onClick={() => setSelectedDateKey(dateKey)}
+              className={`flex min-h-[56px] flex-col items-center border-t pt-1 text-left transition-colors hover:bg-muted/50 ${isToday ? "bg-primary/5" : ""}`}
             >
               <span
                 className={`flex h-6 w-6 items-center justify-center rounded-full text-xs ${
@@ -216,10 +225,51 @@ export const ExpiryCalendar = ({ items, categories }: ExpiryCalendarProps) => {
                   )}
                 </div>
               )}
-            </div>
+            </button>
           );
         })}
       </div>
+
+      {selectedDateKey && (
+        <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-3 sm:items-center">
+          <button
+            type="button"
+            className="absolute inset-0"
+            onClick={() => setSelectedDateKey(null)}
+            aria-label={labels.close}
+          />
+          <div className="relative z-10 max-h-[70vh] w-full max-w-md overflow-y-auto rounded-xl bg-background p-4 shadow-xl">
+            <div className="mb-3 flex items-center justify-between">
+              <h3 className="text-sm font-semibold">{labels.expiryItemsOnDate(selectedDateKey)}</h3>
+              <Button variant="ghost" size="sm" onClick={() => setSelectedDateKey(null)}>
+                {labels.close}
+              </Button>
+            </div>
+            {selectedItems.length === 0 ? (
+              <p className="text-sm text-muted-foreground">{labels.noItemsOnDate}</p>
+            ) : (
+              <ul className="space-y-2">
+                {selectedItems.map((item) => {
+                  const cat = item.category_id ? categoryMap.get(item.category_id) : null;
+                  return (
+                    <li key={item.id} className="flex items-start gap-2 rounded-md border p-2">
+                      <ColorDot color={cat?.color} />
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium leading-snug">{item.name}</p>
+                        {item.expiry_date && (
+                          <p className="text-xs text-muted-foreground">
+                            {item.expiry_date.slice(0, 10)}
+                          </p>
+                        )}
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/locales/en/calendar.json
+++ b/src/locales/en/calendar.json
@@ -9,5 +9,8 @@
   "softDeleteSuccess": "Removed from inventory",
   "reviveSuccess": "Restocked item revived from soft-delete",
   "noItems": "No items with expiry dates",
-  "noItemsHint": "Set expiry dates on your items to see them here"
+  "noItemsHint": "Set expiry dates on your items to see them here",
+  "close": "Close",
+  "noItemsOnDate": "No items expiring on this date",
+  "expiryItemsOnDate": "Items expiring on {{date}}"
 }

--- a/src/locales/ja/calendar.json
+++ b/src/locales/ja/calendar.json
@@ -9,5 +9,8 @@
   "softDeleteSuccess": "在庫から除きました",
   "reviveSuccess": "再入荷を検出、在庫を復活しました",
   "noItems": "期限日が設定されたアイテムはありません",
-  "noItemsHint": "アイテムに期限日を設定するとここに表示されます"
+  "noItemsHint": "アイテムに期限日を設定するとここに表示されます",
+  "close": "閉じる",
+  "noItemsOnDate": "この日に期限を迎えるアイテムはありません",
+  "expiryItemsOnDate": "{{date}} の期限アイテム"
 }

--- a/src/routes/_auth.calendar.tsx
+++ b/src/routes/_auth.calendar.tsx
@@ -67,7 +67,7 @@ const CalendarPage = () => {
       )}
 
       {/* Summary section */}
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
         {/* Left column: expired + this week */}
         <div className="space-y-3">
           {/* Expired */}
@@ -76,7 +76,7 @@ const CalendarPage = () => {
             {expired.length === 0 ? (
               <p className="text-xs text-muted-foreground">{t("noExpired")}</p>
             ) : (
-              <div>
+              <div className="space-y-1">
                 {expired.map((item) => (
                   <ExpiryCheckItem
                     key={item.id}
@@ -97,7 +97,7 @@ const CalendarPage = () => {
             {thisWeek.length === 0 ? (
               <p className="text-xs text-muted-foreground">{t("noThisWeek")}</p>
             ) : (
-              <div>
+              <div className="space-y-1">
                 {thisWeek.map((item) => (
                   <ExpiryCheckItem
                     key={item.id}
@@ -119,7 +119,7 @@ const CalendarPage = () => {
           {thisMonth.length === 0 ? (
             <p className="text-xs text-muted-foreground">{t("noThisMonth")}</p>
           ) : (
-            <div>
+            <div className="space-y-1">
               {thisMonth.map((item) => (
                 <ExpiryCheckItem
                   key={item.id}
@@ -136,7 +136,15 @@ const CalendarPage = () => {
       </div>
 
       {/* Calendar */}
-      <ExpiryCalendar items={items} categories={categories} />
+      <ExpiryCalendar
+        items={items}
+        categories={categories}
+        labels={{
+          close: t("close"),
+          noItemsOnDate: t("noItemsOnDate"),
+          expiryItemsOnDate: (date) => t("expiryItemsOnDate", { date }),
+        }}
+      />
     </div>
   );
 };


### PR DESCRIPTION
### Motivation
- Users could not inspect which items the calendar dots represented when tapping a date, and summary item names were truncated, making it hard to identify expiring products at a glance.
- Improve mobile responsiveness so the summary and calendar are readable without losing item information.

### Description
- Make calendar day cells interactive (`button`) and open a modal/bottom-sheet style overlay that lists all items expiring on the selected date by grouping `items` by `expiry_date` (`src/components/organisms/ExpiryCalendar.tsx`).
- Add a `labels` prop to `ExpiryCalendar` and wire i18n strings for modal title/close/empty state in Japanese and English (`src/routes/_auth.calendar.tsx`, `src/locales/ja/calendar.json`, `src/locales/en/calendar.json`).
- Improve summary layout responsiveness by switching to a single column on small screens and two columns on large screens and add small spacing tweaks to avoid cramped rows (`src/routes/_auth.calendar.tsx`).
- Prevent truncation of product names in summary rows by removing `truncate` and allowing wrapping, and adjust row alignment for better readability (`src/components/molecules/ExpiryCheckItem.tsx`).

### Testing
- Ran formatting and auto-format: `bun run format` and verified with `bun run format:check` (passed).
- Ran linting: `bun run lint` (passed).
- Ran TypeScript checks: `bun run typecheck` (passed).
- Built the app: `bun run build` (production build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00c3441ec88330b1f6bbc3cdb2525f)