### PR TITLE
Support lot-level editing in Item Edit page (MB-19)

### DIFF
--- a/src/components/pages/EditItemPage.tsx
+++ b/src/components/pages/EditItemPage.tsx
@@ -8,6 +8,7 @@ import { Spinner } from "@/components/atoms/Spinner";
 import { ItemForm } from "@/components/organisms/ItemForm";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
 import { downloadExternalImageAsFile, uploadItemImage } from "@/hooks/useItemImage";
 import { useItemLots, useUpdateLot } from "@/hooks/useItemLots";
 import { useItem, useUpdateItem } from "@/hooks/useItems";
@@ -120,9 +121,8 @@ export const EditItemPage = ({ itemId }: EditItemPageProps) => {
       {lots.length > 1 && (
         <div className="space-y-2 rounded-lg border p-3">
           <Label htmlFor="lot-select">{t("editLot")}</Label>
-          <select
+          <Select
             id="lot-select"
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
             value={selectedLot?.id ?? ""}
             onChange={(e) => setSelectedLotId(e.target.value)}
           >
@@ -131,7 +131,7 @@ export const EditItemPage = ({ itemId }: EditItemPageProps) => {
                 {t("lotLabel", { index: index + 1 })}
               </option>
             ))}
-          </select>
+          </Select>
         </div>
       )}
       <ItemForm

--- a/src/components/pages/EditItemPage.tsx
+++ b/src/components/pages/EditItemPage.tsx
@@ -6,7 +6,9 @@ import { useTranslation } from "react-i18next";
 import { Spinner } from "@/components/atoms/Spinner";
 import { ItemForm } from "@/components/organisms/ItemForm";
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 import { downloadExternalImageAsFile, uploadItemImage } from "@/hooks/useItemImage";
+import { useItemLots, useUpdateLot } from "@/hooks/useItemLots";
 import { useItem, useUpdateItem } from "@/hooks/useItems";
 import { OfflineError } from "@/lib/requireOnline";
 import { useToast } from "@/lib/toast-context";
@@ -20,17 +22,34 @@ export const EditItemPage = ({ itemId }: EditItemPageProps) => {
   const { t } = useTranslation("items");
   const navigate = useNavigate();
   const { data: item, isLoading } = useItem(itemId);
+  const { data: lots = [] } = useItemLots(itemId);
   const updateItem = useUpdateItem(itemId);
+  const updateLot = useUpdateLot();
   const { toast } = useToast();
   const pendingFileRef = useRef<File | null>(null);
   const pendingImageUrlRef = useRef<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [selectedLotId, setSelectedLotId] = useState<string | null>(null);
+
+  const selectedLot =
+    lots.find((lot) => lot.id === (selectedLotId ?? lots[0]?.id)) ?? lots[0] ?? null;
 
   const handleSubmit = async (values: ItemFormValues) => {
     setIsSubmitting(true);
     try {
       const oldImagePath = item?.image_path ?? null;
       await updateItem.mutateAsync(values);
+      if (selectedLot) {
+        await updateLot.mutateAsync({
+          lotId: selectedLot.id,
+          itemId,
+          values: {
+            units: values.units,
+            purchase_date: values.purchase_date ?? null,
+            expiry_date: values.expiry_date ?? null,
+          },
+        });
+      }
       const pendingFile = pendingFileRef.current;
       const pendingImageUrl = pendingImageUrlRef.current;
       if (pendingFile || pendingImageUrl) {
@@ -94,18 +113,36 @@ export const EditItemPage = ({ itemId }: EditItemPageProps) => {
         </Button>
         <h1 className="text-xl font-bold">{t("editItem")}</h1>
       </div>
+      {lots.length > 1 && (
+        <div className="space-y-2 rounded-lg border p-3">
+          <Label htmlFor="lot-select">{t("editLot")}</Label>
+          <select
+            id="lot-select"
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            value={selectedLot?.id ?? ""}
+            onChange={(e) => setSelectedLotId(e.target.value)}
+          >
+            {lots.map((lot, index) => (
+              <option key={lot.id} value={lot.id}>
+                {t("lotLabel", { index: index + 1 })}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
       <ItemForm
+        key={selectedLot?.id ?? item.id}
         defaultValues={{
           name: item.name,
           barcode: item.barcode ?? undefined,
           category_id: item.category_id,
           storage_location_id: item.storage_location_id,
-          units: item.units,
+          units: selectedLot?.units ?? item.units,
           content_amount: item.content_amount,
           content_unit: item.content_unit,
           opened_remaining: item.opened_remaining,
-          purchase_date: item.purchase_date ?? undefined,
-          expiry_date: item.expiry_date ?? undefined,
+          purchase_date: selectedLot?.purchase_date ?? item.purchase_date ?? undefined,
+          expiry_date: selectedLot?.expiry_date ?? item.expiry_date ?? undefined,
           notes: item.notes ?? undefined,
           image_path: item.image_path ?? undefined,
         }}

--- a/src/hooks/useItemLots.ts
+++ b/src/hooks/useItemLots.ts
@@ -42,6 +42,32 @@ export const createLot = async (
   return data as ItemLot;
 };
 
+export const updateLot = async (
+  lotId: string,
+  values: {
+    units?: number;
+    opened_remaining?: number | null;
+    purchase_date?: string | null;
+    expiry_date?: string | null;
+  },
+): Promise<ItemLot> => {
+  requireOnline();
+  const { data, error } = await supabase
+    .from("item_lots")
+    .update({
+      units: values.units,
+      opened_remaining: values.opened_remaining,
+      purchase_date: values.purchase_date,
+      expiry_date: values.expiry_date,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", lotId)
+    .select()
+    .single();
+  if (error) throw error;
+  return data as ItemLot;
+};
+
 /** Recompute and update the item aggregate (units, expiry_date, opened_remaining) from its lots. */
 export const syncItemAggregate = async (itemId: string): Promise<void> => {
   const { data: lots, error: lotsError } = await supabase
@@ -146,6 +172,36 @@ export const useConsumeLot = () => {
         qc.invalidateQueries({ queryKey: ["items"] }),
         qc.invalidateQueries({ queryKey: ["consumption-logs", variables.lot.item_id] }),
         qc.invalidateQueries({ queryKey: ["consumption-logs-all"] }),
+      ]);
+    },
+  });
+};
+
+export const useUpdateLot = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      lotId,
+      itemId,
+      values,
+    }: {
+      lotId: string;
+      itemId: string;
+      values: {
+        units?: number;
+        opened_remaining?: number | null;
+        purchase_date?: string | null;
+        expiry_date?: string | null;
+      };
+    }) => {
+      const updated = await updateLot(lotId, values);
+      await syncItemAggregate(itemId);
+      return updated;
+    },
+    onSuccess: async (_data, variables) => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: [...LOTS_KEY, variables.itemId] }),
+        qc.invalidateQueries({ queryKey: ["items"] }),
       ]);
     },
   });

