### PR TITLE
feat: implement inventory stacking with per-lot expiry tracking

### DIFF
--- a/src/components/molecules/ItemCard.stories.tsx
+++ b/src/components/molecules/ItemCard.stories.tsx
@@ -111,3 +111,66 @@ export const NoExpiry: Story = {
     },
   },
 };
+
+export const WithOpenedRemaining: Story = {
+  args: {
+    item: {
+      ...baseItem,
+      name: "牛乳",
+      units: 3,
+      content_amount: 1000,
+      content_unit: "mL",
+      opened_remaining: 350,
+      category_id: null,
+      barcode: null,
+      storage_location_id: null,
+      expiry_date: "2099-06-01",
+      purchase_date: null,
+      notes: null,
+      image_path: null,
+    },
+    categoryName: "食品",
+    locationName: "冷蔵庫",
+  },
+};
+
+export const CountUnit: Story = {
+  args: {
+    item: {
+      ...baseItem,
+      name: "コーヒーカプセル",
+      units: 12,
+      content_amount: 1,
+      content_unit: "個",
+      opened_remaining: null,
+      category_id: null,
+      barcode: null,
+      storage_location_id: null,
+      expiry_date: "2099-12-31",
+      purchase_date: null,
+      notes: null,
+      image_path: null,
+    },
+  },
+};
+
+export const MultiLotStacked: Story = {
+  args: {
+    item: {
+      ...baseItem,
+      name: "シャンプー",
+      units: 5,
+      content_amount: 400,
+      content_unit: "mL",
+      opened_remaining: null,
+      category_id: null,
+      barcode: null,
+      storage_location_id: null,
+      expiry_date: "2099-06-01",
+      purchase_date: null,
+      notes: null,
+      image_path: null,
+    },
+    locationName: "洗面台",
+  },
+};

--- a/src/components/molecules/ItemCard.tsx
+++ b/src/components/molecules/ItemCard.tsx
@@ -15,6 +15,18 @@ interface ItemCardProps {
   warningDays?: number;
 }
 
