### PR TITLE
MB-29: カレンダー削除をロット単位に変更し取り消し導線を追加

### DIFF
--- a/src/components/molecules/ExpiryCheckItem.tsx
+++ b/src/components/molecules/ExpiryCheckItem.tsx
@@ -7,7 +7,7 @@ import type { Item } from "@/types/item";
 interface ExpiryCheckItemProps {
   item: Item;
   categoryColor?: string | null;
-  onCheck: (id: string) => Promise<void>;
+  onCheck: (item: Item) => Promise<void>;
 }
 
 export const ExpiryCheckItem = ({ item, categoryColor, onCheck }: ExpiryCheckItemProps) => {
@@ -17,7 +17,7 @@ export const ExpiryCheckItem = ({ item, categoryColor, onCheck }: ExpiryCheckIte
     if (checked) return;
     setChecked(true);
     try {
-      await onCheck(item.id);
+      await onCheck(item);
     } catch {
       setChecked(false);
     }

--- a/src/components/pages/CalendarPage.stories.tsx
+++ b/src/components/pages/CalendarPage.stories.tsx
@@ -85,7 +85,7 @@ const meta = {
     categories,
     onCheck: async () => {},
     onUndo: async () => {},
-    pendingRemovalItemIds: [],
+    pendingRemovals: [],
   },
   render: (args) => wrapper({ children: <CalendarPage {...args} /> }),
 } satisfies Meta<typeof CalendarPage>;

--- a/src/components/pages/CalendarPage.stories.tsx
+++ b/src/components/pages/CalendarPage.stories.tsx
@@ -84,6 +84,8 @@ const meta = {
   args: {
     categories,
     onCheck: async () => {},
+    onUndo: async () => {},
+    pendingRemovalItemIds: [],
   },
   render: (args) => wrapper({ children: <CalendarPage {...args} /> }),
 } satisfies Meta<typeof CalendarPage>;

--- a/src/components/pages/CalendarPage.tsx
+++ b/src/components/pages/CalendarPage.tsx
@@ -12,7 +12,7 @@ interface CalendarPageProps {
   isLoading: boolean;
   onCheck: (item: Item) => Promise<void>;
   onUndo: (itemId: string) => Promise<void>;
-  pendingRemovalItemIds: string[];
+  pendingRemovals: { itemId: string; itemName: string }[];
 }
 
 export const CalendarPage = ({
@@ -21,7 +21,7 @@ export const CalendarPage = ({
   isLoading,
   onCheck,
   onUndo,
-  pendingRemovalItemIds,
+  pendingRemovals,
 }: CalendarPageProps) => {
   const { t } = useTranslation("calendar");
   const categoryMap = new Map(categories.map((c) => [c.id, c]));
@@ -61,11 +61,11 @@ export const CalendarPage = ({
   return (
     <div className="space-y-4">
       <h1 className="text-xl font-bold">{t("title")}</h1>
-      {pendingRemovalItemIds.length > 0 && (
+      {pendingRemovals.length > 0 && (
         <div className="rounded-lg border border-yellow-300 bg-yellow-50 p-3 text-sm">
           <p className="mb-2 font-medium">{t("pendingRemovalMessage")}</p>
           <div className="flex flex-wrap gap-2">
-            {pendingRemovalItemIds.map((itemId) => (
+            {pendingRemovals.map(({ itemId, itemName }) => (
               <button
                 key={itemId}
                 type="button"
@@ -74,7 +74,7 @@ export const CalendarPage = ({
                 }}
                 className="rounded-md border border-yellow-400 bg-white px-2 py-1 text-xs font-medium hover:bg-yellow-100"
               >
-                {t("undo")}
+                {t("undo")} ({itemName})
               </button>
             ))}
           </div>

--- a/src/components/pages/CalendarPage.tsx
+++ b/src/components/pages/CalendarPage.tsx
@@ -10,10 +10,19 @@ interface CalendarPageProps {
   items: Item[];
   categories: Category[];
   isLoading: boolean;
-  onCheck: (id: string) => Promise<void>;
+  onCheck: (item: Item) => Promise<void>;
+  onUndo: (itemId: string) => Promise<void>;
+  pendingRemovalItemIds: string[];
 }
 
-export const CalendarPage = ({ items, categories, isLoading, onCheck }: CalendarPageProps) => {
+export const CalendarPage = ({
+  items,
+  categories,
+  isLoading,
+  onCheck,
+  onUndo,
+  pendingRemovalItemIds,
+}: CalendarPageProps) => {
   const { t } = useTranslation("calendar");
   const categoryMap = new Map(categories.map((c) => [c.id, c]));
 
@@ -52,6 +61,25 @@ export const CalendarPage = ({ items, categories, isLoading, onCheck }: Calendar
   return (
     <div className="space-y-4">
       <h1 className="text-xl font-bold">{t("title")}</h1>
+      {pendingRemovalItemIds.length > 0 && (
+        <div className="rounded-lg border border-yellow-300 bg-yellow-50 p-3 text-sm">
+          <p className="mb-2 font-medium">{t("pendingRemovalMessage")}</p>
+          <div className="flex flex-wrap gap-2">
+            {pendingRemovalItemIds.map((itemId) => (
+              <button
+                key={itemId}
+                type="button"
+                onClick={() => {
+                  void onUndo(itemId);
+                }}
+                className="rounded-md border border-yellow-400 bg-white px-2 py-1 text-xs font-medium hover:bg-yellow-100"
+              >
+                {t("undo")}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
       {items.length === 0 && (
         <div className="py-12 text-center text-muted-foreground">
           <CalendarDays className="mx-auto mb-3 h-12 w-12 opacity-30" />

--- a/src/locales/en/calendar.json
+++ b/src/locales/en/calendar.json
@@ -12,5 +12,7 @@
   "noItemsHint": "Set expiry dates on your items to see them here",
   "close": "Close",
   "noItemsOnDate": "No items expiring on this date",
-  "expiryItemsOnDate": "Items expiring on {{date}}"
+  "expiryItemsOnDate": "Items expiring on {{date}}",
+  "undo": "Undo",
+  "pendingRemovalMessage": "You can undo removed lots"
 }

--- a/src/locales/ja/calendar.json
+++ b/src/locales/ja/calendar.json
@@ -12,5 +12,7 @@
   "noItemsHint": "アイテムに期限日を設定するとここに表示されます",
   "close": "閉じる",
   "noItemsOnDate": "この日に期限を迎えるアイテムはありません",
-  "expiryItemsOnDate": "{{date}} の期限アイテム"
+  "expiryItemsOnDate": "{{date}} の期限アイテム",
+  "undo": "取り消す",
+  "pendingRemovalMessage": "削除したロットを取り消せます"
 }

--- a/src/routes/_auth.calendar.tsx
+++ b/src/routes/_auth.calendar.tsx
@@ -1,6 +1,6 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
 
 import { CalendarPage } from "@/components/pages/CalendarPage";
 import { LOTS_KEY, syncItemAggregate } from "@/hooks/useItemLots";

--- a/src/routes/_auth.calendar.tsx
+++ b/src/routes/_auth.calendar.tsx
@@ -1,16 +1,85 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
 
 import { CalendarPage } from "@/components/pages/CalendarPage";
-import { useItemsWithExpiry, useSoftDeleteItem } from "@/hooks/useItems";
+import { syncItemAggregate } from "@/hooks/useItemLots";
+import { useItemsWithExpiry } from "@/hooks/useItems";
 import { useCategories } from "@/hooks/useMasterData";
+import { supabase } from "@/lib/supabase";
+import type { Item } from "@/types/item";
+
+interface PendingLotRemoval {
+  lotId: string;
+  itemId: string;
+  units: number;
+  openedRemaining: number | null;
+}
 
 const CalendarRoutePage = () => {
   const { data: items = [], isLoading } = useItemsWithExpiry();
   const { data: categories = [] } = useCategories();
-  const softDelete = useSoftDeleteItem();
+  const [pendingRemovals, setPendingRemovals] = useState<Record<string, PendingLotRemoval>>({});
 
-  const handleCheck = async (id: string) => {
-    await softDelete.mutateAsync(id);
+  const handleCheck = async (item: Item) => {
+    const { data: lots, error } = await supabase
+      .from("item_lots")
+      .select("id, units, opened_remaining, expiry_date")
+      .eq("item_id", item.id)
+      .order("expiry_date", { ascending: true, nullsFirst: false })
+      .order("created_at", { ascending: true });
+    if (error) throw error;
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const monthEnd = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+
+    const targetLot = (lots ?? []).find((lot) => {
+      if (lot.units <= 0 && lot.opened_remaining === null) return false;
+      if (!lot.expiry_date) return false;
+      const [y, m, d] = lot.expiry_date.split("-").map(Number) as [number, number, number];
+      const exp = new Date(y, m - 1, d);
+      return exp <= monthEnd;
+    });
+
+    if (!targetLot) return;
+
+    const { error: updateError } = await supabase
+      .from("item_lots")
+      .update({ units: 0, opened_remaining: null, updated_at: new Date().toISOString() })
+      .eq("id", targetLot.id);
+    if (updateError) throw updateError;
+
+    await syncItemAggregate(item.id);
+    setPendingRemovals((prev) => ({
+      ...prev,
+      [item.id]: {
+        lotId: targetLot.id,
+        itemId: item.id,
+        units: targetLot.units,
+        openedRemaining: targetLot.opened_remaining,
+      },
+    }));
+  };
+
+  const handleUndo = async (itemId: string) => {
+    const pending = pendingRemovals[itemId];
+    if (!pending) return;
+    const { error } = await supabase
+      .from("item_lots")
+      .update({
+        units: pending.units,
+        opened_remaining: pending.openedRemaining,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", pending.lotId);
+    if (error) throw error;
+
+    await syncItemAggregate(pending.itemId);
+    setPendingRemovals((prev) => {
+      const next = { ...prev };
+      delete next[itemId];
+      return next;
+    });
   };
 
   return (
@@ -19,6 +88,8 @@ const CalendarRoutePage = () => {
       categories={categories}
       isLoading={isLoading}
       onCheck={handleCheck}
+      onUndo={handleUndo}
+      pendingRemovalItemIds={Object.keys(pendingRemovals)}
     />
   );
 };

--- a/src/routes/_auth.calendar.tsx
+++ b/src/routes/_auth.calendar.tsx
@@ -1,8 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { CalendarPage } from "@/components/pages/CalendarPage";
-import { syncItemAggregate } from "@/hooks/useItemLots";
+import { LOTS_KEY, syncItemAggregate } from "@/hooks/useItemLots";
 import { useItemsWithExpiry } from "@/hooks/useItems";
 import { useCategories } from "@/hooks/useMasterData";
 import { supabase } from "@/lib/supabase";
@@ -11,11 +12,13 @@ import type { Item } from "@/types/item";
 interface PendingLotRemoval {
   lotId: string;
   itemId: string;
+  itemName: string;
   units: number;
   openedRemaining: number | null;
 }
 
 const CalendarRoutePage = () => {
+  const qc = useQueryClient();
   const { data: items = [], isLoading } = useItemsWithExpiry();
   const { data: categories = [] } = useCategories();
   const [pendingRemovals, setPendingRemovals] = useState<Record<string, PendingLotRemoval>>({});
@@ -50,11 +53,16 @@ const CalendarRoutePage = () => {
     if (updateError) throw updateError;
 
     await syncItemAggregate(item.id);
+    await Promise.all([
+      qc.invalidateQueries({ queryKey: ["items"] }),
+      qc.invalidateQueries({ queryKey: [...LOTS_KEY, item.id] }),
+    ]);
     setPendingRemovals((prev) => ({
       ...prev,
       [item.id]: {
         lotId: targetLot.id,
         itemId: item.id,
+        itemName: item.name,
         units: targetLot.units,
         openedRemaining: targetLot.opened_remaining,
       },
@@ -75,6 +83,10 @@ const CalendarRoutePage = () => {
     if (error) throw error;
 
     await syncItemAggregate(pending.itemId);
+    await Promise.all([
+      qc.invalidateQueries({ queryKey: ["items"] }),
+      qc.invalidateQueries({ queryKey: [...LOTS_KEY, pending.itemId] }),
+    ]);
     setPendingRemovals((prev) => {
       const next = { ...prev };
       delete next[itemId];
@@ -89,7 +101,10 @@ const CalendarRoutePage = () => {
       isLoading={isLoading}
       onCheck={handleCheck}
       onUndo={handleUndo}
-      pendingRemovalItemIds={Object.keys(pendingRemovals)}
+      pendingRemovals={Object.values(pendingRemovals).map(({ itemId, itemName }) => ({
+        itemId,
+        itemName,
+      }))}
     />
   );
 };


### PR DESCRIPTION
### Motivation
- カレンダーページのチェック操作で複数ロットを持つアイテムが全ロットごと削除されてしまう不具合を修正するために、ロット単位で削除対象を管理する必要がありました。 
- ユーザーの誤操作に備えて、即時に取り消しできる導線を提供することで安全に在庫除外できるようにします.

### Description
- 期限カレンダールート（`src/routes/_auth.calendar.tsx`）を変更し、チェック時に`item_lots`を照会して表示対象のロット（今月末までに期限が来るロット）を1件選択して在庫を0化する処理に差し替え、変更後に`syncItemAggregate`を呼んでアイテム集計を再計算するようにしました。 
- 直前に除外したロット情報をコンポーネント stateで保持し、取り消し操作（Undo）でロットの`units`/`opened_remaining`を復元して再集計する`handleUndo`を実装しました。 
- 表示層で`CalendarPage`のpropsを更新し、`onCheck`を`Item`受け取りに変更、`onUndo`と`pendingRemovalItemIds`を追加してページ上部に取り消しUIを表示するようにしました（`src/components/pages/CalendarPage.tsx`）。 
- チェックアイテムのコンポーネント`ExpiryCheckItem`の`onCheck`シグネチャを`(id: string)`から`(item: Item)`へ変更し、チェック時にアイテム情報を渡すように更新しました。 
- 日本語 / 英語のロケールにUndo関連文言を追加しました（`src/locales/ja/calendar.json`, `src/locales/en/calendar.json`）。 
- Storybookのストーリーを`CalendarPage`の新しいpropsに合わせて修正しました（`src/components/pages/CalendarPage.stories.tsx`）。

### Testing
- 自動チェックとして `bun run format:check` が成功しました。 
- 静的解析・リンティングとして `bun run lint` が成功しました。 
- 型チェックとして `bun run typecheck`（`tsc --noEmit`）が成功しました。 
- ビルドチェックとして `bun run build` が成功し、さらに `bun run build-storybook` による Storybook ビルドも成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12ba18bc4483309072430adb48c74c)