### PR TITLE
fix: 使う画面で入力欄が表示されない問題を修正

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,3 @@
+VITE_SUPABASE_URL=http://localhost:54321
+VITE_SUPABASE_PUBLISHABLE_KEY=fake-key-for-tests
+VITE_VAPID_PUBLIC_KEY=fake-vapid-key-for-tests

--- a/src/locales/en/items.json
+++ b/src/locales/en/items.json
@@ -105,5 +105,8 @@
   "lotLabel": "Lot {{index}}",
   "lotCount": "{{count}} lots",
   "selectLot": "Select lot to use",
-  "selectLotHint": "Select a lot above to continue"
+  "selectLotHint": "Select a lot above to continue",
+  "lotsLoadError": "Failed to load stock lots. Please try again later.",
+  "back": "Back",
+  "noStockToConsume": "No stock available to use"
 }

--- a/src/locales/ja/items.json
+++ b/src/locales/ja/items.json
@@ -105,5 +105,8 @@
   "lotLabel": "ロット{{index}}",
   "lotCount": "{{count}}ロット",
   "selectLot": "使うロットを選択",
-  "selectLotHint": "上からロットを選んでください"
+  "selectLotHint": "上からロットを選んでください",
+  "lotsLoadError": "在庫ロットの読み込みに失敗しました。時間をおいて再試行してください。",
+  "back": "戻る",
+  "noStockToConsume": "使用できる在庫がありません"
 }

