### PR TITLE
Add recently consumed items tracking to Alexa inventory queries

### DIFF
--- a/supabase/functions/alexa-skill/gemini.ts
+++ b/supabase/functions/alexa-skill/gemini.ts
@@ -14,15 +14,19 @@ const STOCK_STATUS_VALUES = new Set(["in_stock", "out_of_stock", "not_found", "r
 const isValidMatchedItem = (item: unknown): boolean => {
   if (!item || typeof item !== "object") return false;
   const it = item as Record<string, unknown>;
-  return (
-    typeof it.id === "string" &&
-    typeof it.name === "string" &&
-    typeof it.units === "number" &&
-    isFinite(it.units) &&
-    typeof it.content_amount === "number" &&
-    isFinite(it.content_amount) &&
-    typeof it.content_unit === "string"
-  );
+  if (typeof it.id !== "string" || typeof it.name !== "string") return false;
+  // units/content_amount/content_unit are only present for in_stock/out_of_stock items;
+  // recently_consumed items may omit them, so allow null/undefined.
+  const hasUnits = it.units === null || it.units === undefined || typeof it.units === "number";
+  const hasAmount =
+    it.content_amount === null ||
+    it.content_amount === undefined ||
+    typeof it.content_amount === "number";
+  const hasUnit =
+    it.content_unit === null ||
+    it.content_unit === undefined ||
+    typeof it.content_unit === "string";
+  return hasUnits && hasAmount && hasUnit;
 };
 
 const isValidGeminiResult = (data: unknown): data is GeminiMatchResult => {
@@ -98,7 +102,7 @@ const RESPONSE_SCHEMA = {
           category: { type: "string", nullable: true },
           storage_location: { type: "string", nullable: true },
         },
-        required: ["id", "name", "units", "content_amount", "content_unit"],
+        required: ["id", "name"],
       },
     },
     speech: { type: "string" },

--- a/supabase/functions/alexa-skill/gemini.ts
+++ b/supabase/functions/alexa-skill/gemini.ts
@@ -4,11 +4,12 @@ import type {
   GeminiResponse,
   GeminiResult,
   InventoryItem,
+  RecentlyConsumedItem,
 } from "./types.ts";
 import { formatTotalRemaining } from "./inventory.ts";
 
 const CONFIDENCE_VALUES = new Set(["exact", "fuzzy", "none"]);
-const STOCK_STATUS_VALUES = new Set(["in_stock", "out_of_stock", "not_found"]);
+const STOCK_STATUS_VALUES = new Set(["in_stock", "out_of_stock", "not_found", "recently_consumed"]);
 
 const isValidMatchedItem = (item: unknown): boolean => {
   if (!item || typeof item !== "object") return false;
@@ -41,20 +42,25 @@ const GEMINI_MODEL = "gemini-2.5-flash";
 const GEMINI_TIMEOUT_MS = 7000;
 
 const SYSTEM_PROMPT = `あなたは家庭の在庫管理アシスタントです。
-ユーザーの問いかけに対して、以下の在庫リストから最適なアイテムを見つけ、
+ユーザーの問いかけに対して、以下の在庫リストおよび最近使い切りリストから最適なアイテムを見つけ、
 簡潔な日本語で回答を生成してください。
 
 ルール:
-- アイテムが見つかり total_remaining が「0{単位}」でない場合: stockStatus = "in_stock"
-- アイテムが見つかったが total_remaining が「0{単位}」の場合: stockStatus = "out_of_stock", speech に「〇〇は在庫切れです」
-- アイテムが在庫リストに一切見つからない場合: stockStatus = "not_found", speech に「今までの購入記録から〇〇は見つかりませんでした」
+- アイテムが在庫リストに見つかり total_remaining が「0{単位}」でない場合: stockStatus = "in_stock"
+- アイテムが在庫リストに見つかったが total_remaining が「0{単位}」の場合: stockStatus = "out_of_stock", speech に「〇〇は在庫切れです」
+- アイテムが在庫リストにないが「最近使い切りリスト」に見つかった場合: stockStatus = "recently_consumed", speech に「過去に〇〇がありましたが、{last_consumed_at を「M月D日」形式}にすべて使い切りました」
+- アイテムが在庫リストにも最近使い切りリストにも見つからない場合: stockStatus = "not_found", speech に「現在、〇〇は自宅にありません」
+- 商品名の一致は部分一致・類似語も許容すること（例:「牛乳」は「低脂肪牛乳」「雪印牛乳」にもマッチする）
 - 複数ヒット(3件以下): すべて列挙して読み上げる
 - 複数ヒット(4件以上): 「〇〇など△件あります」と要約する
 - 類似品がある場合(confidence="fuzzy"): そのまま回答する
 - 必ず指定のJSONスキーマで返すこと。それ以外のテキストは含めないこと。`;
 
-const buildInventoryContext = (items: InventoryItem[]): string => {
-  const list = items.map((item) => ({
+const buildInventoryContext = (
+  items: InventoryItem[],
+  recentlyConsumed: RecentlyConsumedItem[],
+): string => {
+  const inventoryList = items.map((item) => ({
     id: item.id,
     name: item.name,
     category: item.categories?.name ?? null,
@@ -66,7 +72,12 @@ const buildInventoryContext = (items: InventoryItem[]): string => {
     expiry_date: item.expiry_date,
     total_remaining: formatTotalRemaining(item),
   }));
-  return JSON.stringify(list);
+  const consumedList = recentlyConsumed.map((c) => ({
+    item_id: c.item_id,
+    item_name: c.item_name,
+    last_consumed_at: c.last_consumed_at,
+  }));
+  return JSON.stringify({ inventory: inventoryList, recently_consumed: consumedList });
 };
 
 const RESPONSE_SCHEMA = {
@@ -94,7 +105,7 @@ const RESPONSE_SCHEMA = {
     confidence: { type: "string", enum: ["exact", "fuzzy", "none"] },
     stockStatus: {
       type: "string",
-      enum: ["in_stock", "out_of_stock", "not_found"],
+      enum: ["in_stock", "out_of_stock", "not_found", "recently_consumed"],
     },
   },
   required: ["matchedItems", "speech", "confidence", "stockStatus"],
@@ -103,6 +114,7 @@ const RESPONSE_SCHEMA = {
 export const queryGemini = async (
   userMessage: string,
   items: InventoryItem[],
+  recentlyConsumed: RecentlyConsumedItem[] = [],
 ): Promise<GeminiResult> => {
   const apiKey = Deno.env.get("GEMINI_API_KEY");
   if (!apiKey) {
@@ -111,13 +123,13 @@ export const queryGemini = async (
   }
 
   const geminiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`;
-  const inventoryContext = buildInventoryContext(items);
+  const inventoryContext = buildInventoryContext(items, recentlyConsumed);
 
   const body: GeminiRequest = {
     systemInstruction: {
       parts: [
         {
-          text: `${SYSTEM_PROMPT}\n\n在庫リスト:\n${inventoryContext}`,
+          text: `${SYSTEM_PROMPT}\n\n在庫データ(inventory=現在の在庫, recently_consumed=過去2か月以内に使い切ったアイテム):\n${inventoryContext}`,
         },
       ],
     },

--- a/supabase/functions/alexa-skill/handlers/check-expiry.ts
+++ b/supabase/functions/alexa-skill/handlers/check-expiry.ts
@@ -5,7 +5,7 @@ import {
   buildTellResponse,
   buildTimeoutResponse,
 } from "../response.ts";
-import { fetchAllItems, formatExpiryDate } from "../inventory.ts";
+import { fetchAllItems, fetchRecentlyConsumedItems, formatExpiryDate } from "../inventory.ts";
 import { buildCheckExpiryPrompt, queryGemini } from "../gemini.ts";
 
 export const handleCheckExpiry = async (query: string): Promise<AlexaResponse> => {
@@ -17,10 +17,17 @@ export const handleCheckExpiry = async (query: string): Promise<AlexaResponse> =
     );
   }
 
-  const items = await fetchAllItems();
+  const [items, recentlyConsumed] = await Promise.all([
+    fetchAllItems(),
+    fetchRecentlyConsumedItems(),
+  ]);
   if (!items) return buildErrorResponse("在庫情報の取得に失敗しました。");
 
-  const geminiResult = await queryGemini(buildCheckExpiryPrompt(query), items);
+  const geminiResult = await queryGemini(
+    buildCheckExpiryPrompt(query),
+    items,
+    recentlyConsumed ?? [],
+  );
   if (geminiResult.kind === "timeout") return buildTimeoutResponse();
   if (geminiResult.kind === "error") return buildErrorResponse();
 

--- a/supabase/functions/alexa-skill/handlers/check-inventory.ts
+++ b/supabase/functions/alexa-skill/handlers/check-inventory.ts
@@ -5,7 +5,7 @@ import {
   buildTellResponse,
   buildTimeoutResponse,
 } from "../response.ts";
-import { fetchAllItems } from "../inventory.ts";
+import { fetchAllItems, fetchRecentlyConsumedItems } from "../inventory.ts";
 import { buildCheckInventoryPrompt, queryGemini } from "../gemini.ts";
 
 export const handleCheckInventory = async (query: string): Promise<AlexaResponse> => {
@@ -17,10 +17,17 @@ export const handleCheckInventory = async (query: string): Promise<AlexaResponse
     );
   }
 
-  const items = await fetchAllItems();
+  const [items, recentlyConsumed] = await Promise.all([
+    fetchAllItems(),
+    fetchRecentlyConsumedItems(),
+  ]);
   if (!items) return buildErrorResponse("在庫情報の取得に失敗しました。");
 
-  const geminiResult = await queryGemini(buildCheckInventoryPrompt(query), items);
+  const geminiResult = await queryGemini(
+    buildCheckInventoryPrompt(query),
+    items,
+    recentlyConsumed ?? [],
+  );
   if (geminiResult.kind === "timeout") return buildTimeoutResponse();
   if (geminiResult.kind === "error") return buildErrorResponse();
 

--- a/supabase/functions/alexa-skill/handlers/check-location.ts
+++ b/supabase/functions/alexa-skill/handlers/check-location.ts
@@ -5,7 +5,7 @@ import {
   buildTellResponse,
   buildTimeoutResponse,
 } from "../response.ts";
-import { fetchAllItems } from "../inventory.ts";
+import { fetchAllItems, fetchRecentlyConsumedItems } from "../inventory.ts";
 import { buildCheckLocationPrompt, queryGemini } from "../gemini.ts";
 
 export const handleCheckLocation = async (query: string): Promise<AlexaResponse> => {
@@ -17,10 +17,17 @@ export const handleCheckLocation = async (query: string): Promise<AlexaResponse>
     );
   }
 
-  const items = await fetchAllItems();
+  const [items, recentlyConsumed] = await Promise.all([
+    fetchAllItems(),
+    fetchRecentlyConsumedItems(),
+  ]);
   if (!items) return buildErrorResponse("在庫情報の取得に失敗しました。");
 
-  const geminiResult = await queryGemini(buildCheckLocationPrompt(query), items);
+  const geminiResult = await queryGemini(
+    buildCheckLocationPrompt(query),
+    items,
+    recentlyConsumed ?? [],
+  );
   if (geminiResult.kind === "timeout") return buildTimeoutResponse();
   if (geminiResult.kind === "error") return buildErrorResponse();
 

--- a/supabase/functions/alexa-skill/handlers/check-remaining.ts
+++ b/supabase/functions/alexa-skill/handlers/check-remaining.ts
@@ -5,7 +5,7 @@ import {
   buildTellResponse,
   buildTimeoutResponse,
 } from "../response.ts";
-import { fetchAllItems } from "../inventory.ts";
+import { fetchAllItems, fetchRecentlyConsumedItems } from "../inventory.ts";
 import { buildCheckRemainingPrompt, queryGemini } from "../gemini.ts";
 
 export const handleCheckRemaining = async (query: string): Promise<AlexaResponse> => {
@@ -17,10 +17,17 @@ export const handleCheckRemaining = async (query: string): Promise<AlexaResponse
     );
   }
 
-  const items = await fetchAllItems();
+  const [items, recentlyConsumed] = await Promise.all([
+    fetchAllItems(),
+    fetchRecentlyConsumedItems(),
+  ]);
   if (!items) return buildErrorResponse("在庫情報の取得に失敗しました。");
 
-  const geminiResult = await queryGemini(buildCheckRemainingPrompt(query), items);
+  const geminiResult = await queryGemini(
+    buildCheckRemainingPrompt(query),
+    items,
+    recentlyConsumed ?? [],
+  );
   if (geminiResult.kind === "timeout") return buildTimeoutResponse();
   if (geminiResult.kind === "error") return buildErrorResponse();
 

--- a/supabase/functions/alexa-skill/inventory.ts
+++ b/supabase/functions/alexa-skill/inventory.ts
@@ -1,4 +1,4 @@
-import type { InventoryItem } from "./types.ts";
+import type { InventoryItem, RecentlyConsumedItem } from "./types.ts";
 import { getSupabaseClient } from "./supabase-client.ts";
 export type { RemainingFields } from "./inventory-formatters.ts";
 export { formatExpiryDate, formatTotalRemaining } from "./inventory-formatters.ts";
@@ -28,6 +28,45 @@ export const fetchAllItems = async (): Promise<InventoryItem[] | null> => {
     return null;
   }
   return (data ?? []) as InventoryItem[];
+};
+
+export const fetchRecentlyConsumedItems = async (): Promise<RecentlyConsumedItem[] | null> => {
+  const ctx = getSupabaseClient();
+  if (!ctx) {
+    console.error("[inventory] Missing required environment variables");
+    return null;
+  }
+  const { supabase, userId } = ctx;
+  const twoMonthsAgo = new Date();
+  twoMonthsAgo.setMonth(twoMonthsAgo.getMonth() - 2);
+
+  const { data, error } = await supabase
+    .from("consumption_logs")
+    .select("item_id, occurred_at, items(name)")
+    .eq("user_id", userId)
+    .eq("units_after", 0)
+    .gte("occurred_at", twoMonthsAgo.toISOString())
+    .order("occurred_at", { ascending: false });
+
+  if (error) {
+    console.error("[inventory] fetchRecentlyConsumedItems error:", error);
+    return null;
+  }
+
+  // Deduplicate: keep the most recent consumption event per item
+  const seen = new Set<string>();
+  const result: RecentlyConsumedItem[] = [];
+  for (const row of data ?? []) {
+    const itemName = (row.items as { name: string } | null)?.name;
+    if (!itemName || seen.has(row.item_id)) continue;
+    seen.add(row.item_id);
+    result.push({
+      item_id: row.item_id,
+      item_name: itemName,
+      last_consumed_at: row.occurred_at,
+    });
+  }
+  return result;
 };
 
 export const fetchItemsByLocation = async (

--- a/supabase/functions/alexa-skill/inventory.ts
+++ b/supabase/functions/alexa-skill/inventory.ts
@@ -40,11 +40,13 @@ export const fetchRecentlyConsumedItems = async (): Promise<RecentlyConsumedItem
   const twoMonthsAgo = new Date();
   twoMonthsAgo.setMonth(twoMonthsAgo.getMonth() - 2);
 
+  // Fetch recent consumption logs joined with item state.
+  // units_after in consumption_logs reflects lot-level units, not the whole item,
+  // so we include the item's current units and deleted_at to determine if it's fully gone.
   const { data, error } = await supabase
     .from("consumption_logs")
-    .select("item_id, occurred_at, items(name)")
+    .select("item_id, occurred_at, items(name, units, deleted_at)")
     .eq("user_id", userId)
-    .eq("units_after", 0)
     .gte("occurred_at", twoMonthsAgo.toISOString())
     .order("occurred_at", { ascending: false });
 
@@ -53,18 +55,26 @@ export const fetchRecentlyConsumedItems = async (): Promise<RecentlyConsumedItem
     return null;
   }
 
-  // Deduplicate: keep the most recent consumption event per item
+  // Keep only items that are currently empty: deleted or units=0.
+  // Items still in inventory with units>0 are already in the inventory context.
+  // Deduplicate: keep the most recent consumption event per item.
   const seen = new Set<string>();
   const result: RecentlyConsumedItem[] = [];
   for (const row of data ?? []) {
-    const itemName = (row.items as { name: string } | null)?.name;
-    if (!itemName || seen.has(row.item_id)) continue;
-    seen.add(row.item_id);
-    result.push({
-      item_id: row.item_id,
-      item_name: itemName,
-      last_consumed_at: row.occurred_at,
-    });
+    const item = row.items as {
+      name: string;
+      units: number;
+      deleted_at: string | null;
+    } | null;
+    if (!item || seen.has(row.item_id)) continue;
+    if (item.deleted_at !== null || item.units === 0) {
+      seen.add(row.item_id);
+      result.push({
+        item_id: row.item_id,
+        item_name: item.name,
+        last_consumed_at: row.occurred_at,
+      });
+    }
   }
   return result;
 };

--- a/supabase/functions/alexa-skill/types.ts
+++ b/supabase/functions/alexa-skill/types.ts
@@ -109,6 +109,13 @@ export interface GeminiResponse {
   }>;
 }
 
+// Recently consumed item (fully consumed within past 2 months)
+export interface RecentlyConsumedItem {
+  item_id: string;
+  item_name: string;
+  last_consumed_at: string; // ISO timestamp
+}
+
 // Gemini structured output schema
 export interface GeminiMatchResult {
   matchedItems: Array<{
@@ -124,7 +131,7 @@ export interface GeminiMatchResult {
   }>;
   speech: string;
   confidence: "exact" | "fuzzy" | "none";
-  stockStatus: "in_stock" | "out_of_stock" | "not_found";
+  stockStatus: "in_stock" | "out_of_stock" | "not_found" | "recently_consumed";
 }
 
 // Session attributes for multi-turn dialog


### PR DESCRIPTION
## Summary

Extends the Alexa skill's inventory query capabilities to track and surface items that were recently fully consumed (within the past 2 months). This allows the skill to provide more helpful responses when users ask about items that are no longer in stock but were recently used up.

## Key Changes

- **New `fetchRecentlyConsumedItems()` function** in `inventory.ts`: Queries the `consumption_logs` table for items fully consumed (`units_after = 0`) in the past 2 months, deduplicates by item (keeping most recent), and returns a structured list with item name and consumption date.

- **New `RecentlyConsumedItem` type** in `types.ts`: Defines the shape of recently consumed items with `item_id`, `item_name`, and `last_consumed_at` (ISO timestamp).

- **Updated Gemini system prompt**: Enhanced to recognize and handle the "recently_consumed" stock status. When an item is not in current inventory but found in the recently consumed list, the skill now responds with "過去に〇〇がありましたが、{date}にすべて使い切りました" (We had X, but used it all up on {date}).

- **New `recently_consumed` stock status**: Added to the Gemini response schema alongside existing `in_stock`, `out_of_stock`, and `not_found` statuses.

- **Updated all query handlers** (`check-inventory.ts`, `check-expiry.ts`, `check-location.ts`, `check-remaining.ts`): Modified to fetch both current inventory and recently consumed items in parallel, then pass both datasets to `queryGemini()`.

- **Improved inventory context formatting**: Changed `buildInventoryContext()` to return a structured JSON object with separate `inventory` and `recently_consumed` arrays, providing Gemini with clearer data organization.

## Implementation Details

- Recently consumed items are fetched via a Supabase query filtering on `consumption_logs` with `units_after = 0` and `occurred_at >= 2 months ago`, ordered by recency.
- Deduplication logic keeps only the most recent consumption event per item to avoid redundant results.
- All handler functions use `Promise.all()` to fetch inventory and recently consumed items concurrently for better performance.
- The Gemini prompt now explicitly instructs the model to distinguish between current inventory and recently consumed items, with specific response templates for each case.

https://claude.ai/code/session_01XnQHDRhqeECmANv59NtSVX