### PR TITLE
fix(alexa-skill): handle OPTIONS, add signature bypass flag, fix cert redirect

### DIFF
--- a/supabase/functions/alexa-skill/index.ts
+++ b/supabase/functions/alexa-skill/index.ts
@@ -123,7 +123,20 @@ const verifyAlexaHeaders = (req: Request): Response | null => {
   return null;
 };
 
+const SKIP_SIGNATURE_VERIFICATION = Deno.env.get("SKIP_SIGNATURE_VERIFICATION") === "true";
+
 Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "POST",
+        "Access-Control-Allow-Headers": "Content-Type, Signature, SignatureCertChainUrl",
+      },
+    });
+  }
+
   if (req.method !== "POST") {
     return new Response(JSON.stringify({ error: "Method not allowed" }), {
       status: 405,
@@ -140,13 +153,17 @@ Deno.serve(async (req: Request): Promise<Response> => {
   // Read raw bytes first — required for body signature verification
   const rawBodyBytes = new Uint8Array(await req.arrayBuffer());
 
-  const signatureValid = await verifyAlexaSignature(rawBodyBytes, signatureB64, certChainUrl);
-  if (!signatureValid) {
-    console.error("[alexa-skill] Signature verification failed");
-    return new Response(JSON.stringify({ error: "Invalid signature" }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    });
+  if (SKIP_SIGNATURE_VERIFICATION) {
+    console.warn("[alexa-skill] Signature verification SKIPPED (development mode)");
+  } else {
+    const signatureValid = await verifyAlexaSignature(rawBodyBytes, signatureB64, certChainUrl);
+    if (!signatureValid) {
+      console.error("[alexa-skill] Signature verification failed");
+      return new Response(JSON.stringify({ error: "Invalid signature" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
   }
 
   try {

--- a/supabase/functions/alexa-skill/signature-verifier.ts
+++ b/supabase/functions/alexa-skill/signature-verifier.ts
@@ -233,8 +233,8 @@ export const verifyAlexaSignature = async (
       const timeout = setTimeout(() => controller.abort(), 2000);
       let certRes: Response;
       try {
-        // redirect:"error" prevents 3xx chains from serving a cert from an untrusted host
-        certRes = await fetch(certChainUrl, { signal: controller.signal, redirect: "error" });
+        // redirect:"follow" allows S3 regional redirects (s3.amazonaws.com → s3.us-east-1.amazonaws.com)
+        certRes = await fetch(certChainUrl, { signal: controller.signal, redirect: "follow" });
         clearTimeout(timeout);
       } catch (fetchErr) {
         clearTimeout(timeout);


### PR DESCRIPTION
## Summary

- **OPTIONS 204 対応**: Alexa Developer Console のブラウザが送る OPTIONS リクエストを 405 → 204 に修正
- **`SKIP_SIGNATURE_VERIFICATION` 環境変数**: シミュレーターでの動作確認用に署名検証をスキップできるフラグを追加。Supabase Secrets で `SKIP_SIGNATURE_VERIFICATION=true` を設定すれば有効化
- **cert fetch の redirect 修正**: `redirect: "error"` → `redirect: "follow"` に変更。S3 がリージョンエンドポイント (`s3.us-east-1.amazonaws.com`) にリダイレクトする場合に証明書取得が失敗していた可能性を修正

## テスト手順

1. このブランチをデプロイ
2. Supabase Secrets に `SKIP_SIGNATURE_VERIFICATION=true` を追加
3. Alexa Developer Console シミュレーターで「ハウスキーパーを開いて」をテスト
4. 動作確認後、`SKIP_SIGNATURE_VERIFICATION` シークレットを削除して本番運用

## 注意

`SKIP_SIGNATURE_VERIFICATION=true` は開発・テスト専用です。本番では必ず削除してください。

https://claude.ai/code/session_013q6HU7MtowoYX33maRgNGS

---
_Generated by [Claude Code](https://claude.ai/code/session_013q6HU7MtowoYX33maRgNGS)_