--- a/src/routes/_auth.items.$itemId.consume.test.tsx
+++ b/src/routes/_auth.items.$itemId.consume.test.tsx
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import * as useItemLotsModule from "@/hooks/useItemLots";
+import * as useItemsModule from "@/hooks/useItems";
+import { ToastContext } from "@/lib/toast-context";
+import type { ToastContextValue } from "@/lib/toast-context";
+import type { Item, ItemLot } from "@/types/item";
+
+// Import routerContext via relative path (not in public package exports) to provide
+// a minimal router stub so that useNavigate inside ItemConsumePage doesn't throw.
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { routerContext } from "../../node_modules/@tanstack/react-router/dist/esm/routerContext.js";
+
+import { ItemConsumePage, Route } from "./_auth.items.$itemId.consume";
+
+// Minimal stub that satisfies what useNavigate reads off the router.
+const stubRouter = {
+  navigate: () => Promise.resolve(),
+  buildLocation: () => ({ href: "/" }),
+  isServer: false,
+  options: {},
+  state: { location: { href: "/", pathname: "/" }, matches: [], pendingMatches: [] },
+} as unknown as Parameters<typeof routerContext.Provider>[0]["value"];
+
+const stubToast: ToastContextValue = { toasts: [], toast: () => {}, dismiss: () => {} };
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <routerContext.Provider value={stubRouter}>
+    <ToastContext.Provider value={stubToast}>{children}</ToastContext.Provider>
+  </routerContext.Provider>
+);
+
+const baseItem: Item = {
+  id: "test-item-id",
+  user_id: "test-user-id",
+  name: "テスト商品",
+  barcode: null,
+  category_id: null,
+  storage_location_id: null,
+  units: 1,
+  content_amount: 500,
+  content_unit: "mL",
+  opened_remaining: null,
+  purchase_date: null,
+  expiry_date: null,
+  image_path: null,
+  notes: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  deleted_at: null,
+};
+
+const baseLot: ItemLot = {
+  id: "test-lot-id",
+  user_id: "test-user-id",
+  item_id: "test-item-id",
+  units: 1,
+  opened_remaining: null,
+  purchase_date: null,
+  expiry_date: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const renderPage = () => render(<ItemConsumePage />, { wrapper: Wrapper as React.ComponentType });
+
+describe("ItemConsumePage", () => {
+  let lotsspy: ReturnType<typeof spyOn>;
+  let itemspy: ReturnType<typeof spyOn>;
+  let consumespy: ReturnType<typeof spyOn>;
+  let paramsspy: ReturnType<typeof spyOn>;
+  let searchspy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    paramsspy = spyOn(Route, "useParams").mockReturnValue({
+      itemId: "test-item-id",
+    } as ReturnType<typeof Route.useParams>);
+
+    searchspy = spyOn(Route, "useSearch").mockReturnValue({
+      lotId: undefined,
+    } as ReturnType<typeof Route.useSearch>);
+
+    lotsspy = spyOn(useItemLotsModule, "useItemLots").mockReturnValue({
+      data: [baseLot],
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useItemLotsModule.useItemLots>);
+
+    itemspy = spyOn(useItemsModule, "useItem").mockReturnValue({
+      data: baseItem,
+      isLoading: false,
+    } as ReturnType<typeof useItemsModule.useItem>);
+
+    consumespy = spyOn(useItemLotsModule, "useConsumeLot").mockReturnValue({
+      mutateAsync: async () => baseLot,
+      isPending: false,
+    } as unknown as ReturnType<typeof useItemLotsModule.useConsumeLot>);
+  });
+
+  afterEach(() => {
+    paramsspy.mockRestore();
+    searchspy.mockRestore();
+    lotsspy.mockRestore();
+    itemspy.mockRestore();
+    consumespy.mockRestore();
+    cleanup();
+  });
+
+  it("shows spinner while item is loading", () => {
+    itemspy.mockReturnValue({ data: undefined, isLoading: true } as ReturnType<
+      typeof useItemsModule.useItem
+    >);
+    const { getByRole, queryByRole } = renderPage();
+    expect(getByRole("status")).toBeDefined();
+    expect(queryByRole("spinbutton")).toBeNull();
+  });
+
+  it("shows spinner while lots are loading", () => {
+    lotsspy.mockReturnValue({ data: [], isLoading: true, isError: false } as ReturnType<
+      typeof useItemLotsModule.useItemLots
+    >);
+    const { getByRole, queryByRole } = renderPage();
+    expect(getByRole("status")).toBeDefined();
+    expect(queryByRole("spinbutton")).toBeNull();
+  });
+
+  it("shows error message when lots query fails", () => {
+    lotsspy.mockReturnValue({ data: [], isLoading: false, isError: true } as ReturnType<
+      typeof useItemLotsModule.useItemLots
+    >);
+    const { getByText, queryByRole } = renderPage();
+    expect(getByText("lotsLoadError")).toBeDefined();
+    expect(queryByRole("spinbutton")).toBeNull();
+  });
+
+  it("shows item not found when item is null and not loading", () => {
+    itemspy.mockReturnValue({ data: undefined, isLoading: false } as ReturnType<
+      typeof useItemsModule.useItem
+    >);
+    const { getByText } = renderPage();
+    expect(getByText("itemNotFound")).toBeDefined();
+  });
+
+  it("shows no stock message when there are no lots", () => {
+    lotsspy.mockReturnValue({ data: [], isLoading: false, isError: false } as ReturnType<
+      typeof useItemLotsModule.useItemLots
+    >);
+    const { getByText, queryByRole } = renderPage();
+    expect(getByText("noStockToConsume")).toBeDefined();
+    expect(queryByRole("spinbutton")).toBeNull();
+  });
+
+  it("shows no stock message when all lots have zero units and no opened_remaining", () => {
+    lotsspy.mockReturnValue({
+      data: [{ ...baseLot, units: 0, opened_remaining: null }],
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useItemLotsModule.useItemLots>);
+    const { getByText, queryByRole } = renderPage();
+    expect(getByText("noStockToConsume")).toBeDefined();
+    expect(queryByRole("spinbutton")).toBeNull();
+  });
+
+  it("shows numeric input when there is one active lot", () => {
+    const { getByRole } = renderPage();
+    expect(getByRole("spinbutton")).toBeDefined();
+  });
+
+  it("shows numeric input when lot has opened_remaining (active even with units=1)", () => {
+    lotsspy.mockReturnValue({
+      data: [{ ...baseLot, units: 1, opened_remaining: 250 }],
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useItemLotsModule.useItemLots>);
+    const { getByRole } = renderPage();
+    expect(getByRole("spinbutton")).toBeDefined();
+  });
+});

--- a/src/routes/_auth.items.$itemId.consume.test.tsx
+++ b/src/routes/_auth.items.$itemId.consume.test.tsx
@@ -1,10 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 
 import * as useItemLotsModule from "@/hooks/useItemLots";
 import * as useItemsModule from "@/hooks/useItems";
-import { ToastContext } from "@/lib/toast-context";
-import type { ToastContextValue } from "@/lib/toast-context";
+import { ToastContext, type ToastContextValue } from "@/lib/toast-context";
 import type { Item, ItemLot } from "@/types/item";
 
 // Import routerContext via relative path (not in public package exports) to provide
@@ -12,7 +11,6 @@ import type { Item, ItemLot } from "@/types/item";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { routerContext } from "../../node_modules/@tanstack/react-router/dist/esm/routerContext.js";
-
 import { ItemConsumePage, Route } from "./_auth.items.$itemId.consume";
 
 // Minimal stub that satisfies what useNavigate reads off the router.

--- a/src/routes/_auth.items.$itemId.consume.tsx
+++ b/src/routes/_auth.items.$itemId.consume.tsx
@@ -19,7 +19,7 @@ const ItemConsumePage = () => {
   const { lotId: preselectedLotId } = Route.useSearch();
   const navigate = useNavigate();
   const { data: item, isLoading: itemLoading } = useItem(itemId);
-  const { data: lots = [], isLoading: lotsLoading } = useItemLots(itemId);
+  const { data: lots = [], isLoading: lotsLoading, isError: lotsError } = useItemLots(itemId);
   const consumeLot = useConsumeLot();
   const { toast } = useToast();
   const [selectedLotId, setSelectedLotId] = useState<string | null>(preselectedLotId ?? null);
@@ -76,6 +76,29 @@ const ItemConsumePage = () => {
     return (
       <div className="flex min-h-[200px] items-center justify-center">
         <Spinner />
+      </div>
+    );
+  }
+
+  if (lotsError) {
+    return (
+      <div className="space-y-4">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => void navigate({ to: "/items/$itemId", params: { itemId } })}
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <div className="space-y-3 rounded-lg border border-destructive p-4 text-destructive">
+          <p className="font-medium">{t("lotsLoadError")}</p>
+          <Button
+            variant="outline"
+            onClick={() => void navigate({ to: "/items/$itemId", params: { itemId } })}
+          >
+            {t("back")}
+          </Button>
+        </div>
       </div>
     );
   }
@@ -239,6 +262,10 @@ const ItemConsumePage = () => {
             {t("consume")}
           </Button>
         </>
+      )}
+
+      {activeLots.length === 0 && (
+        <p className="text-center text-sm text-muted-foreground">{t("noStockToConsume")}</p>
       )}
 
       {hasMultipleLots && !selectedLot && (

--- a/src/routes/_auth.items.$itemId.consume.tsx
+++ b/src/routes/_auth.items.$itemId.consume.tsx
@@ -13,7 +13,7 @@ import { parseLocalDate } from "@/lib/dateUtils";
 import { useToast } from "@/lib/toast-context";
 import { computeConsumption, type ItemLot } from "@/types/item";
 
-const ItemConsumePage = () => {
+export const ItemConsumePage = () => {
   const { t } = useTranslation("items");
   const { itemId } = Route.useParams();
   const { lotId: preselectedLotId } = Route.useSearch();


### PR DESCRIPTION
Supabase に item_lots マイグレーションが未適用だったため
item_lots テーブルが存在せず、ロットクエリが空を返していた。

- Supabase に create_item_lots マイグレーションを適用し、
  既存の全アクティブアイテムを item_lots に移行（32件）
- consume ページにロットクエリのエラーハンドリングを追加
  （失敗時に無言で空フォームを表示するのを防ぐ）
- activeLots が空の場合（在庫なし）のメッセージを追加
- ja/en 翻訳キー追加: lotsLoadError, back, noStockToConsume

https://claude.ai/code/session_01GBs8TEMfn1HAXM6FsmZ1xh