### PR TITLE
[Alexa] Edge Function基盤 #148

### DIFF
--- a/supabase/functions/alexa-skill/handlers/add-to-shopping-list.ts
+++ b/supabase/functions/alexa-skill/handlers/add-to-shopping-list.ts
@@ -13,5 +13,9 @@ export const handleAddToShoppingList = async (
       {},
     );
   }
-  return buildAskResponse(`${query}の買い物リスト追加は準備中です。`, "他に何かできることはありますか？", {});
+  return buildAskResponse(
+    `${query}の買い物リスト追加は準備中です。`,
+    "他に何かできることはありますか？",
+    {},
+  );
 };

--- a/supabase/functions/alexa-skill/handlers/add-to-shopping-list.ts
+++ b/supabase/functions/alexa-skill/handlers/add-to-shopping-list.ts
@@ -1,11 +1,17 @@
 import type { AlexaResponse, SessionAttributes } from "../types.ts";
-import { buildErrorResponse } from "../response.ts";
+import { buildAskResponse } from "../response.ts";
 
 // TODO: implement in feature/alexa-shopping-list-intent (#151)
 export const handleAddToShoppingList = async (
   query: string,
   _sessionAttributes: SessionAttributes,
 ): Promise<AlexaResponse> => {
-  if (!query) return buildErrorResponse("何を買い物リストに追加しますか？");
-  return buildErrorResponse(`${query}の買い物リスト追加は準備中です。`);
+  if (!query) {
+    return buildAskResponse(
+      "何を買い物リストに追加しますか？商品名を教えてください。",
+      "追加したい商品名を教えてください。",
+      {},
+    );
+  }
+  return buildAskResponse(`${query}の買い物リスト追加は準備中です。`, "他に何かできることはありますか？", {});
 };

--- a/supabase/functions/alexa-skill/handlers/add-to-shopping-list.ts
+++ b/supabase/functions/alexa-skill/handlers/add-to-shopping-list.ts
@@ -1,0 +1,11 @@
+import type { AlexaResponse, SessionAttributes } from "../types.ts";
+import { buildErrorResponse } from "../response.ts";
+
+// TODO: implement in feature/alexa-shopping-list-intent (#151)
+export const handleAddToShoppingList = async (
+  query: string,
+  _sessionAttributes: SessionAttributes,
+): Promise<AlexaResponse> => {
+  if (!query) return buildErrorResponse("何を買い物リストに追加しますか？");
+  return buildErrorResponse(`${query}の買い物リスト追加は準備中です。`);
+};

--- a/supabase/functions/alexa-skill/handlers/check-expiry.ts
+++ b/supabase/functions/alexa-skill/handlers/check-expiry.ts
@@ -1,0 +1,8 @@
+import type { AlexaResponse } from "../types.ts";
+import { buildErrorResponse } from "../response.ts";
+
+// TODO: implement in feature/alexa-inventory-intents (#150)
+export const handleCheckExpiry = async (query: string): Promise<AlexaResponse> => {
+  if (!query) return buildErrorResponse("何の賞味期限を確認しますか？");
+  return buildErrorResponse(`${query}の賞味期限確認は準備中です。`);
+};

--- a/supabase/functions/alexa-skill/handlers/check-expiry.ts
+++ b/supabase/functions/alexa-skill/handlers/check-expiry.ts
@@ -1,8 +1,14 @@
 import type { AlexaResponse } from "../types.ts";
-import { buildErrorResponse } from "../response.ts";
+import { buildAskResponse } from "../response.ts";
 
 // TODO: implement in feature/alexa-inventory-intents (#150)
 export const handleCheckExpiry = async (query: string): Promise<AlexaResponse> => {
-  if (!query) return buildErrorResponse("何の賞味期限を確認しますか？");
-  return buildErrorResponse(`${query}の賞味期限確認は準備中です。`);
+  if (!query) {
+    return buildAskResponse(
+      "何の賞味期限を確認しますか？商品名を教えてください。",
+      "確認したい商品名を教えてください。",
+      {},
+    );
+  }
+  return buildAskResponse(`${query}の賞味期限確認は準備中です。`, "他に確認することはありますか？", {});
 };

--- a/supabase/functions/alexa-skill/handlers/check-expiry.ts
+++ b/supabase/functions/alexa-skill/handlers/check-expiry.ts
@@ -10,5 +10,9 @@ export const handleCheckExpiry = async (query: string): Promise<AlexaResponse> =
       {},
     );
   }