--- a/src/locales/en/items.json
+++ b/src/locales/en/items.json
@@ -111,5 +111,6 @@
   "urgentBannerNoExpiringSoonItems": "No expiring-soon items",
   "lotsLoadError": "Failed to load stock lots. Please try again later.",
   "back": "Back",
-  "noStockToConsume": "No stock available to use"
+  "noStockToConsume": "No stock available to use",
+  "editLot": "Select lot to edit"
 }

--- a/src/locales/ja/items.json
+++ b/src/locales/ja/items.json
@@ -111,5 +111,6 @@
   "urgentBannerNoExpiringSoonItems": "期限間近の商品はありません",
   "lotsLoadError": "在庫ロットの読み込みに失敗しました。時間をおいて再試行してください。",
   "back": "戻る",
-  "noStockToConsume": "使用できる在庫がありません"
+  "noStockToConsume": "使用できる在庫がありません",
+  "editLot": "編集するロットを選択"
 }


### PR DESCRIPTION
### Motivation
- Fix incorrect inventory management when editing an item that has multiple purchase lots by making editable fields operate at the lot level. 
- Ensure editing preserves correct `units`/`purchase_date`/`expiry_date` per lot instead of only updating the aggregated item values.

### Description
- Added `updateLot` API and `useUpdateLot` mutation to `src/hooks/useItemLots.ts` to update a single `item_lot` and then call `syncItemAggregate` with proper query cache invalidation. 
- Updated `src/components/pages/EditItemPage.tsx` to load lots, show a lot selector when multiple lots exist, drive `ItemForm` initial values from the selected lot, and submit the lot-level update (units/purchase_date/expiry_date) after the item-level update. 
- Kept item-level updates via the existing `useUpdateItem` path and ensured `requireOnline()` is respected in lot updates; added `editLot` i18n keys to `src/locales/en/items.json` and `src/locales/ja/items.json`. 

### Testing
- Ran formatting checks and fixes with `bun run format` and `bun run format:check`, and the code is formatted successfully. 
- Ran linting with `bun run lint` and type checking with `bun run typecheck`, and both succeeded with no errors. 
- Built the app with `bun run build`, and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1033431e488330b78b9ae2d35e7d3d)