### PR TITLE
fix: 商品編集時の更新ペイロードを部分更新に修正

### DIFF
--- a/src/hooks/useItems.test.ts
+++ b/src/hooks/useItems.test.ts
@@ -116,4 +116,26 @@ describe("normalizeUpdateValues", () => {
     const result = normalizeUpdateValues({ opened_remaining: null });
     expect(result).toEqual({ opened_remaining: null });
   });
+
+  test("treats present undefined on nullable fields as clear (null)", () => {
+    const result = normalizeUpdateValues({
+      barcode: undefined,
+      category_id: undefined,
+      storage_location_id: undefined,
+      purchase_date: undefined,
+      expiry_date: undefined,
+      notes: undefined,
+      image_path: undefined,
+    });
+
+    expect(result).toEqual({
+      barcode: null,
+      category_id: null,
+      storage_location_id: null,
+      purchase_date: null,
+      expiry_date: null,
+      notes: null,
+      image_path: null,
+    });
+  });
 });

--- a/src/hooks/useItems.test.ts
+++ b/src/hooks/useItems.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { normalizeUpdateValues } from "@/hooks/useItems";
 import { upsertItemInListCache } from "@/lib/itemCache";
 import type { Item } from "@/types/item";
 
@@ -81,5 +82,38 @@ describe("upsertItemInListCache", () => {
     upsertItemInListCache(original, makeItem({ id: "new-item" }));
     expect(original).toBe(originalRef);
     expect(original).toHaveLength(1);
+  });
+});
+
+describe("normalizeUpdateValues", () => {
+  test("omits undefined fields to keep updates partial", () => {
+    const result = normalizeUpdateValues({ name: "Updated name" });
+    expect(result).toEqual({ name: "Updated name" });
+    expect("units" in result).toBe(false);
+    expect("content_amount" in result).toBe(false);
+    expect("barcode" in result).toBe(false);
+  });
+
+  test("converts explicit empty strings to null for nullable text fields", () => {
+    const result = normalizeUpdateValues({
+      barcode: "",
+      purchase_date: "",
+      expiry_date: "",
+      notes: "",
+      image_path: "",
+    });
+
+    expect(result).toEqual({
+      barcode: null,
+      purchase_date: null,
+      expiry_date: null,
+      notes: null,
+      image_path: null,
+    });
+  });
+
+  test("keeps explicit null for opened_remaining", () => {
+    const result = normalizeUpdateValues({ opened_remaining: null });
+    expect(result).toEqual({ opened_remaining: null });
   });
 });

--- a/src/hooks/useItems.ts
+++ b/src/hooks/useItems.ts
@@ -80,7 +80,7 @@ const fetchItem = async (id: string): Promise<Item> => {
   return data as Item;
 };
 