-  return buildAskResponse(`${query}の賞味期限確認は準備中です。`, "他に確認することはありますか？", {});
+  return buildAskResponse(
+    `${query}の賞味期限確認は準備中です。`,
+    "他に確認することはありますか？",
+    {},
+  );
 };

--- a/supabase/functions/alexa-skill/handlers/check-inventory.ts
+++ b/supabase/functions/alexa-skill/handlers/check-inventory.ts
@@ -1,0 +1,9 @@
+import type { AlexaResponse } from "../types.ts";
+import { buildErrorResponse } from "../response.ts";
+
+// TODO: implement in feature/alexa-gemini-integration (#149) and feature/alexa-inventory-intents (#150)
+export const handleCheckInventory = async (query: string): Promise<AlexaResponse> => {
+  if (!query) return buildErrorResponse("何を調べますか？");
+  // placeholder
+  return buildErrorResponse(`${query}の在庫確認は準備中です。`);
+};

--- a/supabase/functions/alexa-skill/handlers/check-inventory.ts
+++ b/supabase/functions/alexa-skill/handlers/check-inventory.ts
@@ -1,9 +1,14 @@
 import type { AlexaResponse } from "../types.ts";
-import { buildErrorResponse } from "../response.ts";
+import { buildAskResponse } from "../response.ts";
 
-// TODO: implement in feature/alexa-gemini-integration (#149) and feature/alexa-inventory-intents (#150)
+// TODO: implement in feature/alexa-inventory-intents (#150)
 export const handleCheckInventory = async (query: string): Promise<AlexaResponse> => {
-  if (!query) return buildErrorResponse("何を調べますか？");
-  // placeholder
-  return buildErrorResponse(`${query}の在庫確認は準備中です。`);
+  if (!query) {
+    return buildAskResponse(
+      "何を調べますか？商品名を教えてください。",
+      "確認したい商品名を教えてください。",
+      {},
+    );
+  }
+  return buildAskResponse(`${query}の在庫確認は準備中です。`, "他に確認することはありますか？", {});
 };

--- a/supabase/functions/alexa-skill/handlers/check-location.ts
+++ b/supabase/functions/alexa-skill/handlers/check-location.ts
@@ -1,8 +1,14 @@
 import type { AlexaResponse } from "../types.ts";
-import { buildErrorResponse } from "../response.ts";
+import { buildAskResponse } from "../response.ts";
 
 // TODO: implement in feature/alexa-inventory-intents (#150)
 export const handleCheckLocation = async (query: string): Promise<AlexaResponse> => {
-  if (!query) return buildErrorResponse("何の保管場所を確認しますか？");
-  return buildErrorResponse(`${query}の保管場所確認は準備中です。`);
+  if (!query) {
+    return buildAskResponse(
+      "何の保管場所を確認しますか？商品名を教えてください。",
+      "確認したい商品名を教えてください。",
+      {},
+    );
+  }
+  return buildAskResponse(`${query}の保管場所確認は準備中です。`, "他に確認することはありますか？", {});
 };

--- a/supabase/functions/alexa-skill/handlers/check-location.ts
+++ b/supabase/functions/alexa-skill/handlers/check-location.ts
@@ -1,0 +1,8 @@
+import type { AlexaResponse } from "../types.ts";
+import { buildErrorResponse } from "../response.ts";
+
+// TODO: implement in feature/alexa-inventory-intents (#150)
+export const handleCheckLocation = async (query: string): Promise<AlexaResponse> => {
+  if (!query) return buildErrorResponse("何の保管場所を確認しますか？");
+  return buildErrorResponse(`${query}の保管場所確認は準備中です。`);
+};

--- a/supabase/functions/alexa-skill/handlers/check-location.ts
+++ b/supabase/functions/alexa-skill/handlers/check-location.ts
@@ -10,5 +10,9 @@ export const handleCheckLocation = async (query: string): Promise<AlexaResponse>
       {},
     );
   }
-  return buildAskResponse(`${query}の保管場所確認は準備中です。`, "他に確認することはありますか？", {});
+  return buildAskResponse(
+    `${query}の保管場所確認は準備中です。`,
+    "他に確認することはありますか？",
+    {},
+  );
 };

--- a/supabase/functions/alexa-skill/handlers/check-remaining.ts
+++ b/supabase/functions/alexa-skill/handlers/check-remaining.ts
@@ -1,8 +1,14 @@
 import type { AlexaResponse } from "../types.ts";