+const formatRemaining = (
+  units: number,
+  contentAmount: number,
+  openedRemaining: number | null,
+): string => {
+  const total =
+    openedRemaining !== null
+      ? (units - 1) * contentAmount + openedRemaining
+      : units * contentAmount;
+  return total % 1 === 0 ? String(total) : total.toFixed(2).replace(/\.?0+$/, "");
+};
+
 export const ItemCard = ({ item, categoryName, locationName, warningDays }: ItemCardProps) => {
   const { t, i18n } = useTranslation("items");
   const expiryStatus = getExpiryStatus(item.expiry_date, warningDays);
@@ -64,7 +76,19 @@ export const ItemCard = ({ item, categoryName, locationName, warningDays }: Item
             {isEmpty ? (
               <span className="text-muted-foreground">{t("emptyStock")}</span>
             ) : (
-              <span>{t("unitsDisplay", { units: item.units })}</span>
+              <span>
+                {t("unitsDisplay", { units: item.units })}
+                <span className="ml-1 text-xs font-normal text-muted-foreground">
+                  {t("remainingDisplay", {
+                    amount: formatRemaining(
+                      item.units,
+                      item.content_amount,
+                      item.opened_remaining ?? null,
+                    ),
+                    unit: item.content_unit,
+                  })}
+                </span>
+              </span>
             )}
           </span>
           <ExpiryBadge expiryDate={item.expiry_date} warningDays={warningDays} />

--- a/src/components/molecules/ItemCard.tsx
+++ b/src/components/molecules/ItemCard.tsx
@@ -66,16 +66,18 @@ export const ItemCard = ({ item, categoryName, locationName, warningDays }: Item
             ) : (
               <span>
                 {t("unitsDisplay", { units: item.units })}
-                <span className="ml-1 text-xs font-normal text-muted-foreground">
-                  {t("remainingDisplay", {
-                    amount: formatRemaining(
-                      item.units,
-                      item.content_amount,
-                      item.opened_remaining ?? null,
-                    ),
-                    unit: item.content_unit,
-                  })}
-                </span>
+                {item.opened_remaining !== null && item.opened_remaining !== undefined && (
+                  <span className="ml-1 text-xs font-normal text-muted-foreground">
+                    {t("remainingDisplay", {
+                      amount: formatRemaining(
+                        item.units,
+                        item.content_amount,
+                        item.opened_remaining,
+                      ),
+                      unit: item.content_unit,
+                    })}
+                  </span>
+                )}
               </span>
             )}
           </span>

--- a/src/components/molecules/ItemCard.tsx
+++ b/src/components/molecules/ItemCard.tsx
@@ -6,7 +6,7 @@ import { ExpiryBadge } from "@/components/atoms/ExpiryBadge";
 import { ItemImage } from "@/components/atoms/ItemImage";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
-import { getExpiryStatus, type Item } from "@/types/item";
+import { formatRemaining, getExpiryStatus, type Item } from "@/types/item";
 
 interface ItemCardProps {
   item: Item;
@@ -14,18 +14,6 @@ interface ItemCardProps {
   locationName?: string | undefined;
   warningDays?: number;
 }
-
-const formatRemaining = (
-  units: number,
-  contentAmount: number,
-  openedRemaining: number | null,
-): string => {
-  const total =
-    openedRemaining !== null
-      ? (units - 1) * contentAmount + openedRemaining
-      : units * contentAmount;
-  return total % 1 === 0 ? String(total) : total.toFixed(2).replace(/\.?0+$/, "");
-};
 
 export const ItemCard = ({ item, categoryName, locationName, warningDays }: ItemCardProps) => {
   const { t, i18n } = useTranslation("items");

--- a/src/components/organisms/ItemForm.stories.tsx
+++ b/src/components/organisms/ItemForm.stories.tsx
@@ -9,6 +9,8 @@ const meta = {
   parameters: { layout: "padded" },
   args: {
     onSubmit: fn(),
+    onBarcodeScanned: fn(),
+    onPendingFileChange: fn(),
   },
 } satisfies Meta<typeof ItemForm>;
 
@@ -43,5 +45,21 @@ export const Submitting: Story = {
       content_unit: "mL",
     },
     isSubmitting: true,
+  },
+};
+
+/** 追加購入として登録するモード（既存アイテムが検出された場合のラベル） */
+export const StackMode: Story = {
+  args: {
+    defaultValues: {
+      name: "有機牛乳",
+      barcode: "4901234567890",
+      units: 2,
+      content_amount: 1000,
+      content_unit: "mL",
+      purchase_date: "2024-01-15",
+      expiry_date: "2099-02-28",
+    },
+    submitLabel: "追加購入として登録",
   },
 };

--- a/src/components/organisms/ItemForm.tsx
+++ b/src/components/organisms/ItemForm.tsx
@@ -31,6 +31,8 @@ interface ItemFormProps {
   isSubmitting?: boolean;
   submitLabel?: string;
   onPendingFileChange?: (file: File | null) => void;
+  /** Called after a barcode is scanned or manually looked up */
+  onBarcodeScanned?: (barcode: string, source: "db" | "api" | null) => void;
 }
 
 export const ItemForm = ({
@@ -39,6 +41,7 @@ export const ItemForm = ({
   isSubmitting,
   submitLabel,
   onPendingFileChange,
+  onBarcodeScanned,
 }: ItemFormProps) => {
   const { t } = useTranslation("items");
   const { t: ts } = useTranslation("settings");
@@ -99,6 +102,7 @@ export const ItemForm = ({
     setLookupResult(result.product);
     setLookupSource(result.source);
     if (result.product?.name) set("name", result.product.name);
+    onBarcodeScanned?.(barcode, result.source);
   };
 
   const handleAddCategory = async (name: string) => {

--- a/src/hooks/useConsumeItem.ts
+++ b/src/hooks/useConsumeItem.ts
@@ -19,12 +19,13 @@ const consumeItem = async ({ item, deltaAmount }: ConsumeParams): Promise<Item> 
   if (userError || !userData.user) throw new Error("Not authenticated");
 
   // Find the earliest-created lot to consume from (FIFO)
-  const { data: lots } = await supabase
+  const { data: lots, error: lotsError } = await supabase
     .from("item_lots")
     .select("*")
     .eq("item_id", item.id)
     .order("created_at", { ascending: true })
     .limit(1);
+  if (lotsError) throw lotsError;
 
   if (lots && lots.length > 0 && lots[0]) {
     await consumeLotFn({ lot: lots[0], item, deltaAmount });

--- a/src/hooks/useConsumeItem.ts
+++ b/src/hooks/useConsumeItem.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 
-import { consumeLot as consumeLotFn, LOTS_KEY, syncItemAggregate } from "@/hooks/useItemLots";
+import { consumeLot as consumeLotFn, LOTS_KEY } from "@/hooks/useItemLots";
 import { OfflineError, requireOnline } from "@/lib/requireOnline";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/lib/toast-context";
@@ -53,8 +53,7 @@ const consumeItem = async ({ item, deltaAmount }: ConsumeParams): Promise<Item> 
       opened_remaining_before: item.opened_remaining ?? null,
       opened_remaining_after: result.opened_remaining_after,
     });
-
-    await syncItemAggregate(item.id);
+    // Skip syncItemAggregate: no lots exist, so it would reset items to units=0
   }
 
   const { data: updated, error } = await supabase

--- a/src/hooks/useConsumeItem.ts
+++ b/src/hooks/useConsumeItem.ts
@@ -26,9 +26,8 @@ const consumeItem = async ({ item, deltaAmount }: ConsumeParams): Promise<Item> 
     .order("created_at", { ascending: true })
     .limit(1);
 
-  if (lots && lots.length > 0) {
-    const lot = lots[0] as Parameters<typeof consumeLotFn>[0]["lot"];
-    await consumeLotFn({ lot, item, deltaAmount });
+  if (lots && lots.length > 0 && lots[0]) {
+    await consumeLotFn({ lot: lots[0], item, deltaAmount });
   } else {
     // Fallback: no lots exist yet → update items table directly and create log
     const result = computeConsumption(item, deltaAmount);

--- a/src/hooks/useConsumeItem.ts
+++ b/src/hooks/useConsumeItem.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 
+import { consumeLot as consumeLotFn, LOTS_KEY, syncItemAggregate } from "@/hooks/useItemLots";
 import { OfflineError, requireOnline } from "@/lib/requireOnline";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/lib/toast-context";
@@ -11,39 +12,58 @@ interface ConsumeParams {
   deltaAmount: number;
 }
 
+/** Consume from a single-lot item (backward compat path). */
 const consumeItem = async ({ item, deltaAmount }: ConsumeParams): Promise<Item> => {
   requireOnline();
   const { data: userData, error: userError } = await supabase.auth.getUser();
   if (userError || !userData.user) throw new Error("Not authenticated");
 
-  const result = computeConsumption(item, deltaAmount);
-  if (result.error) throw new Error(result.error);
+  // Find the earliest-created lot to consume from (FIFO)
+  const { data: lots } = await supabase
+    .from("item_lots")
+    .select("*")
+    .eq("item_id", item.id)
+    .order("created_at", { ascending: true })
+    .limit(1);
 
-  const { data, error } = await supabase
+  if (lots && lots.length > 0) {
+    const lot = lots[0] as Parameters<typeof consumeLotFn>[0]["lot"];
+    await consumeLotFn({ lot, item, deltaAmount });
+  } else {
+    // Fallback: no lots exist yet → update items table directly and create log
+    const result = computeConsumption(item, deltaAmount);
+    if (result.error) throw new Error(result.error);
+
+    await supabase
+      .from("items")
+      .update({
+        units: result.units_after,
+        opened_remaining: result.opened_remaining_after,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", item.id);
+
+    await supabase.from("consumption_logs").insert({
+      user_id: userData.user.id,
+      item_id: item.id,
+      delta_amount: deltaAmount,
+      delta_unit: item.content_unit,
+      units_before: item.units,
+      units_after: result.units_after,
+      opened_remaining_before: item.opened_remaining ?? null,
+      opened_remaining_after: result.opened_remaining_after,
+    });
+
+    await syncItemAggregate(item.id);
+  }
+
+  const { data: updated, error } = await supabase
     .from("items")
-    .update({
-      units: result.units_after,
-      opened_remaining: result.opened_remaining_after,
-      updated_at: new Date().toISOString(),
-    })
+    .select("*")
     .eq("id", item.id)
-    .select()
     .single();
   if (error) throw error;
-
-  // Log failure is non-fatal: stock is already updated, so we skip throwing
-  await supabase.from("consumption_logs").insert({
-    user_id: userData.user.id,
-    item_id: item.id,
-    delta_amount: deltaAmount,
-    delta_unit: item.content_unit,
-    units_before: item.units,
-    units_after: result.units_after,
-    opened_remaining_before: item.opened_remaining ?? null,
-    opened_remaining_after: result.opened_remaining_after,
-  });
-
-  return data as Item;
+  return updated as Item;
 };
 
 export const useConsumeItem = () => {
@@ -56,6 +76,7 @@ export const useConsumeItem = () => {
       qc.setQueryData(["items", data.id], data);
       await Promise.all([
         qc.invalidateQueries({ queryKey: ["items"] }),
+        qc.invalidateQueries({ queryKey: [...LOTS_KEY, data.id] }),
         qc.invalidateQueries({ queryKey: ["consumption-logs", data.id] }),
         qc.invalidateQueries({ queryKey: ["consumption-logs-all"] }),
       ]);

--- a/src/hooks/useItemLots.ts
+++ b/src/hooks/useItemLots.ts
@@ -2,8 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { requireOnline } from "@/lib/requireOnline";
 import { supabase } from "@/lib/supabase";
-import type { Item, ItemLot } from "@/types/item";
-import { computeConsumption } from "@/types/item";
+import { computeConsumption, type Item, type ItemLot } from "@/types/item";
 
 export const LOTS_KEY = ["item-lots"] as const;
 

--- a/src/hooks/useItemLots.ts
+++ b/src/hooks/useItemLots.ts
@@ -112,7 +112,7 @@ export const consumeLot = async ({
   if (error) throw error;
 
   // Log failure is non-fatal: stock is already updated above
-  await supabase.from("consumption_logs").insert({
+  const { error: logError } = await supabase.from("consumption_logs").insert({
     user_id: userData.user.id,
     item_id: lot.item_id,
     delta_amount: deltaAmount,
@@ -122,6 +122,7 @@ export const consumeLot = async ({
     opened_remaining_before: lot.opened_remaining ?? null,
     opened_remaining_after: result.opened_remaining_after,
   });
+  if (logError) console.warn("Failed to insert consumption log:", logError);
 
   await syncItemAggregate(lot.item_id);
 

--- a/src/hooks/useItemLots.ts
+++ b/src/hooks/useItemLots.ts
@@ -44,10 +44,11 @@ export const createLot = async (
 
 /** Recompute and update the item aggregate (units, expiry_date, opened_remaining) from its lots. */
 export const syncItemAggregate = async (itemId: string): Promise<void> => {
-  const { data: lots } = await supabase
+  const { data: lots, error: lotsError } = await supabase
     .from("item_lots")
     .select("units, expiry_date, opened_remaining")
     .eq("item_id", itemId);
+  if (lotsError) throw lotsError;
 
   const rows = lots ?? [];
   const totalUnits = rows.reduce((sum, l) => sum + (l.units as number), 0);
@@ -62,7 +63,7 @@ export const syncItemAggregate = async (itemId: string): Promise<void> => {
   const openLots = rows.filter((l) => l.opened_remaining !== null);
   const aggregateOpenedRemaining = openLots.length === 1 ? openLots[0]!.opened_remaining : null;
 
-  await supabase
+  const { error: updateError } = await supabase
     .from("items")
     .update({
       units: totalUnits,
@@ -71,6 +72,7 @@ export const syncItemAggregate = async (itemId: string): Promise<void> => {
       updated_at: new Date().toISOString(),
     })
     .eq("id", itemId);
+  if (updateError) throw updateError;
 };
 
 interface ConsumeLotParams {
@@ -109,6 +111,7 @@ export const consumeLot = async ({
     .single();
   if (error) throw error;
 
+  // Log failure is non-fatal: stock is already updated above
   await supabase.from("consumption_logs").insert({
     user_id: userData.user.id,
     item_id: lot.item_id,

--- a/src/hooks/useItemLots.ts
+++ b/src/hooks/useItemLots.ts
@@ -43,24 +43,32 @@ export const createLot = async (
   return data as ItemLot;
 };
 
-/** Recompute and update the item aggregate (units + expiry_date) from its lots. */
+/** Recompute and update the item aggregate (units, expiry_date, opened_remaining) from its lots. */
 export const syncItemAggregate = async (itemId: string): Promise<void> => {
   const { data: lots } = await supabase
     .from("item_lots")
-    .select("units, expiry_date")
+    .select("units, expiry_date, opened_remaining")
     .eq("item_id", itemId);
 
-  const totalUnits = (lots ?? []).reduce((sum, l) => sum + (l.units as number), 0);
-  const expiryDates = (lots ?? [])
+  const rows = lots ?? [];
+  const totalUnits = rows.reduce((sum, l) => sum + (l.units as number), 0);
+
+  const expiryDates = rows
     .map((l) => l.expiry_date as string | null)
     .filter((d): d is string => d !== null);
   const earliestExpiry = expiryDates.length > 0 ? expiryDates.sort()[0] : null;
+
+  // Keep opened_remaining on items only when exactly one lot is open,
+  // so the card can display an accurate total remaining amount.
+  const openLots = rows.filter((l) => l.opened_remaining !== null);
+  const aggregateOpenedRemaining = openLots.length === 1 ? openLots[0]!.opened_remaining : null;
 
   await supabase
     .from("items")
     .update({
       units: totalUnits,
       expiry_date: earliestExpiry,
+      opened_remaining: aggregateOpenedRemaining,
       updated_at: new Date().toISOString(),
     })
     .eq("id", itemId);
@@ -72,7 +80,11 @@ interface ConsumeLotParams {
   deltaAmount: number;
 }
 
-export const consumeLot = async ({ lot, item, deltaAmount }: ConsumeLotParams): Promise<ItemLot> => {
+export const consumeLot = async ({
+  lot,
+  item,
+  deltaAmount,
+}: ConsumeLotParams): Promise<ItemLot> => {
   requireOnline();
   const { data: userData, error: userError } = await supabase.auth.getUser();
   if (userError || !userData.user) throw new Error("Not authenticated");

--- a/src/hooks/useItemLots.ts
+++ b/src/hooks/useItemLots.ts
@@ -1,0 +1,138 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { requireOnline } from "@/lib/requireOnline";
+import { supabase } from "@/lib/supabase";
+import type { Item, ItemLot } from "@/types/item";
+import { computeConsumption } from "@/types/item";
+
+export const LOTS_KEY = ["item-lots"] as const;
+
+const fetchLots = async (itemId: string): Promise<ItemLot[]> => {
+  const { data, error } = await supabase
+    .from("item_lots")
+    .select("*")
+    .eq("item_id", itemId)
+    .order("created_at", { ascending: true });
+  if (error) throw error;
+  return (data ?? []) as ItemLot[];
+};
+
+export const createLot = async (
+  userId: string,
+  itemId: string,
+  lot: {
+    units: number;
+    opened_remaining?: number | null;
+    purchase_date?: string | null;
+    expiry_date?: string | null;
+  },
+): Promise<ItemLot> => {
+  const { data, error } = await supabase
+    .from("item_lots")
+    .insert({
+      user_id: userId,
+      item_id: itemId,
+      units: lot.units,
+      opened_remaining: lot.opened_remaining ?? null,
+      purchase_date: lot.purchase_date ?? null,
+      expiry_date: lot.expiry_date ?? null,
+    })
+    .select()
+    .single();
+  if (error) throw error;
+  return data as ItemLot;
+};
+
+/** Recompute and update the item aggregate (units + expiry_date) from its lots. */
+export const syncItemAggregate = async (itemId: string): Promise<void> => {
+  const { data: lots } = await supabase
+    .from("item_lots")
+    .select("units, expiry_date")
+    .eq("item_id", itemId);
+
+  const totalUnits = (lots ?? []).reduce((sum, l) => sum + (l.units as number), 0);
+  const expiryDates = (lots ?? [])
+    .map((l) => l.expiry_date as string | null)
+    .filter((d): d is string => d !== null);
+  const earliestExpiry = expiryDates.length > 0 ? expiryDates.sort()[0] : null;
+
+  await supabase
+    .from("items")
+    .update({
+      units: totalUnits,
+      expiry_date: earliestExpiry,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", itemId);
+};
+
+interface ConsumeLotParams {
+  lot: ItemLot;
+  item: Pick<Item, "content_amount" | "content_unit">;
+  deltaAmount: number;
+}
+
+export const consumeLot = async ({ lot, item, deltaAmount }: ConsumeLotParams): Promise<ItemLot> => {
+  requireOnline();
+  const { data: userData, error: userError } = await supabase.auth.getUser();
+  if (userError || !userData.user) throw new Error("Not authenticated");
+
+  const virtual = {
+    units: lot.units,
+    content_amount: item.content_amount,
+    content_unit: item.content_unit,
+    opened_remaining: lot.opened_remaining ?? null,
+  };
+  const result = computeConsumption(virtual, deltaAmount);
+  if (result.error) throw new Error(result.error);
+
+  const { data, error } = await supabase
+    .from("item_lots")
+    .update({
+      units: result.units_after,
+      opened_remaining: result.opened_remaining_after,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", lot.id)
+    .select()
+    .single();
+  if (error) throw error;
+
+  await supabase.from("consumption_logs").insert({
+    user_id: userData.user.id,
+    item_id: lot.item_id,
+    delta_amount: deltaAmount,
+    delta_unit: item.content_unit,
+    units_before: lot.units,
+    units_after: result.units_after,
+    opened_remaining_before: lot.opened_remaining ?? null,
+    opened_remaining_after: result.opened_remaining_after,
+  });
+
+  await syncItemAggregate(lot.item_id);
+
+  return data as ItemLot;
+};
+
+export const useItemLots = (itemId: string) =>
+  useQuery({
+    queryKey: [...LOTS_KEY, itemId],
+    queryFn: () => fetchLots(itemId),
+    enabled: !!itemId,
+    staleTime: 30_000,
+  });
+
+export const useConsumeLot = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: consumeLot,
+    onSuccess: async (_data, variables) => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: [...LOTS_KEY, variables.lot.item_id] }),
+        qc.invalidateQueries({ queryKey: ["items"] }),
+        qc.invalidateQueries({ queryKey: ["consumption-logs", variables.lot.item_id] }),
+        qc.invalidateQueries({ queryKey: ["consumption-logs-all"] }),
+      ]);
+    },
+  });
+};

--- a/src/hooks/useItemLots.ts
+++ b/src/hooks/useItemLots.ts
@@ -112,7 +112,7 @@ export const consumeLot = async ({
   if (error) throw error;
 
   // Log failure is non-fatal: stock is already updated above
-  const { error: logError } = await supabase.from("consumption_logs").insert({
+  await supabase.from("consumption_logs").insert({
     user_id: userData.user.id,
     item_id: lot.item_id,
     delta_amount: deltaAmount,
@@ -122,7 +122,6 @@ export const consumeLot = async ({
     opened_remaining_before: lot.opened_remaining ?? null,
     opened_remaining_after: result.opened_remaining_after,
   });
-  if (logError) console.warn("Failed to insert consumption log:", logError);
 
   await syncItemAggregate(lot.item_id);
 

--- a/src/hooks/useItems.ts
+++ b/src/hooks/useItems.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 
+import { createLot, LOTS_KEY, syncItemAggregate } from "@/hooks/useItemLots";
 import { OfflineError, requireOnline } from "@/lib/requireOnline";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/lib/toast-context";
@@ -70,6 +71,38 @@ const normalizeFormValues = (values: Partial<ItemFormValues>) => ({
 });
 
 /**
+ * バーコードが一致するアクティブなアイテムを探す。
+ * 見つかった場合は新規ロットを追加してそのアイテムを返す。なければ null。
+ */
+const tryStackToActiveItem = async (
+  barcode: string,
+  values: ItemFormValues,
+  userId: string,
+): Promise<Item | null> => {
+  const { data } = await supabase
+    .from("items")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("barcode", barcode)
+    .is("deleted_at", null)
+    .limit(1)
+    .maybeSingle();
+  if (!data) return null;
+
+  const item = data as Item;
+  await createLot(userId, item.id, {
+    units: values.units ?? 1,
+    opened_remaining: values.opened_remaining ?? null,
+    purchase_date: values.purchase_date || null,
+    expiry_date: values.expiry_date || null,
+  });
+  await syncItemAggregate(item.id);
+
+  const { data: updated } = await supabase.from("items").select("*").eq("id", item.id).single();
+  return updated as Item;
+};
+
+/**
  * バーコードが一致するソフトデリート済みアイテムを復活させる。
  * 復活した場合は revived item を返す。なければ null。
  */
@@ -88,28 +121,40 @@ const tryReviveItem = async (
     .single();
   if (!data) return null;
 
+  const item = data as Item;
   const { data: revived, error } = await supabase
     .from("items")
     .update({
       deleted_at: null,
-      units: values.units ?? 1,
-      expiry_date: values.expiry_date || null,
-      purchase_date: values.purchase_date || null,
       updated_at: new Date().toISOString(),
     })
-    .eq("id", (data as Item).id)
+    .eq("id", item.id)
     .select()
     .single();
   if (error) throw error;
+
+  await createLot(userId, item.id, {
+    units: values.units ?? 1,
+    opened_remaining: values.opened_remaining ?? null,
+    purchase_date: values.purchase_date || null,
+    expiry_date: values.expiry_date || null,
+  });
+  await syncItemAggregate(item.id);
+
   return revived as Item;
 };
 
-const createItem = async (values: ItemFormValues): Promise<Item & { _revived?: boolean }> => {
+const createItem = async (
+  values: ItemFormValues,
+): Promise<Item & { _revived?: boolean; _stacked?: boolean }> => {
   requireOnline();
   const { data: userData, error: userError } = await supabase.auth.getUser();
   if (userError || !userData.user) throw new Error("Not authenticated");
 
   if (values.barcode) {
+    const stacked = await tryStackToActiveItem(values.barcode, values, userData.user.id);
+    if (stacked) return { ...stacked, _stacked: true };
+
     const revived = await tryReviveItem(values.barcode, values, userData.user.id);
     if (revived) return { ...revived, _revived: true };
   }
@@ -121,7 +166,16 @@ const createItem = async (values: ItemFormValues): Promise<Item & { _revived?: b
     .select()
     .single();
   if (error) throw error;
-  return data as Item;
+
+  const item = data as Item;
+  await createLot(userData.user.id, item.id, {
+    units: values.units ?? 1,
+    opened_remaining: values.opened_remaining ?? null,
+    purchase_date: values.purchase_date || null,
+    expiry_date: values.expiry_date || null,
+  });
+
+  return item;
 };
 
 const updateItem = async (id: string, values: Partial<ItemFormValues>): Promise<Item> => {
@@ -180,12 +234,16 @@ export const useItem = (id: string) =>
 export const useCreateItem = () => {
   const qc = useQueryClient();
   const { toast } = useToast();
-  const { t } = useTranslation(["common", "calendar"]);
+  const { t } = useTranslation(["common", "calendar", "items"]);
   return useMutation({
     mutationFn: createItem,
     onSuccess: async (data) => {
+      const result = data as Item & { _revived?: boolean; _stacked?: boolean };
       await qc.invalidateQueries({ queryKey: ITEMS_KEY, refetchType: "all" });
-      if ((data as Item & { _revived?: boolean })._revived) {
+      if (result._stacked || result._revived) {
+        await qc.invalidateQueries({ queryKey: LOTS_KEY, refetchType: "all" });
+      }
+      if (result._revived) {
         toast(t("calendar:reviveSuccess"), "success");
       }
     },

--- a/src/hooks/useItems.ts
+++ b/src/hooks/useItems.ts
@@ -205,6 +205,19 @@ const softDeleteItem = async (id: string): Promise<void> => {
   if (error) throw error;
 };
 
+/** バーコードでアクティブなアイテムを検索する (新規登録画面でのスタック検出用) */
+export const findActiveItemByBarcode = async (barcode: string): Promise<Item | null> => {
+  const { data, error } = await supabase
+    .from("items")
+    .select("*")
+    .eq("barcode", barcode)
+    .is("deleted_at", null)
+    .limit(1)
+    .maybeSingle();
+  if (error) throw error;
+  return data ? (data as Item) : null;
+};
+
 /** カレンダー用: expiry_date を持つアクティブアイテムのみ返す */
 const fetchItemsWithExpiry = async (): Promise<Item[]> => {
   const { data, error } = await supabase

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,0 +1,5 @@
+/** Parse a YYYY-MM-DD date string as a local-time Date to avoid UTC off-by-one display. */
+export const parseLocalDate = (dateStr: string): Date => {
+  const [y, m, d] = dateStr.split("-").map(Number) as [number, number, number];
+  return new Date(y, m - 1, d);
+};

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -292,6 +292,48 @@ export interface Database {
         };
         Relationships: [];
       };
+      item_lots: {
+        Row: {
+          id: string;
+          user_id: string;
+          item_id: string;
+          units: number;
+          opened_remaining: number | null;
+          purchase_date: string | null;
+          expiry_date: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          item_id: string;
+          units?: number;
+          opened_remaining?: number | null;
+          purchase_date?: string | null;
+          expiry_date?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          item_id?: string;
+          units?: number;
+          opened_remaining?: number | null;
+          purchase_date?: string | null;
+          expiry_date?: string | null;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "item_lots_item_id_fkey";
+            columns: ["item_id"];
+            referencedRelation: "items";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       shopping_list_items: {
         Row: {
           id: string;

--- a/src/locales/en/items.json
+++ b/src/locales/en/items.json
@@ -58,6 +58,7 @@
   },
   "totalAmount": "Total",
   "unitsDisplay": "{{units}} units",
+  "remainingDisplay": "({{amount}}{{unit}} left)",
   "emptyStock": "Used up",
   "noItems": "No items",
   "searchPlaceholder": "Search by name or barcode",

--- a/src/locales/en/items.json
+++ b/src/locales/en/items.json
@@ -94,5 +94,15 @@
   "consumeValidationError": "Enter a value greater than 0",
   "lookupFromHistory": "Found a match from your previously registered items",
   "unitsRequired": "Enter a quantity",
-  "contentAmountRequired": "Enter a value greater than 0"
+  "contentAmountRequired": "Enter a value greater than 0",
+  "stackSuccess": "Added as new stock to existing item",
+  "stackBannerTitle": "This item is already in your inventory",
+  "stackBannerBody": "\"{{name}}\" will have additional stock added. Enter quantity, purchase date, and expiry date. Category, location, and notes will be inherited.",
+  "stackSubmitLabel": "Add as additional stock",
+  "lots": "Lots",
+  "noLots": "No lot information",
+  "lotLabel": "Lot {{index}}",
+  "lotCount": "{{count}} lots",
+  "selectLot": "Select lot to use",
+  "selectLotHint": "Select a lot above to continue"
 }

--- a/src/locales/ja/items.json
+++ b/src/locales/ja/items.json
@@ -58,6 +58,7 @@
   },
   "totalAmount": "総量",
   "unitsDisplay": "{{units}}点",
+  "remainingDisplay": "(残: {{amount}}{{unit}})",
   "emptyStock": "使い切り",
   "noItems": "在庫がありません",
   "searchPlaceholder": "商品名・バーコードで検索",

--- a/src/locales/ja/items.json
+++ b/src/locales/ja/items.json
@@ -94,5 +94,15 @@
   "consumeValidationError": "0より大きい値を入力してください",
   "lookupFromHistory": "過去に登録した商品データから候補を見つけました",
   "unitsRequired": "個数を入力してください",
-  "contentAmountRequired": "0より大きい数値を入力してください"
+  "contentAmountRequired": "0より大きい数値を入力してください",
+  "stackSuccess": "既存の在庫にロットを追加しました",
+  "stackBannerTitle": "同じ商品が既に在庫にあります",
+  "stackBannerBody": "「{{name}}」に追加購入として記録します。点数・購入日・賞味期限を入力してください。カテゴリ・保管場所・メモは引き継がれます。",
+  "stackSubmitLabel": "追加購入として登録",
+  "lots": "ロット一覧",
+  "noLots": "ロット情報がありません",
+  "lotLabel": "ロット{{index}}",
+  "lotCount": "{{count}}ロット",
+  "selectLot": "使うロットを選択",
+  "selectLotHint": "上からロットを選んでください"
 }

--- a/src/routes/_auth.items.$itemId.consume.tsx
+++ b/src/routes/_auth.items.$itemId.consume.tsx
@@ -1,4 +1,9 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+
+const parseLocalDate = (dateStr: string) => {
+  const [y, m, d] = dateStr.split("-").map(Number) as [number, number, number];
+  return new Date(y, m - 1, d);
+};
 import { ArrowLeft } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -171,12 +176,12 @@ const ItemConsumePage = () => {
                   </p>
                   {lot.expiry_date && (
                     <p className="text-xs text-muted-foreground">
-                      {t("expiryDate")}: {new Date(lot.expiry_date).toLocaleDateString()}
+                      {t("expiryDate")}: {parseLocalDate(lot.expiry_date).toLocaleDateString()}
                     </p>
                   )}
                   {lot.purchase_date && (
                     <p className="text-xs text-muted-foreground">
-                      {t("purchaseDate")}: {new Date(lot.purchase_date).toLocaleDateString()}
+                      {t("purchaseDate")}: {parseLocalDate(lot.purchase_date).toLocaleDateString()}
                     </p>
                   )}
                 </button>

--- a/src/routes/_auth.items.$itemId.consume.tsx
+++ b/src/routes/_auth.items.$itemId.consume.tsx
@@ -7,39 +7,63 @@ import { Spinner } from "@/components/atoms/Spinner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useConsumeItem } from "@/hooks/useConsumeItem";
+import { useConsumeLot, useItemLots } from "@/hooks/useItemLots";
 import { useItem } from "@/hooks/useItems";
 import { useToast } from "@/lib/toast-context";
-import { computeConsumption } from "@/types/item"; // used for live preview only
+import { computeConsumption, type ItemLot } from "@/types/item";
 
 const ItemConsumePage = () => {
   const { t } = useTranslation("items");
   const { itemId } = Route.useParams();
+  const { lotId: preselectedLotId } = Route.useSearch();
   const navigate = useNavigate();
-  const { data: item, isLoading } = useItem(itemId);
-  const consumeItem = useConsumeItem();
+  const { data: item, isLoading: itemLoading } = useItem(itemId);
+  const { data: lots = [], isLoading: lotsLoading } = useItemLots(itemId);
+  const consumeLot = useConsumeLot();
   const { toast } = useToast();
+  const [selectedLotId, setSelectedLotId] = useState<string | null>(preselectedLotId ?? null);
   const [delta, setDelta] = useState("");
   const [validationError, setValidationError] = useState("");
 
+  const isLoading = itemLoading || lotsLoading;
+
+  const activeLots = lots.filter((l) => l.units > 0 || l.opened_remaining !== null);
+  const hasMultipleLots = activeLots.length > 1;
+
+  const selectedLot: ItemLot | null =
+    selectedLotId != null
+      ? (activeLots.find((l) => l.id === selectedLotId) ?? null)
+      : activeLots.length === 1
+        ? activeLots[0]!
+        : null;
+
   const deltaNum = parseFloat(delta);
   const preview =
-    item && !isNaN(deltaNum) && deltaNum > 0 ? computeConsumption(item, deltaNum) : null;
+    item && selectedLot && !isNaN(deltaNum) && deltaNum > 0
+      ? computeConsumption(
+          {
+            units: selectedLot.units,
+            content_amount: item.content_amount,
+            content_unit: item.content_unit,
+            opened_remaining: selectedLot.opened_remaining ?? null,
+          },
+          deltaNum,
+        )
+      : null;
 
   const handleSubmit = async () => {
-    if (!item) return;
+    if (!item || !selectedLot) return;
     const amount = parseFloat(delta);
     if (isNaN(amount) || amount <= 0) {
       setValidationError(t("consumeValidationError"));
       return;
     }
-    // preview already holds the computation result; re-use it instead of recalculating
     if (!preview || preview.error) {
       setValidationError(preview?.error ?? t("consumeValidationError"));
       return;
     }
     try {
-      await consumeItem.mutateAsync({ item, deltaAmount: amount });
+      await consumeLot.mutateAsync({ lot: selectedLot, item, deltaAmount: amount });
       toast(t("consumeSuccess"), "success");
       void navigate({ to: "/items/$itemId", params: { itemId } });
     } catch {
@@ -72,18 +96,19 @@ const ItemConsumePage = () => {
     );
   }
 
-  const currentDisplay =
-    item.opened_remaining !== null && item.opened_remaining !== undefined
+  const currentDisplay = selectedLot
+    ? selectedLot.opened_remaining !== null && selectedLot.opened_remaining !== undefined
       ? t("openedDisplay", {
-          remaining: item.opened_remaining,
+          remaining: selectedLot.opened_remaining,
           unit: item.content_unit,
-          count: item.units > 0 ? item.units - 1 : 0,
+          count: selectedLot.units > 0 ? selectedLot.units - 1 : 0,
         })
       : t("totalDisplaySealed", {
-          units: item.units,
+          units: selectedLot.units,
           amount: item.content_amount,
           unit: item.content_unit,
-        });
+        })
+    : null;
 
   return (
     <div className="mx-auto max-w-2xl space-y-6">
@@ -101,63 +126,130 @@ const ItemConsumePage = () => {
       {/* Current state */}
       <div className="rounded-lg bg-muted p-4">
         <p className="font-semibold">{item.name}</p>
-        <p className="mt-1 text-sm text-muted-foreground">
-          {t("currentStock")}: {currentDisplay}
-        </p>
-      </div>
-
-      {/* Input */}
-      <div className="space-y-2">
-        <Label htmlFor="delta">
-          {t("consumeAmount")} ({item.content_unit})
-        </Label>
-        <Input
-          id="delta"
-          type="number"
-          min={0.01}
-          step={0.01}
-          value={delta}
-          onChange={(e) => {
-            setDelta(e.target.value);
-            setValidationError("");
-          }}
-          placeholder={t("consumeAmountPlaceholder")}
-          autoFocus
-        />
-        {validationError && <p className="text-sm text-destructive">{validationError}</p>}
-      </div>
-
-      {/* Preview */}
-      {preview && !preview.error && (
-        <div className="rounded-lg border p-4 text-sm">
-          <p className="font-medium text-muted-foreground">{t("consumePreviewTitle")}</p>
-          <p className="mt-1">
-            {t("consumeUnitsDisplay", { units: preview.units_after })}
-            {preview.opened_remaining_after !== null && preview.opened_remaining_after !== undefined
-              ? t("consumeOpenedSuffix", {
-                  remaining: preview.opened_remaining_after,
-                  unit: item.content_unit,
-                })
-              : ""}
+        {currentDisplay && (
+          <p className="mt-1 text-sm text-muted-foreground">
+            {t("currentStock")}: {currentDisplay}
           </p>
+        )}
+      </div>
+
+      {/* Lot selector (shown only when multiple active lots exist) */}
+      {hasMultipleLots && (
+        <div className="space-y-2">
+          <Label>{t("selectLot")}</Label>
+          <div className="space-y-2">
+            {activeLots.map((lot, index) => {
+              const lotDisplay =
+                lot.opened_remaining !== null && lot.opened_remaining !== undefined
+                  ? t("totalDisplayOpened", {
+                      units: lot.units,
+                      remaining: lot.opened_remaining,
+                      unit: item.content_unit,
+                    })
+                  : t("totalDisplaySealed", {
+                      units: lot.units,
+                      amount: item.content_amount,
+                      unit: item.content_unit,
+                    });
+              return (
+                <button
+                  key={lot.id}
+                  type="button"
+                  onClick={() => {
+                    setSelectedLotId(lot.id);
+                    setDelta("");
+                    setValidationError("");
+                  }}
+                  className={`w-full rounded-lg border p-3 text-left transition-colors ${
+                    selectedLotId === lot.id
+                      ? "border-primary bg-primary/5"
+                      : "border-border hover:border-primary/50"
+                  }`}
+                >
+                  <p className="text-sm font-medium">
+                    {t("lotLabel", { index: index + 1 })} — {lotDisplay}
+                  </p>
+                  {lot.expiry_date && (
+                    <p className="text-xs text-muted-foreground">
+                      {t("expiryDate")}: {new Date(lot.expiry_date).toLocaleDateString()}
+                    </p>
+                  )}
+                  {lot.purchase_date && (
+                    <p className="text-xs text-muted-foreground">
+                      {t("purchaseDate")}: {new Date(lot.purchase_date).toLocaleDateString()}
+                    </p>
+                  )}
+                </button>
+              );
+            })}
+          </div>
         </div>
       )}
-      {preview?.error && <p className="text-sm text-destructive">{preview.error}</p>}
 
-      <Button
-        className="w-full"
-        onClick={() => {
-          void handleSubmit();
-        }}
-        disabled={consumeItem.isPending || !delta || parseFloat(delta) <= 0}
-      >
-        {consumeItem.isPending ? <Spinner className="mr-2 h-4 w-4" /> : null}
-        {t("consume")}
-      </Button>
+      {/* Input */}
+      {selectedLot && (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor="delta">
+              {t("consumeAmount")} ({item.content_unit})
+            </Label>
+            <Input
+              id="delta"
+              type="number"
+              min={0.01}
+              step={0.01}
+              value={delta}
+              onChange={(e) => {
+                setDelta(e.target.value);
+                setValidationError("");
+              }}
+              placeholder={t("consumeAmountPlaceholder")}
+              autoFocus={!hasMultipleLots}
+            />
+            {validationError && <p className="text-sm text-destructive">{validationError}</p>}
+          </div>
+
+          {/* Preview */}
+          {preview && !preview.error && (
+            <div className="rounded-lg border p-4 text-sm">
+              <p className="font-medium text-muted-foreground">{t("consumePreviewTitle")}</p>
+              <p className="mt-1">
+                {t("consumeUnitsDisplay", { units: preview.units_after })}
+                {preview.opened_remaining_after !== null &&
+                preview.opened_remaining_after !== undefined
+                  ? t("consumeOpenedSuffix", {
+                      remaining: preview.opened_remaining_after,
+                      unit: item.content_unit,
+                    })
+                  : ""}
+              </p>
+            </div>
+          )}
+          {preview?.error && <p className="text-sm text-destructive">{preview.error}</p>}
+
+          <Button
+            className="w-full"
+            onClick={() => {
+              void handleSubmit();
+            }}
+            disabled={consumeLot.isPending || !delta || parseFloat(delta) <= 0}
+          >
+            {consumeLot.isPending ? <Spinner className="mr-2 h-4 w-4" /> : null}
+            {t("consume")}
+          </Button>
+        </>
+      )}
+
+      {hasMultipleLots && !selectedLot && (
+        <p className="text-center text-sm text-muted-foreground">{t("selectLotHint")}</p>
+      )}
     </div>
   );
 };
 
 export const Route = createFileRoute("/_auth/items/$itemId/consume")({
   component: ItemConsumePage,
+  validateSearch: (search: Record<string, unknown>) => ({
+    lotId: typeof search.lotId === "string" ? search.lotId : undefined,
+  }),
 });

--- a/src/routes/_auth.items.$itemId.consume.tsx
+++ b/src/routes/_auth.items.$itemId.consume.tsx
@@ -31,7 +31,7 @@ const ItemConsumePage = () => {
   const hasMultipleLots = activeLots.length > 1;
 
   const selectedLot: ItemLot | null =
-    selectedLotId != null
+    selectedLotId !== null
       ? (activeLots.find((l) => l.id === selectedLotId) ?? null)
       : activeLots.length === 1
         ? activeLots[0]!

--- a/src/routes/_auth.items.$itemId.consume.tsx
+++ b/src/routes/_auth.items.$itemId.consume.tsx
@@ -1,9 +1,4 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-
-const parseLocalDate = (dateStr: string) => {
-  const [y, m, d] = dateStr.split("-").map(Number) as [number, number, number];
-  return new Date(y, m - 1, d);
-};
 import { ArrowLeft } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -14,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useConsumeLot, useItemLots } from "@/hooks/useItemLots";
 import { useItem } from "@/hooks/useItems";
+import { parseLocalDate } from "@/lib/dateUtils";
 import { useToast } from "@/lib/toast-context";
 import { computeConsumption, type ItemLot } from "@/types/item";
 

--- a/src/routes/_auth.items.$itemId.tsx
+++ b/src/routes/_auth.items.$itemId.tsx
@@ -29,13 +29,9 @@ import { useDeleteItem, useItem } from "@/hooks/useItems";
 import { useCategories, useStorageLocations } from "@/hooks/useMasterData";
 import { useUpsertShoppingItem } from "@/hooks/useShoppingList";
 import { useUserSettings } from "@/hooks/useUserSettings";
+import { parseLocalDate } from "@/lib/dateUtils";
 import { useToast } from "@/lib/toast-context";
 import { getExpiryStatus } from "@/types/item";
-
-const parseLocalDate = (dateStr: string) => {
-  const [y, m, d] = dateStr.split("-").map(Number) as [number, number, number];
-  return new Date(y, m - 1, d);
-};
 
 const DetailRow = ({ icon, label, value }: { icon: ReactNode; label: string; value: string }) => (
   <div className="flex items-start gap-3">
@@ -369,7 +365,7 @@ const ItemDetailPage = () => {
                               </p>
                             )}
                           </div>
-                          {!isEmpty && (
+                          {(lot.units > 0 || lot.opened_remaining !== null) && (
                             <Button
                               variant="outline"
                               size="sm"

--- a/src/routes/_auth.items.$itemId.tsx
+++ b/src/routes/_auth.items.$itemId.tsx
@@ -5,6 +5,7 @@ import {
   Edit,
   Hash,
   History,
+  Layers,
   MapPin,
   Package,
   RefreshCw,
@@ -23,11 +24,13 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { useConsumptionLogs } from "@/hooks/useConsumptionLogs";
+import { useItemLots } from "@/hooks/useItemLots";
 import { useDeleteItem, useItem } from "@/hooks/useItems";
 import { useCategories, useStorageLocations } from "@/hooks/useMasterData";
 import { useUpsertShoppingItem } from "@/hooks/useShoppingList";
 import { useUserSettings } from "@/hooks/useUserSettings";
 import { useToast } from "@/lib/toast-context";
+import { getExpiryStatus } from "@/types/item";
 
 const DetailRow = ({ icon, label, value }: { icon: ReactNode; label: string; value: string }) => (
   <div className="flex items-start gap-3">
@@ -50,6 +53,7 @@ const ItemDetailPage = () => {
       m.routeId === "/_auth/items/$itemId/consume" || m.routeId === "/_auth/items/$itemId/edit",
   );
   const { data: item, isLoading, error } = useItem(itemId);
+  const { data: lots = [] } = useItemLots(itemId);
   const { data: categories = [] } = useCategories();
   const { data: locations = [] } = useStorageLocations();
   const { data: userSettings } = useUserSettings();
@@ -58,7 +62,7 @@ const ItemDetailPage = () => {
   const { data: logs = [] } = useConsumptionLogs(itemId);
   const { toast } = useToast();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [detailTab, setDetailTab] = useState<"info" | "history">("info");
+  const [detailTab, setDetailTab] = useState<"info" | "lots" | "history">("info");
 
   const handleRestock = async () => {
     if (!item) return;
@@ -115,6 +119,7 @@ const ItemDetailPage = () => {
   }
 
   const isEmpty = item.units === 0;
+  const hasMultipleLots = lots.length > 1;
   const totalDisplay =
     item.opened_remaining !== null && item.opened_remaining !== undefined
       ? t("totalDisplayOpened", {
@@ -211,6 +216,12 @@ const ItemDetailPage = () => {
                   {t("emptyStock")}
                 </Badge>
               )}
+              {hasMultipleLots && (
+                <Badge variant="outline" className="gap-1">
+                  <Layers className="h-3 w-3" />
+                  {t("lotCount", { count: lots.length })}
+                </Badge>
+              )}
               <ExpiryBadge
                 expiryDate={item.expiry_date}
                 warningDays={userSettings?.expiry_warning_days}
@@ -227,6 +238,20 @@ const ItemDetailPage = () => {
               <Package className="h-4 w-4" />
               {t("itemDetail")}
             </button>
+            {lots.length > 0 && (
+              <button
+                className={`flex flex-1 items-center justify-center gap-1 rounded py-1.5 text-sm font-medium transition-colors ${detailTab === "lots" ? "bg-primary text-primary-foreground" : "text-muted-foreground"}`}
+                onClick={() => setDetailTab("lots")}
+              >
+                <Layers className="h-4 w-4" />
+                {t("lots")}
+                {hasMultipleLots && (
+                  <span className="ml-1 rounded-full bg-primary/20 px-1.5 text-xs">
+                    {lots.length}
+                  </span>
+                )}
+              </button>
+            )}
             <button
               className={`flex flex-1 items-center justify-center gap-1 rounded py-1.5 text-sm font-medium transition-colors ${detailTab === "history" ? "bg-primary text-primary-foreground" : "text-muted-foreground"}`}
               onClick={() => setDetailTab("history")}
@@ -241,7 +266,7 @@ const ItemDetailPage = () => {
             </button>
           </div>
 
-          {detailTab === "info" ? (
+          {detailTab === "info" && (
             <Card>
               <CardContent className="space-y-3 p-4">
                 <DetailRow
@@ -286,7 +311,79 @@ const ItemDetailPage = () => {
                 )}
               </CardContent>
             </Card>
-          ) : (
+          )}
+
+          {detailTab === "lots" && (
+            <div className="space-y-2">
+              {lots.length === 0 ? (
+                <p className="py-6 text-center text-sm text-muted-foreground">{t("noLots")}</p>
+              ) : (
+                lots.map((lot, index) => {
+                  const lotDisplay =
+                    lot.opened_remaining !== null && lot.opened_remaining !== undefined
+                      ? t("totalDisplayOpened", {
+                          units: lot.units,
+                          remaining: lot.opened_remaining,
+                          unit: item.content_unit,
+                        })
+                      : t("totalDisplaySealed", {
+                          units: lot.units,
+                          amount: item.content_amount,
+                          unit: item.content_unit,
+                        });
+                  const expiryStatus = getExpiryStatus(
+                    lot.expiry_date,
+                    userSettings?.expiry_warning_days,
+                  );
+                  return (
+                    <Card key={lot.id}>
+                      <CardContent className="p-3">
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="space-y-0.5">
+                            <p className="text-sm font-medium">
+                              {t("lotLabel", { index: index + 1 })} — {lotDisplay}
+                            </p>
+                            {lot.expiry_date && (
+                              <p
+                                className={`text-xs ${expiryStatus === "expired" ? "text-destructive" : expiryStatus === "expiring-soon" ? "text-warning" : "text-muted-foreground"}`}
+                              >
+                                {t("expiryDate")}: {new Date(lot.expiry_date).toLocaleDateString()}
+                              </p>
+                            )}
+                            {lot.purchase_date && (
+                              <p className="text-xs text-muted-foreground">
+                                {t("purchaseDate")}:{" "}
+                                {new Date(lot.purchase_date).toLocaleDateString()}
+                              </p>
+                            )}
+                          </div>
+                          {!isEmpty && (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="shrink-0"
+                              onClick={() =>
+                                void navigate({
+                                  to: "/items/$itemId/consume",
+                                  params: { itemId },
+                                  search: { lotId: lot.id },
+                                })
+                              }
+                            >
+                              <Zap className="h-3 w-3" />
+                              {t("consume")}
+                            </Button>
+                          )}
+                        </div>
+                      </CardContent>
+                    </Card>
+                  );
+                })
+              )}
+            </div>
+          )}
+
+          {detailTab === "history" && (
             <div className="space-y-2">
               {logs.length === 0 ? (
                 <p className="py-6 text-center text-sm text-muted-foreground">{t("noHistory")}</p>

--- a/src/routes/_auth.items.$itemId.tsx
+++ b/src/routes/_auth.items.$itemId.tsx
@@ -32,6 +32,11 @@ import { useUserSettings } from "@/hooks/useUserSettings";
 import { useToast } from "@/lib/toast-context";
 import { getExpiryStatus } from "@/types/item";
 
+const parseLocalDate = (dateStr: string) => {
+  const [y, m, d] = dateStr.split("-").map(Number) as [number, number, number];
+  return new Date(y, m - 1, d);
+};
+
 const DetailRow = ({ icon, label, value }: { icon: ReactNode; label: string; value: string }) => (
   <div className="flex items-start gap-3">
     <span className="mt-0.5 text-muted-foreground">{icon}</span>
@@ -298,14 +303,14 @@ const ItemDetailPage = () => {
                   <DetailRow
                     icon={<Calendar className="h-4 w-4" />}
                     label={t("purchaseDate")}
-                    value={new Date(item.purchase_date).toLocaleDateString()}
+                    value={parseLocalDate(item.purchase_date).toLocaleDateString()}
                   />
                 )}
                 {item.expiry_date && (
                   <DetailRow
                     icon={<Calendar className="h-4 w-4" />}
                     label={t("expiryDate")}
-                    value={new Date(item.expiry_date).toLocaleDateString()}
+                    value={parseLocalDate(item.expiry_date).toLocaleDateString()}
                   />
                 )}
                 {item.notes && (
@@ -353,13 +358,14 @@ const ItemDetailPage = () => {
                               <p
                                 className={`text-xs ${expiryStatus === "expired" ? "text-destructive" : expiryStatus === "expiring-soon" ? "text-warning" : "text-muted-foreground"}`}
                               >
-                                {t("expiryDate")}: {new Date(lot.expiry_date).toLocaleDateString()}
+                                {t("expiryDate")}:{" "}
+                                {parseLocalDate(lot.expiry_date).toLocaleDateString()}
                               </p>
                             )}
                             {lot.purchase_date && (
                               <p className="text-xs text-muted-foreground">
                                 {t("purchaseDate")}:{" "}
-                                {new Date(lot.purchase_date).toLocaleDateString()}
+                                {parseLocalDate(lot.purchase_date).toLocaleDateString()}
                               </p>
                             )}
                           </div>

--- a/src/routes/_auth.items.$itemId.tsx
+++ b/src/routes/_auth.items.$itemId.tsx
@@ -162,7 +162,13 @@ const ItemDetailPage = () => {
             variant="outline"
             size="sm"
             disabled={isEmpty}
-            onClick={() => void navigate({ to: "/items/$itemId/consume", params: { itemId } })}
+            onClick={() =>
+              void navigate({
+                to: "/items/$itemId/consume",
+                params: { itemId },
+                search: { lotId: undefined },
+              })
+            }
           >
             <Zap className="h-4 w-4" />
             {t("consume")}

--- a/src/routes/_auth.items.new.tsx
+++ b/src/routes/_auth.items.new.tsx
@@ -6,9 +6,8 @@ import { useTranslation } from "react-i18next";
 import { ItemForm } from "@/components/organisms/ItemForm";
 import { Button } from "@/components/ui/button";
 import { uploadItemImage } from "@/hooks/useItemImage";
-import { useCreateItem } from "@/hooks/useItems";
+import { findActiveItemByBarcode, useCreateItem } from "@/hooks/useItems";
 import { OfflineError } from "@/lib/requireOnline";
-import { supabase } from "@/lib/supabase";
 import { useToast } from "@/lib/toast-context";
 import type { Item, ItemFormValues } from "@/types/item";
 
@@ -20,22 +19,14 @@ const NewItemPage = () => {
   const pendingFileRef = useRef<File | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [existingItem, setExistingItem] = useState<Item | null>(null);
-  const [stackedItemId, setStackedItemId] = useState<string | null>(null);
 
   const handleBarcodeScanned = async (barcode: string, source: "db" | "api" | null) => {
     if (source !== "db") {
       setExistingItem(null);
       return;
     }
-    const { data } = await supabase
-      .from("items")
-      .select("*")
-      .eq("barcode", barcode)
-      .is("deleted_at", null)
-      .limit(1)
-      .maybeSingle();
-    setExistingItem(data ? (data as Item) : null);
-    if (data) setStackedItemId((data as Item).id);
+    const found = await findActiveItemByBarcode(barcode);
+    setExistingItem(found);
   };
 
   const handleSubmit = async (values: ItemFormValues) => {
@@ -61,7 +52,7 @@ const NewItemPage = () => {
         toast(t("stackSuccess"), "success");
         void navigate({
           to: "/items/$itemId",
-          params: { itemId: stackedItemId ?? item.id },
+          params: { itemId: item.id },
         });
       } else {
         toast(t("createSuccess"), "success");

--- a/src/routes/_auth.items.new.tsx
+++ b/src/routes/_auth.items.new.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, PackagePlus } from "lucide-react";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -8,8 +8,9 @@ import { Button } from "@/components/ui/button";
 import { uploadItemImage } from "@/hooks/useItemImage";
 import { useCreateItem } from "@/hooks/useItems";
 import { OfflineError } from "@/lib/requireOnline";
+import { supabase } from "@/lib/supabase";
 import { useToast } from "@/lib/toast-context";
-import type { ItemFormValues } from "@/types/item";
+import type { Item, ItemFormValues } from "@/types/item";
 
 const NewItemPage = () => {
   const { t } = useTranslation("items");
@@ -18,12 +19,32 @@ const NewItemPage = () => {
   const { toast } = useToast();
   const pendingFileRef = useRef<File | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [existingItem, setExistingItem] = useState<Item | null>(null);
+  const [stackedItemId, setStackedItemId] = useState<string | null>(null);
+
+  const handleBarcodeScanned = async (barcode: string, source: "db" | "api" | null) => {
+    if (source !== "db") {
+      setExistingItem(null);
+      return;
+    }
+    const { data } = await supabase
+      .from("items")
+      .select("*")
+      .eq("barcode", barcode)
+      .is("deleted_at", null)
+      .limit(1)
+      .maybeSingle();
+    setExistingItem(data ? (data as Item) : null);
+    if (data) setStackedItemId((data as Item).id);
+  };
 
   const handleSubmit = async (values: ItemFormValues) => {
     setIsSubmitting(true);
     try {
       const item = await createItem.mutateAsync(values);
-      if (pendingFileRef.current && item) {
+      const result = item as Item & { _stacked?: boolean; _revived?: boolean };
+
+      if (pendingFileRef.current && item && !result._stacked) {
         try {
           await uploadItemImage({ itemId: item.id, file: pendingFileRef.current });
         } catch (err) {
@@ -35,8 +56,17 @@ const NewItemPage = () => {
           return;
         }
       }
-      toast(t("createSuccess"), "success");
-      void navigate({ to: "/" });
+
+      if (result._stacked) {
+        toast(t("stackSuccess"), "success");
+        void navigate({
+          to: "/items/$itemId",
+          params: { itemId: stackedItemId ?? item.id },
+        });
+      } else {
+        toast(t("createSuccess"), "success");
+        void navigate({ to: "/" });
+      }
     } catch {
       toast(t("common:unknownError"), "error");
     } finally {
@@ -52,6 +82,19 @@ const NewItemPage = () => {
         </Button>
         <h1 className="text-xl font-bold">{t("addItem")}</h1>
       </div>
+
+      {existingItem && (
+        <div className="flex items-start gap-3 rounded-lg border border-primary/40 bg-primary/5 p-3">
+          <PackagePlus className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+          <div className="text-sm">
+            <p className="font-medium text-primary">{t("stackBannerTitle")}</p>
+            <p className="mt-0.5 text-muted-foreground">
+              {t("stackBannerBody", { name: existingItem.name })}
+            </p>
+          </div>
+        </div>
+      )}
+
       <ItemForm
         onSubmit={(values) => {
           void handleSubmit(values);
@@ -60,6 +103,10 @@ const NewItemPage = () => {
         onPendingFileChange={(file) => {
           pendingFileRef.current = file;
         }}
+        onBarcodeScanned={(barcode, source) => {
+          void handleBarcodeScanned(barcode, source);
+        }}
+        submitLabel={existingItem ? t("stackSubmitLabel") : undefined}
       />
     </div>
   );

--- a/src/types/item.test.ts
+++ b/src/types/item.test.ts
@@ -55,7 +55,8 @@ describe("itemLotSchema", () => {
   });
 
   test("missing required fields fail", () => {
-    const { id: _id, ...withoutId } = validLot;
+    const withoutId: Record<string, unknown> = { ...validLot };
+    delete withoutId["id"];
     const result = itemLotSchema.safeParse(withoutId);
     expect(result.success).toBe(false);
   });

--- a/src/types/item.test.ts
+++ b/src/types/item.test.ts
@@ -1,6 +1,99 @@
 import { describe, expect, test } from "bun:test";
 
-import { computeConsumption, DEFAULT_EXPIRY_WARNING_DAYS, getExpiryStatus } from "./item";
+import {
+  computeConsumption,
+  DEFAULT_EXPIRY_WARNING_DAYS,
+  formatRemaining,
+  getExpiryStatus,
+  itemLotSchema,
+} from "./item";
+
+// --- itemLotSchema ---
+
+describe("itemLotSchema", () => {
+  // Zod v4 requires version nibble [1-8] and variant nibble [89abAB]
+  const validLot = {
+    id: "00000000-0000-4000-8000-000000000001",
+    user_id: "00000000-0000-4000-8000-000000000002",
+    item_id: "00000000-0000-4000-8000-000000000003",
+    units: 2,
+    opened_remaining: null,
+    purchase_date: null,
+    expiry_date: "2099-12-31",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+  };
+
+  test("valid lot parses correctly", () => {
+    const result = itemLotSchema.safeParse(validLot);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.units).toBe(2);
+      expect(result.data.opened_remaining).toBeNull();
+    }
+  });
+
+  test("units=0 is allowed", () => {
+    const result = itemLotSchema.safeParse({ ...validLot, units: 0 });
+    expect(result.success).toBe(true);
+  });
+
+  test("negative units fail", () => {
+    const result = itemLotSchema.safeParse({ ...validLot, units: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  test("opened_remaining as number is valid", () => {
+    const result = itemLotSchema.safeParse({ ...validLot, opened_remaining: 350 });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.opened_remaining).toBe(350);
+  });
+
+  test("negative opened_remaining fails", () => {
+    const result = itemLotSchema.safeParse({ ...validLot, opened_remaining: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  test("missing required fields fail", () => {
+    const { id: _id, ...withoutId } = validLot;
+    const result = itemLotSchema.safeParse(withoutId);
+    expect(result.success).toBe(false);
+  });
+});
+
+// --- formatRemaining ---
+
+describe("formatRemaining", () => {
+  test("all sealed: units × content_amount", () => {
+    expect(formatRemaining(3, 1000, null)).toBe("3000");
+  });
+
+  test("one opened unit: (units-1) × amount + opened_remaining", () => {
+    expect(formatRemaining(3, 1000, 350)).toBe("2350");
+  });
+
+  test("single unit fully sealed", () => {
+    expect(formatRemaining(1, 500, null)).toBe("500");
+  });
+
+  test("single unit opened", () => {
+    expect(formatRemaining(1, 500, 200)).toBe("200");
+  });
+
+  test("count unit (個) with content_amount=1", () => {
+    expect(formatRemaining(5, 1, null)).toBe("5");
+  });
+
+  test("decimal content_amount strips trailing zeros", () => {
+    // 2 × 1.5 = 3.0 → "3"
+    expect(formatRemaining(2, 1.5, null)).toBe("3");
+  });
+
+  test("decimal result keeps significant digits", () => {
+    // 1 × 1.5 opened=0.75 → (0 × 1.5) + 0.75 = 0.75
+    expect(formatRemaining(1, 1.5, 0.75)).toBe("0.75");
+  });
+});
 
 // --- getExpiryStatus ---
 

--- a/src/types/item.test.ts
+++ b/src/types/item.test.ts
@@ -196,4 +196,10 @@ describe("computeConsumption", () => {
     expect(r.opened_remaining_after).toBeNull();
     expect(r.error).toBeUndefined();
   });
+
+  test("opened: consume more than opened with no sealed units left => error", () => {
+    // units=1 (the open unit), opened=200, delta=300: only 200 available, not 800
+    const r = computeConsumption({ ...baseItem, units: 1, opened_remaining: 200 }, 300);
+    expect(r.error).toBeDefined();
+  });
 });

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -131,32 +131,35 @@ export const computeConsumption = (
   opened_remaining_after: number | null;
   error?: string;
 } => {
-  const contentAmount = item.content_amount;
-  let remaining = item.opened_remaining ?? contentAmount;
-  let units = item.units;
+  const { content_amount: contentAmount, units, opened_remaining: openedRemaining } = item;
 
-  remaining -= delta;
+  // Compute total available stock to detect over-consumption before mutating state.
+  // When opened_remaining is set, the open unit is already counted in `units`,
+  // so sealed units = units - 1.
+  const totalBefore =
+    units === 0
+      ? 0
+      : openedRemaining !== null
+        ? (units - 1) * contentAmount + openedRemaining
+        : units * contentAmount;
 
-  while (remaining < 0 && units > 0) {
-    units -= 1;
-    remaining += contentAmount;
-  }
-
-  if (remaining < 0) {
+  if (delta > totalBefore) {
     return { units_after: 0, opened_remaining_after: 0, error: "在庫が不足しています" };
   }
 
-  // opened unit fully consumed → decrement units
-  if (remaining === 0) {
-    units -= 1;
-    if (units < 0) {
-      return { units_after: 0, opened_remaining_after: 0, error: "在庫が不足しています" };
-    }
-    return { units_after: units, opened_remaining_after: null };
+  // Round to avoid floating-point noise (DB stores numeric(12,2))
+  const round = (n: number) => Math.round(n * 1e10) / 1e10;
+  const totalAfter = round(totalBefore - delta);
+
+  if (totalAfter === 0) {
+    return { units_after: 0, opened_remaining_after: null };
   }
 
-  return {
-    units_after: units,
-    opened_remaining_after: remaining,
-  };
+  const sealedUnits = Math.floor(round(totalAfter / contentAmount));
+  const openedAfter = round(totalAfter - sealedUnits * contentAmount);
+
+  if (openedAfter === 0) {
+    return { units_after: sealedUnits, opened_remaining_after: null };
+  }
+  return { units_after: sealedUnits + 1, opened_remaining_after: openedAfter };
 };

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -110,6 +110,19 @@ export const getExpiryStatus = (
   return "ok";
 };
 
+/** カードや一覧で使う「残量」の合計値を文字列として返す。 */
+export const formatRemaining = (
+  units: number,
+  contentAmount: number,
+  openedRemaining: number | null,
+): string => {
+  const total =
+    openedRemaining !== null
+      ? (units - 1) * contentAmount + openedRemaining
+      : units * contentAmount;
+  return total % 1 === 0 ? String(total) : total.toFixed(2).replace(/\.?0+$/, "");
+};
+
 export const computeConsumption = (
   item: Pick<Item, "units" | "content_amount" | "content_unit" | "opened_remaining">,
   delta: number,

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -54,6 +54,18 @@ export const itemFormSchema = z.object({
   image_path: z.string().optional(),
 });
 
+export const itemLotSchema = z.object({
+  id: z.string().uuid(),
+  user_id: z.string().uuid(),
+  item_id: z.string().uuid(),
+  units: z.number().int().min(0).default(1),
+  opened_remaining: z.number().min(0).nullable().optional(),
+  purchase_date: z.string().nullable().optional(),
+  expiry_date: z.string().nullable().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
 export const consumeFormSchema = z.object({
   delta_amount: z.coerce.number().positive("消費量は0より大きい値を入力してください"),
 });
@@ -71,6 +83,7 @@ export const userSettingsSchema = z.object({
 export type Category = z.infer<typeof categorySchema>;
 export type StorageLocation = z.infer<typeof storageLocationSchema>;
 export type Item = z.infer<typeof itemSchema>;
+export type ItemLot = z.infer<typeof itemLotSchema>;
 export type ItemFormValues = z.infer<typeof itemFormSchema>;
 export type ConsumeFormValues = z.infer<typeof consumeFormSchema>;
 export type UserSettings = z.infer<typeof userSettingsSchema>;

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -131,7 +131,8 @@ export const computeConsumption = (
   opened_remaining_after: number | null;
   error?: string;
 } => {
-  const { content_amount: contentAmount, units, opened_remaining: openedRemaining } = item;
+  const { content_amount: contentAmount, units } = item;
+  const openedRemaining = item.opened_remaining ?? null;
 
   // Compute total available stock to detect over-consumption before mutating state.
   // When opened_remaining is set, the open unit is already counted in `units`,

--- a/supabase/migrations/20260513000001_create_item_lots.sql
+++ b/supabase/migrations/20260513000001_create_item_lots.sql
@@ -1,0 +1,30 @@
+-- item_lots: per-purchase inventory batches
+-- Each item can have multiple lots with individual expiry/purchase dates.
+create table item_lots (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  item_id uuid not null references items(id) on delete cascade,
+  units int not null default 1 check (units >= 0),
+  opened_remaining numeric(12,2) check (opened_remaining is null or opened_remaining >= 0),
+  purchase_date date,
+  expiry_date date,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index item_lots_item_idx on item_lots(item_id, created_at asc);
+create index item_lots_user_idx on item_lots(user_id);
+create index item_lots_expiry_idx on item_lots(expiry_date);
+
+alter table item_lots enable row level security;
+create policy "item_lots_owner_all" on item_lots for all
+  using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+create trigger item_lots_set_updated_at before update on item_lots
+  for each row execute function public.set_updated_at();
+
+-- Migrate existing active items: create one lot per item
+insert into item_lots (user_id, item_id, units, opened_remaining, purchase_date, expiry_date, created_at, updated_at)
+select user_id, id, units, opened_remaining, purchase_date, expiry_date, created_at, updated_at
+from items
+where deleted_at is null;

--- a/supabase/migrations/20260513000001_create_item_lots.sql
+++ b/supabase/migrations/20260513000001_create_item_lots.sql
@@ -6,6 +6,7 @@ create table item_lots (
   item_id uuid not null references items(id) on delete cascade,
   units int not null default 1 check (units >= 0),
   opened_remaining numeric(12,2) check (opened_remaining is null or opened_remaining >= 0),
+  constraint item_lots_opened_requires_unit check (opened_remaining is null or units >= 1),
   purchase_date date,
   expiry_date date,
   created_at timestamptz not null default now(),
@@ -17,8 +18,17 @@ create index item_lots_user_idx on item_lots(user_id);
 create index item_lots_expiry_idx on item_lots(expiry_date);
 
 alter table item_lots enable row level security;
+-- Verify both user ownership and that item_id belongs to the same user,
+-- preventing cross-tenant references from malicious clients.
 create policy "item_lots_owner_all" on item_lots for all
-  using (auth.uid() = user_id) with check (auth.uid() = user_id);
+  using (
+    auth.uid() = user_id
+    and exists (select 1 from items where items.id = item_lots.item_id and items.user_id = auth.uid())
+  )
+  with check (
+    auth.uid() = user_id
+    and exists (select 1 from items where items.id = item_lots.item_id and items.user_id = auth.uid())
+  );
 
 create trigger item_lots_set_updated_at before update on item_lots
   for each row execute function public.set_updated_at();


### PR DESCRIPTION
When adding a product that already exists (same barcode), stock is now
stacked onto the existing item rather than creating a duplicate. Each
purchase is recorded as a separate lot with its own expiry date and
purchase date.

Key changes:
- New `item_lots` table tracks per-purchase batches with individual
  units, opened_remaining, purchase_date, and expiry_date
- `items.units` and `items.expiry_date` are kept as aggregate cache
  values (total units, earliest expiry) updated after every lot change
- When scanning a barcode that matches an active item, a new lot is
  added instead of creating a new item; a banner informs the user
- When a soft-deleted item is revived, a new lot is added rather than
  overwriting the unit count
- Item detail page gains a "Lots" tab showing each batch with its
  individual expiry/purchase dates and a per-lot consume button
- Consume page shows a lot selector when multiple lots exist, enabling
  the user to choose which batch to draw from (especially useful for
  g/mL items)

https://claude.ai/code/session_01U55M633CGKb8DZGXrvgjB3