-const normalizeCreateValues = (values: ItemFormValues) => ({
+export const normalizeCreateValues = (values: ItemFormValues) => ({
   name: values.name,
   barcode: values.barcode || null,
   category_id: values.category_id || null,
@@ -98,7 +98,7 @@ const normalizeCreateValues = (values: ItemFormValues) => ({
   image_path: values.image_path || null,
 });
 
-const normalizeUpdateValues = (values: Partial<ItemFormValues>) => ({
+export const normalizeUpdateValues = (values: Partial<ItemFormValues>) => ({
   ...(values.name !== undefined && { name: values.name }),
   ...(values.barcode !== undefined && { barcode: values.barcode || null }),
   ...(values.category_id !== undefined && { category_id: values.category_id || null }),

--- a/src/hooks/useItems.ts
+++ b/src/hooks/useItems.ts
@@ -98,22 +98,38 @@ export const normalizeCreateValues = (values: ItemFormValues) => ({
   image_path: values.image_path || null,
 });
 
-export const normalizeUpdateValues = (values: Partial<ItemFormValues>) => ({
-  ...(values.name !== undefined && { name: values.name }),
-  ...(values.barcode !== undefined && { barcode: values.barcode || null }),
-  ...(values.category_id !== undefined && { category_id: values.category_id || null }),
-  ...(values.storage_location_id !== undefined && {
-    storage_location_id: values.storage_location_id || null,
-  }),
-  ...(values.units !== undefined && { units: values.units }),
-  ...(values.content_amount !== undefined && { content_amount: values.content_amount }),
-  ...(values.content_unit !== undefined && { content_unit: values.content_unit }),
-  ...(values.opened_remaining !== undefined && { opened_remaining: values.opened_remaining }),
-  ...(values.purchase_date !== undefined && { purchase_date: values.purchase_date || null }),
-  ...(values.expiry_date !== undefined && { expiry_date: values.expiry_date || null }),
-  ...(values.notes !== undefined && { notes: values.notes || null }),
-  ...(values.image_path !== undefined && { image_path: values.image_path || null }),
-});
+const hasOwn = <K extends PropertyKey>(obj: object, key: K): obj is Record<K, unknown> =>
+  Object.prototype.hasOwnProperty.call(obj, key);
+
+export const normalizeUpdateValues = (values: Partial<ItemFormValues>) => {
+  const normalized: Record<string, unknown> = {};
+
+  if (hasOwn(values, "name") && values.name !== undefined) normalized.name = values.name;
+
+  if (hasOwn(values, "barcode")) normalized.barcode = values.barcode || null;
+  if (hasOwn(values, "category_id")) normalized.category_id = values.category_id || null;
+  if (hasOwn(values, "storage_location_id")) {
+    normalized.storage_location_id = values.storage_location_id || null;
+  }
+
+  if (hasOwn(values, "units") && values.units !== undefined) normalized.units = values.units;
+  if (hasOwn(values, "content_amount") && values.content_amount !== undefined) {
+    normalized.content_amount = values.content_amount;
+  }
+  if (hasOwn(values, "content_unit") && values.content_unit !== undefined) {
+    normalized.content_unit = values.content_unit;
+  }
+  if (hasOwn(values, "opened_remaining") && values.opened_remaining !== undefined) {
+    normalized.opened_remaining = values.opened_remaining;
+  }
+
+  if (hasOwn(values, "purchase_date")) normalized.purchase_date = values.purchase_date || null;
+  if (hasOwn(values, "expiry_date")) normalized.expiry_date = values.expiry_date || null;
+  if (hasOwn(values, "notes")) normalized.notes = values.notes || null;
+  if (hasOwn(values, "image_path")) normalized.image_path = values.image_path || null;
+
+  return normalized;
+};
 
 /**
  * バーコードが一致するアクティブなアイテムを探す。

--- a/src/hooks/useItems.ts
+++ b/src/hooks/useItems.ts
@@ -80,8 +80,8 @@ const fetchItem = async (id: string): Promise<Item> => {
   return data as Item;
 };
 
-const normalizeFormValues = (values: Partial<ItemFormValues>) => ({
-  ...(values.name !== undefined && { name: values.name }),
+const normalizeCreateValues = (values: ItemFormValues) => ({
+  name: values.name,
   barcode: values.barcode || null,
   category_id: values.category_id || null,
   storage_location_id: values.storage_location_id || null,
@@ -96,6 +96,23 @@ const normalizeFormValues = (values: Partial<ItemFormValues>) => ({
   expiry_date: values.expiry_date || null,
   notes: values.notes || null,
   image_path: values.image_path || null,
+});
+
+const normalizeUpdateValues = (values: Partial<ItemFormValues>) => ({
+  ...(values.name !== undefined && { name: values.name }),
+  ...(values.barcode !== undefined && { barcode: values.barcode || null }),
+  ...(values.category_id !== undefined && { category_id: values.category_id || null }),
+  ...(values.storage_location_id !== undefined && {
+    storage_location_id: values.storage_location_id || null,
+  }),
+  ...(values.units !== undefined && { units: values.units }),
+  ...(values.content_amount !== undefined && { content_amount: values.content_amount }),
+  ...(values.content_unit !== undefined && { content_unit: values.content_unit }),
+  ...(values.opened_remaining !== undefined && { opened_remaining: values.opened_remaining }),
+  ...(values.purchase_date !== undefined && { purchase_date: values.purchase_date || null }),
+  ...(values.expiry_date !== undefined && { expiry_date: values.expiry_date || null }),
+  ...(values.notes !== undefined && { notes: values.notes || null }),
+  ...(values.image_path !== undefined && { image_path: values.image_path || null }),
 });
 
 /**
@@ -187,10 +204,10 @@ const createItem = async (
     if (revived) return { ...revived, _revived: true };
   }
 
-  const normalized = normalizeFormValues(values);
+  const normalized = normalizeCreateValues(values);
   const { data, error } = await supabase
     .from("items")
-    .insert({ ...normalized, name: values.name, user_id: userData.user.id })
+    .insert({ ...normalized, user_id: userData.user.id })
     .select()
     .single();
   if (error) throw error;
@@ -210,7 +227,7 @@ const updateItem = async (id: string, values: Partial<ItemFormValues>): Promise<
   requireOnline();
   const { data, error } = await supabase
     .from("items")
-    .update({ ...normalizeFormValues(values), updated_at: new Date().toISOString() })
+    .update({ ...normalizeUpdateValues(values), updated_at: new Date().toISOString() })
     .eq("id", id)
     .select()
     .single();


### PR DESCRIPTION
### Motivation
- 編集画面で商品名などを変更して「保存」してもページ上に即時反映されない原因は、更新処理が未指定フィールドまでデフォルト値で上書きしていたためです。 
- 更新は部分更新（指定したフィールドのみ送る）にして不意な上書きを防ぐ必要がありました。

### Description
- `src/hooks/useItems.ts` に `normalizeCreateValues(values: ItemFormValues)` を追加し、作成時は従来どおり全フィールドを正規化するようにしました。 
- 同ファイルに `normalizeUpdateValues(values: Partial<ItemFormValues>)` を追加し、更新時は `undefined` のフィールドを送信しない部分更新となるようにしました。 
- `createItem` は `normalizeCreateValues` を使うように、`updateItem` は `normalizeUpdateValues` を使うように切り替えました。

### Testing
- フォーマットと静的解析を含むチェックを実行し、`bun run format`, `bun run format:check`, `bun run lint`, `bun run typecheck` はすべて成功しました。 
- ビルド検証として `bun run build` を実行し、ビルドは成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cfb7af8ec83309ded423bc00313b9)