-import { buildErrorResponse } from "../response.ts";
+import { buildAskResponse } from "../response.ts";
 
 // TODO: implement in feature/alexa-inventory-intents (#150)
 export const handleCheckRemaining = async (query: string): Promise<AlexaResponse> => {
-  if (!query) return buildErrorResponse("何の残量を確認しますか？");
-  return buildErrorResponse(`${query}の残量確認は準備中です。`);
+  if (!query) {
+    return buildAskResponse(
+      "何の残量を確認しますか？商品名を教えてください。",
+      "確認したい商品名を教えてください。",
+      {},
+    );
+  }
+  return buildAskResponse(`${query}の残量確認は準備中です。`, "他に確認することはありますか？", {});
 };

--- a/supabase/functions/alexa-skill/handlers/check-remaining.ts
+++ b/supabase/functions/alexa-skill/handlers/check-remaining.ts
@@ -1,0 +1,8 @@
+import type { AlexaResponse } from "../types.ts";
+import { buildErrorResponse } from "../response.ts";
+
+// TODO: implement in feature/alexa-inventory-intents (#150)
+export const handleCheckRemaining = async (query: string): Promise<AlexaResponse> => {
+  if (!query) return buildErrorResponse("何の残量を確認しますか？");
+  return buildErrorResponse(`${query}の残量確認は準備中です。`);
+};

--- a/supabase/functions/alexa-skill/handlers/list-by-location.ts
+++ b/supabase/functions/alexa-skill/handlers/list-by-location.ts
@@ -1,8 +1,14 @@
 import type { AlexaResponse } from "../types.ts";
-import { buildErrorResponse } from "../response.ts";
+import { buildAskResponse } from "../response.ts";
 
 // TODO: implement in feature/alexa-inventory-intents (#150)
 export const handleListByLocation = async (location: string): Promise<AlexaResponse> => {
-  if (!location) return buildErrorResponse("どこの在庫を確認しますか？");
-  return buildErrorResponse(`${location}の在庫一覧は準備中です。`);
+  if (!location) {
+    return buildAskResponse(
+      "どこの在庫を確認しますか？場所を教えてください。",
+      "確認したい場所を教えてください。",
+      {},
+    );
+  }
+  return buildAskResponse(`${location}の在庫一覧は準備中です。`, "他に確認することはありますか？", {});
 };

--- a/supabase/functions/alexa-skill/handlers/list-by-location.ts
+++ b/supabase/functions/alexa-skill/handlers/list-by-location.ts
@@ -10,5 +10,9 @@ export const handleListByLocation = async (location: string): Promise<AlexaRespo
       {},
     );
   }
-  return buildAskResponse(`${location}の在庫一覧は準備中です。`, "他に確認することはありますか？", {});
+  return buildAskResponse(
+    `${location}の在庫一覧は準備中です。`,
+    "他に確認することはありますか？",
+    {},
+  );
 };

--- a/supabase/functions/alexa-skill/handlers/list-by-location.ts
+++ b/supabase/functions/alexa-skill/handlers/list-by-location.ts
@@ -1,0 +1,8 @@
+import type { AlexaResponse } from "../types.ts";
+import { buildErrorResponse } from "../response.ts";
+
+// TODO: implement in feature/alexa-inventory-intents (#150)
+export const handleListByLocation = async (location: string): Promise<AlexaResponse> => {
+  if (!location) return buildErrorResponse("どこの在庫を確認しますか？");
+  return buildErrorResponse(`${location}の在庫一覧は準備中です。`);
+};

--- a/supabase/functions/alexa-skill/handlers/yes-no.ts
+++ b/supabase/functions/alexa-skill/handlers/yes-no.ts
@@ -1,0 +1,16 @@
+import type { AlexaResponse, SessionAttributes } from "../types.ts";
+import { buildTellResponse } from "../response.ts";
+
+// TODO: implement full multi-turn dialog in feature/alexa-shopping-list-intent (#151)
+export const handleYesNo = async (
+  isYes: boolean,
+  sessionAttributes: SessionAttributes,
+): Promise<AlexaResponse> => {
+  if (!sessionAttributes.pendingAction) {
+    return buildTellResponse(
+      isYes ? "はい、わかりました。" : "わかりました。",
+    );
+  }
+  // placeholder until #151
+  return buildTellResponse("この機能は準備中です。");
+};

