### PR TITLE
fix: strengthen image-proxy content-type handling to prevent API image save failures

### DIFF
--- a/supabase/functions/image-proxy/index.ts
+++ b/supabase/functions/image-proxy/index.ts
@@ -10,7 +10,7 @@ const ALLOWED_HOSTS = [
   /^item-shopping\.c\.yimg\.jp$/,
 ];
 
-const ALLOWED_CONTENT_TYPES = ["image/jpeg", "image/png", "image/webp"];
+const ALLOWED_CONTENT_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
 
 const MAX_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
 
@@ -19,6 +19,14 @@ const isAllowedHost = (hostname: string): boolean =>
 
 const isAllowedUrl = (url: URL): boolean =>
   url.protocol === "https:" && isAllowedHost(url.hostname);
+
+const inferContentTypeFromPath = (path: string): string | null => {
+  const normalized = path.toLowerCase();
+  if (normalized.endsWith(".jpg") || normalized.endsWith(".jpeg")) return "image/jpeg";
+  if (normalized.endsWith(".png")) return "image/png";
+  if (normalized.endsWith(".webp")) return "image/webp";
+  return null;
+};
 
 Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") {
@@ -79,7 +87,11 @@ Deno.serve(async (req: Request) => {
 
     // Validate Content-Type before reading body
     const contentType = res.headers.get("Content-Type") ?? "";
-    const matchedType = ALLOWED_CONTENT_TYPES.find((t) => contentType.startsWith(t));
+    const matchedTypeFromHeader = ALLOWED_CONTENT_TYPES.find((t) => contentType.startsWith(t));
+    const matchedType =
+      matchedTypeFromHeader ??
+      inferContentTypeFromPath(finalUrl.pathname) ??
+      inferContentTypeFromPath(parsed.pathname);
     if (!matchedType) {
       return new Response(JSON.stringify({ error: "Unsupported content type" }), {
         status: 400,

--- a/supabase/functions/image-proxy/index.ts
+++ b/supabase/functions/image-proxy/index.ts
@@ -102,7 +102,7 @@ Deno.serve(async (req: Request) => {
     const matchedType =
       matchedTypeFromHeader ??
       (canInferContentTypeFromPath(contentType)
-        ? inferContentTypeFromPath(finalUrl.pathname) ?? inferContentTypeFromPath(parsed.pathname)
+        ? (inferContentTypeFromPath(finalUrl.pathname) ?? inferContentTypeFromPath(parsed.pathname))
         : null);
     if (!matchedType) {
       return new Response(JSON.stringify({ error: "Unsupported content type" }), {

--- a/supabase/functions/image-proxy/index.ts
+++ b/supabase/functions/image-proxy/index.ts
@@ -11,6 +11,7 @@ const ALLOWED_HOSTS = [
 ];
 
 const ALLOWED_CONTENT_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
+const GENERIC_CONTENT_TYPES = ["application/octet-stream", "binary/octet-stream"];
 
 const MAX_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
 
@@ -26,6 +27,16 @@ const inferContentTypeFromPath = (path: string): string | null => {
   if (normalized.endsWith(".png")) return "image/png";
   if (normalized.endsWith(".webp")) return "image/webp";
   return null;
+};
+
+const getMatchedTypeFromHeader = (contentType: string): string | null => {
+  const normalized = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+  return ALLOWED_CONTENT_TYPES.find((t) => normalized === t) ?? null;
+};
+
+const canInferContentTypeFromPath = (contentType: string): boolean => {
+  const normalized = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+  return !normalized || GENERIC_CONTENT_TYPES.includes(normalized);
 };
 
 Deno.serve(async (req: Request) => {
@@ -87,11 +98,12 @@ Deno.serve(async (req: Request) => {
 
     // Validate Content-Type before reading body
     const contentType = res.headers.get("Content-Type") ?? "";
-    const matchedTypeFromHeader = ALLOWED_CONTENT_TYPES.find((t) => contentType.startsWith(t));
+    const matchedTypeFromHeader = getMatchedTypeFromHeader(contentType);
     const matchedType =
       matchedTypeFromHeader ??
-      inferContentTypeFromPath(finalUrl.pathname) ??
-      inferContentTypeFromPath(parsed.pathname);
+      (canInferContentTypeFromPath(contentType)
+        ? inferContentTypeFromPath(finalUrl.pathname) ?? inferContentTypeFromPath(parsed.pathname)
+        : null);
     if (!matchedType) {
       return new Response(JSON.stringify({ error: "Unsupported content type" }), {
         status: 400,


### PR DESCRIPTION
### Motivation
- External product images returned by barcode lookup sometimes fail to save because the image proxy requires a strict `Content-Type` header that some upstream hosts do not provide or set inconsistently.
- Improve robustness of the client-side image save flow so API-sourced images (e.g. from JAN lookup) are accepted when the URL clearly indicates a supported image type.

### Description
- Added `image/jpg` to the allowed content types list in `supabase/functions/image-proxy/index.ts`.
- Implemented `inferContentTypeFromPath(path)` to guess MIME type from URL path extensions (`.jpg/.jpeg/.png/.webp`).
- Use header-based detection first, then fall back to inference from the final redirected URL and the original request URL to determine allowed image MIME.
- Modified the content-type matching logic to accept inferred types so the proxy will return image data when headers are missing/misconfigured.

### Testing
- Ran `bun run format:check` and it passed with no formatting issues.
- Ran `bun run lint` and it passed with zero errors/warnings.
- Ran `bun run typecheck` and it passed with zero type errors.
- Ran `bun run build` and the build succeeded (there were non-failing warnings about a route test export and chunk size, but the build completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099af1605c8330924514587f952bf3)