--- a/supabase/functions/alexa-skill/handlers/yes-no.ts
+++ b/supabase/functions/alexa-skill/handlers/yes-no.ts
@@ -7,9 +7,7 @@ export const handleYesNo = async (
   sessionAttributes: SessionAttributes,
 ): Promise<AlexaResponse> => {
   if (!sessionAttributes.pendingAction) {
-    return buildTellResponse(
-      isYes ? "はい、わかりました。" : "わかりました。",
-    );
+    return buildTellResponse(isYes ? "はい、わかりました。" : "わかりました。");
   }
   // placeholder until #151
   return buildTellResponse("この機能は準備中です。");

--- a/supabase/functions/alexa-skill/index.ts
+++ b/supabase/functions/alexa-skill/index.ts
@@ -1,20 +1,29 @@
-import type { AlexaRequest, AlexaResponse, SessionAttributes } from "./types.ts";
+import type { AlexaRequest, AlexaResponse, AlexaSlot, SessionAttributes } from "./types.ts";
 import { buildAskResponse, buildErrorResponse, buildTellResponse } from "./response.ts";
 
 const ALEXA_SKILL_ID = Deno.env.get("ALEXA_SKILL_ID") ?? "";
 
-const verifyApplicationId = (req: AlexaRequest): boolean => {
+const verifyApplicationId = (req: AlexaRequest): Response | null => {
   if (!ALEXA_SKILL_ID) {
-    console.error("[alexa-skill] ALEXA_SKILL_ID is not configured — rejecting request");
-    return false;
+    console.error("[alexa-skill] ALEXA_SKILL_ID is not configured");
+    return new Response(JSON.stringify({ error: "Server configuration error" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
   }
   const appId =
     req.session?.application?.applicationId ?? req.context?.System?.application?.applicationId;
-  return appId === ALEXA_SKILL_ID;
+  if (appId !== ALEXA_SKILL_ID) {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  return null;
 };
 
 const verifyTimestamp = (req: AlexaRequest): boolean => {
-  const timestamp = req.request.timestamp;
+  const timestamp = req.request?.timestamp;
   if (!timestamp) return false;
   const diffSeconds = Math.abs(Date.now() - new Date(timestamp).getTime()) / 1000;
   return diffSeconds <= 150;
@@ -40,7 +49,7 @@ const handleStop = (): AlexaResponse => buildTellResponse("ハウスキーパー
 
 const routeIntent = async (
   intentName: string,
-  slots: Record<string, { name: string; value?: string }>,
+  slots: Record<string, AlexaSlot>,
   sessionAttributes: SessionAttributes,
 ): Promise<AlexaResponse> => {
   switch (intentName) {
@@ -103,12 +112,8 @@ Deno.serve(async (req: Request): Promise<Response> => {
   try {
     const body = (await req.json()) as AlexaRequest;
 
-    if (!verifyApplicationId(body)) {
-      return new Response(JSON.stringify({ error: "Forbidden" }), {
-        status: 403,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
+    const appIdError = verifyApplicationId(body);
+    if (appIdError) return appIdError;
 
     if (!verifyTimestamp(body)) {
       return new Response(JSON.stringify({ error: "Request timestamp out of range" }), {

--- a/supabase/functions/alexa-skill/index.ts
+++ b/supabase/functions/alexa-skill/index.ts
@@ -1,0 +1,143 @@
+import type { AlexaRequest, AlexaResponse, SessionAttributes } from "./types.ts";
+import {
+  buildAskResponse,
+  buildErrorResponse,
+  buildTellResponse,
+} from "./response.ts";
+
+const ALEXA_SKILL_ID = Deno.env.get("ALEXA_SKILL_ID") ?? "";
+
+const verifyApplicationId = (req: AlexaRequest): boolean => {
+  if (!ALEXA_SKILL_ID) return true; // skip check if not configured
+  const appId =
+    req.session?.application?.applicationId ??
+    req.context?.System?.application?.applicationId;
+  return appId === ALEXA_SKILL_ID;
+};
+
+const handleLaunch = (): AlexaResponse =>
+  buildAskResponse(
+    "ハウスキーパーを開きました。在庫について何でも聞いてください。たとえば「牛乳はある？」や「賞味期限を教えて」などと話しかけてみてください。",
+    "何を確認しますか？",
+    {},
+  );
+
+const handleSessionEnded = (): AlexaResponse =>
+  buildTellResponse("またお気軽にどうぞ。");
+
+const handleHelp = (): AlexaResponse =>
+  buildAskResponse(
+    "在庫の確認ができます。「牛乳はある？」「賞味期限は？」「冷蔵庫に何がある？」「どこにある？」「あとどれくらい残ってる？」「買い物リストに追加して」などと話しかけてください。",
+    "何を確認しますか？",
+    {},
+  );
+
+const handleStop = (): AlexaResponse =>
+  buildTellResponse("ハウスキーパーを終了します。");
+
+const routeIntent = async (
+  intentName: string,
+  slots: Record<string, { name: string; value?: string }>,
+  sessionAttributes: SessionAttributes,
+): Promise<AlexaResponse> => {
+  switch (intentName) {
+    case "AMAZON.HelpIntent":
+      return handleHelp();
+
+    case "AMAZON.StopIntent":
+    case "AMAZON.CancelIntent":
+      return handleStop();
+
+    case "AMAZON.YesIntent":
+    case "AMAZON.NoIntent": {
+      const { handleYesNo } = await import("./handlers/yes-no.ts");
+      return handleYesNo(intentName === "AMAZON.YesIntent", sessionAttributes);
+    }
+
+    case "CheckInventoryIntent": {
+      const { handleCheckInventory } = await import("./handlers/check-inventory.ts");
+      return handleCheckInventory(slots["ItemQuery"]?.value ?? "");
+    }
+
+    case "CheckExpiryIntent": {
+      const { handleCheckExpiry } = await import("./handlers/check-expiry.ts");
+      return handleCheckExpiry(slots["ItemQuery"]?.value ?? "");
+    }
+
+    case "ListByLocationIntent": {
+      const { handleListByLocation } = await import("./handlers/list-by-location.ts");
+      return handleListByLocation(slots["LocationQuery"]?.value ?? "");
+    }
+
+    case "CheckLocationIntent": {
+      const { handleCheckLocation } = await import("./handlers/check-location.ts");
+      return handleCheckLocation(slots["ItemQuery"]?.value ?? "");
+    }
+
+    case "CheckRemainingIntent": {
+      const { handleCheckRemaining } = await import("./handlers/check-remaining.ts");
+      return handleCheckRemaining(slots["ItemQuery"]?.value ?? "");
+    }
+
+    case "AddToShoppingListIntent": {
+      const { handleAddToShoppingList } = await import("./handlers/add-to-shopping-list.ts");
+      return handleAddToShoppingList(
+        slots["ItemQuery"]?.value ?? "",
+        sessionAttributes,
+      );
+    }
+
+    default:
+      return buildErrorResponse("そのリクエストには対応していません。");
+  }
+};
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const body = (await req.json()) as AlexaRequest;
+
+    if (!verifyApplicationId(body)) {
+      return new Response(JSON.stringify({ error: "Invalid application ID" }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const sessionAttributes = (body.session?.attributes ?? {}) as SessionAttributes;
+    let alexaResponse: AlexaResponse;
+
+    const requestType = body.request.type;
+
+    if (requestType === "LaunchRequest") {
+      alexaResponse = handleLaunch();
+    } else if (requestType === "SessionEndedRequest") {
+      alexaResponse = handleSessionEnded();
+    } else if (requestType === "IntentRequest") {
+      const intent = (body.request as { type: "IntentRequest"; intent: { name: string; slots?: Record<string, { name: string; value?: string }> } }).intent;
+      alexaResponse = await routeIntent(
+        intent.name,
+        intent.slots ?? {},
+        sessionAttributes,
+      );
+    } else {
+      alexaResponse = buildErrorResponse();
+    }
+
+    return new Response(JSON.stringify(alexaResponse), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    console.error("[alexa-skill] Error:", err);
+    const errResponse = buildErrorResponse();
+    return new Response(JSON.stringify(errResponse), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+});

--- a/supabase/functions/alexa-skill/index.ts
+++ b/supabase/functions/alexa-skill/index.ts
@@ -8,16 +8,26 @@ import {
 const ALEXA_SKILL_ID = Deno.env.get("ALEXA_SKILL_ID") ?? "";
 
 const verifyApplicationId = (req: AlexaRequest): boolean => {
-  if (!ALEXA_SKILL_ID) return true; // skip check if not configured
+  if (!ALEXA_SKILL_ID) {
+    console.error("[alexa-skill] ALEXA_SKILL_ID is not configured — rejecting request");
+    return false;
+  }
   const appId =
     req.session?.application?.applicationId ??
     req.context?.System?.application?.applicationId;
   return appId === ALEXA_SKILL_ID;
 };
 
+const verifyTimestamp = (req: AlexaRequest): boolean => {
+  const timestamp = req.request.timestamp;
+  if (!timestamp) return false;
+  const diffSeconds = Math.abs(Date.now() - new Date(timestamp).getTime()) / 1000;
+  return diffSeconds <= 150;
+};
+
 const handleLaunch = (): AlexaResponse =>
   buildAskResponse(
-    "ハウスキーパーを開きました。在庫について何でも聞いてください。たとえば「牛乳はある？」や「賞味期限を教えて」などと話しかけてみてください。",
+    "ハウスキーパーを開きました。在庫について何でも聞いてください。たとえば「牛乳はある？」などと話しかけてみてください。",
     "何を確認しますか？",
     {},
   );
@@ -27,7 +37,7 @@ const handleSessionEnded = (): AlexaResponse =>
 
 const handleHelp = (): AlexaResponse =>
   buildAskResponse(
-    "在庫の確認ができます。「牛乳はある？」「賞味期限は？」「冷蔵庫に何がある？」「どこにある？」「あとどれくらい残ってる？」「買い物リストに追加して」などと話しかけてください。",
+    "在庫の確認ができます。「牛乳はある？」「賞味期限は？」「冷蔵庫に何がある？」「どこにある？」「あとどれくらい残ってる？」などと話しかけてください。",
     "何を確認しますか？",
     {},
   );
@@ -104,8 +114,15 @@ Deno.serve(async (req: Request): Promise<Response> => {
     const body = (await req.json()) as AlexaRequest;
 
     if (!verifyApplicationId(body)) {
-      return new Response(JSON.stringify({ error: "Invalid application ID" }), {
+      return new Response(JSON.stringify({ error: "Forbidden" }), {
         status: 403,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (!verifyTimestamp(body)) {
+      return new Response(JSON.stringify({ error: "Request timestamp out of range" }), {
+        status: 400,
         headers: { "Content-Type": "application/json" },
       });
     }
@@ -113,14 +130,12 @@ Deno.serve(async (req: Request): Promise<Response> => {
     const sessionAttributes = (body.session?.attributes ?? {}) as SessionAttributes;
     let alexaResponse: AlexaResponse;
 
-    const requestType = body.request.type;
-
-    if (requestType === "LaunchRequest") {
+    if (body.request.type === "LaunchRequest") {
       alexaResponse = handleLaunch();
-    } else if (requestType === "SessionEndedRequest") {
+    } else if (body.request.type === "SessionEndedRequest") {
       alexaResponse = handleSessionEnded();
-    } else if (requestType === "IntentRequest") {
-      const intent = (body.request as { type: "IntentRequest"; intent: { name: string; slots?: Record<string, { name: string; value?: string }> } }).intent;
+    } else if (body.request.type === "IntentRequest") {
+      const { intent } = body.request;
       alexaResponse = await routeIntent(
         intent.name,
         intent.slots ?? {},
@@ -135,8 +150,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
     });
   } catch (err) {
     console.error("[alexa-skill] Error:", err);
-    const errResponse = buildErrorResponse();
-    return new Response(JSON.stringify(errResponse), {
+    return new Response(JSON.stringify(buildErrorResponse()), {
       headers: { "Content-Type": "application/json" },
     });
   }

--- a/supabase/functions/alexa-skill/index.ts
+++ b/supabase/functions/alexa-skill/index.ts
@@ -1,9 +1,5 @@
 import type { AlexaRequest, AlexaResponse, SessionAttributes } from "./types.ts";
-import {
-  buildAskResponse,
-  buildErrorResponse,
-  buildTellResponse,
-} from "./response.ts";
+import { buildAskResponse, buildErrorResponse, buildTellResponse } from "./response.ts";
 
 const ALEXA_SKILL_ID = Deno.env.get("ALEXA_SKILL_ID") ?? "";
 
@@ -13,8 +9,7 @@ const verifyApplicationId = (req: AlexaRequest): boolean => {
     return false;
   }
   const appId =
-    req.session?.application?.applicationId ??
-    req.context?.System?.application?.applicationId;
+    req.session?.application?.applicationId ?? req.context?.System?.application?.applicationId;
   return appId === ALEXA_SKILL_ID;
 };
 
@@ -32,8 +27,7 @@ const handleLaunch = (): AlexaResponse =>
     {},
   );
 
-const handleSessionEnded = (): AlexaResponse =>
-  buildTellResponse("またお気軽にどうぞ。");
+const handleSessionEnded = (): AlexaResponse => buildTellResponse("またお気軽にどうぞ。");
 
 const handleHelp = (): AlexaResponse =>
   buildAskResponse(
@@ -42,8 +36,7 @@ const handleHelp = (): AlexaResponse =>
     {},
   );
 
-const handleStop = (): AlexaResponse =>
-  buildTellResponse("ハウスキーパーを終了します。");
+const handleStop = (): AlexaResponse => buildTellResponse("ハウスキーパーを終了します。");
 
 const routeIntent = async (
   intentName: string,
@@ -91,10 +84,7 @@ const routeIntent = async (
 
     case "AddToShoppingListIntent": {
       const { handleAddToShoppingList } = await import("./handlers/add-to-shopping-list.ts");
-      return handleAddToShoppingList(
-        slots["ItemQuery"]?.value ?? "",
-        sessionAttributes,
-      );
+      return handleAddToShoppingList(slots["ItemQuery"]?.value ?? "", sessionAttributes);
     }
 
     default:
@@ -136,11 +126,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
       alexaResponse = handleSessionEnded();
     } else if (body.request.type === "IntentRequest") {
       const { intent } = body.request;
-      alexaResponse = await routeIntent(
-        intent.name,
-        intent.slots ?? {},
-        sessionAttributes,
-      );
+      alexaResponse = await routeIntent(intent.name, intent.slots ?? {}, sessionAttributes);
     } else {
       alexaResponse = buildErrorResponse();
     }

--- a/supabase/functions/alexa-skill/response.ts
+++ b/supabase/functions/alexa-skill/response.ts
@@ -1,0 +1,37 @@
+import type { AlexaResponse, SessionAttributes } from "./types.ts";
+
+export const buildTellResponse = (
+  speech: string,
+  sessionAttributes?: SessionAttributes,
+): AlexaResponse => ({
+  version: "1.0",
+  sessionAttributes,
+  response: {
+    outputSpeech: { type: "PlainText", text: speech },
+    shouldEndSession: true,
+  },
+});
+
+export const buildAskResponse = (
+  speech: string,
+  reprompt: string,
+  sessionAttributes: SessionAttributes,
+): AlexaResponse => ({
+  version: "1.0",
+  sessionAttributes,
+  response: {
+    outputSpeech: { type: "PlainText", text: speech },
+    reprompt: { outputSpeech: { type: "PlainText", text: reprompt } },
+    shouldEndSession: false,
+  },
+});
+
+export const buildErrorResponse = (message?: string): AlexaResponse =>
+  buildTellResponse(
+    message ?? "申し訳ありません。エラーが発生しました。もう一度お試しください。",
+  );
+
+export const buildTimeoutResponse = (): AlexaResponse =>
+  buildTellResponse(
+    "ただいま応答に時間がかかっています。もう一度お試しください。",
+  );

--- a/supabase/functions/alexa-skill/response.ts
+++ b/supabase/functions/alexa-skill/response.ts
@@ -27,11 +27,7 @@ export const buildAskResponse = (
 });
 
 export const buildErrorResponse = (message?: string): AlexaResponse =>
-  buildTellResponse(
-    message ?? "申し訳ありません。エラーが発生しました。もう一度お試しください。",
-  );
+  buildTellResponse(message ?? "申し訳ありません。エラーが発生しました。もう一度お試しください。");
 
 export const buildTimeoutResponse = (): AlexaResponse =>
-  buildTellResponse(
-    "ただいま応答に時間がかかっています。もう一度お試しください。",
-  );
+  buildTellResponse("ただいま応答に時間がかかっています。もう一度お試しください。");

--- a/supabase/functions/alexa-skill/types.ts
+++ b/supabase/functions/alexa-skill/types.ts
@@ -141,3 +141,9 @@ export interface SessionAttributes extends Record<string, unknown> {
   pendingItem?: PendingShoppingItem;
   pendingQuery?: string;
 }
+
+// Discriminated union for Gemini query results
+export type GeminiResult =
+  | { kind: "ok"; data: GeminiMatchResult }
+  | { kind: "timeout" }
+  | { kind: "error" };

--- a/supabase/functions/alexa-skill/types.ts
+++ b/supabase/functions/alexa-skill/types.ts
@@ -12,11 +12,11 @@ export interface AlexaIntent {
 
 export interface AlexaRequest {
   version: string;
-  session: {
+  session?: {
     new: boolean;
     sessionId: string;
     application: { applicationId: string };
-    attributes: Record<string, unknown>;
+    attributes?: Record<string, unknown>;
     user: { userId: string };
   };
   context: {
@@ -116,10 +116,10 @@ export interface GeminiMatchResult {
     units: number;
     content_amount: number;
     content_unit: string;
-    opened_remaining: number | null;
-    expiry_date: string | null;
-    category: string | null;
-    storage_location: string | null;
+    opened_remaining?: number | null;
+    expiry_date?: string | null;
+    category?: string | null;
+    storage_location?: string | null;
   }>;
   speech: string;
   confidence: "exact" | "fuzzy" | "none";

--- a/supabase/functions/alexa-skill/types.ts
+++ b/supabase/functions/alexa-skill/types.ts
@@ -1,0 +1,143 @@
+export interface AlexaSlot {
+  name: string;
+  value?: string;
+  confirmationStatus?: "NONE" | "CONFIRMED" | "DENIED";
+}
+
+export interface AlexaIntent {
+  name: string;
+  confirmationStatus?: "NONE" | "CONFIRMED" | "DENIED";
+  slots?: Record<string, AlexaSlot>;
+}
+
+export interface AlexaRequest {
+  version: string;
+  session: {
+    new: boolean;
+    sessionId: string;
+    application: { applicationId: string };
+    attributes: Record<string, unknown>;
+    user: { userId: string };
+  };
+  context: {
+    System: {
+      application: { applicationId: string };
+      user: { userId: string };
+    };
+  };
+  request:
+    | {
+        type: "LaunchRequest";
+        requestId: string;
+        timestamp: string;
+      }
+    | {
+        type: "IntentRequest";
+        requestId: string;
+        timestamp: string;
+        intent: AlexaIntent;
+      }
+    | {
+        type: "SessionEndedRequest";
+        requestId: string;
+        timestamp: string;
+        reason: string;
+      };
+}
+
+export interface AlexaOutputSpeech {
+  type: "PlainText" | "SSML";
+  text?: string;
+  ssml?: string;
+}
+
+export interface AlexaResponse {
+  version: string;
+  sessionAttributes?: Record<string, unknown>;
+  response: {
+    outputSpeech: AlexaOutputSpeech;
+    reprompt?: {
+      outputSpeech: AlexaOutputSpeech;
+    };
+    shouldEndSession: boolean;
+    card?: {
+      type: string;
+      title?: string;
+      content?: string;
+    };
+  };
+}
+
+// Supabase item type for Edge Function (subset of full DB type)
+export interface InventoryItem {
+  id: string;
+  name: string;
+  category_id: string | null;
+  storage_location_id: string | null;
+  units: number;
+  content_amount: number;
+  content_unit: string;
+  opened_remaining: number | null;
+  expiry_date: string | null;
+  deleted_at: string | null;
+  categories: { name: string } | null;
+  storage_locations: { name: string } | null;
+}
+
+// Gemini API types
+export interface GeminiContent {
+  parts: Array<{ text: string }>;
+  role: "user" | "model";
+}
+
+export interface GeminiRequest {
+  contents: GeminiContent[];
+  systemInstruction?: { parts: Array<{ text: string }> };
+  generationConfig?: {
+    responseMimeType?: string;
+    responseSchema?: unknown;
+    temperature?: number;
+  };
+}
+
+export interface GeminiResponse {
+  candidates: Array<{
+    content: {
+      parts: Array<{ text: string }>;
+    };
+  }>;
+}
+
+// Gemini structured output schema
+export interface GeminiMatchResult {
+  matchedItems: Array<{
+    id: string;
+    name: string;
+    units: number;
+    content_amount: number;
+    content_unit: string;
+    opened_remaining: number | null;
+    expiry_date: string | null;
+    category: string | null;
+    storage_location: string | null;
+  }>;
+  speech: string;
+  confidence: "exact" | "fuzzy" | "none";
+  stockStatus: "in_stock" | "out_of_stock" | "not_found";
+}
+
+// Session attributes for multi-turn dialog
+export interface PendingShoppingItem {
+  id: string | null;
+  name: string;
+  units: number;
+  content_amount: number;
+  content_unit: string;
+  opened_remaining: number | null;
+}
+
+export interface SessionAttributes extends Record<string, unknown> {
+  pendingAction?: "add_to_shopping_list" | "choose_alternate";
+  pendingItem?: PendingShoppingItem;
+  pendingQuery?: string;
+}


### PR DESCRIPTION
Closes #148

## 変更内容

- `supabase/functions/alexa-skill/types.ts`: 型定義
  - AlexaRequest / AlexaResponse / AlexaIntent / AlexaSlot
  - InventoryItem（Supabase用）
  - GeminiRequest / GeminiResponse / GeminiMatchResult
  - SessionAttributes（マルチターンダイアログ用）
- `supabase/functions/alexa-skill/response.ts`: レスポンスビルダー
  - buildTellResponse / buildAskResponse / buildErrorResponse / buildTimeoutResponse
- `supabase/functions/alexa-skill/index.ts`: エントリポイント・ルーティング
  - LaunchRequest / IntentRequest / SessionEndedRequest ハンドラ
  - ALEXA_SKILL_ID による Application ID 検証
  - 6インテント + Help / Stop / Cancel / YesNo のルーティング
- 各インテントハンドラのプレースホルダー（handlers/）

---
_Generated by [Claude Code](https://claude.ai/code/session_013q6HU7MtowoYX33maRgNGS)_