### PR TITLE
Relax image-proxy allowlist to accept *.yimg.jp for product images

### DIFF
--- a/supabase/functions/image-proxy/index.ts
+++ b/supabase/functions/image-proxy/index.ts
@@ -4,7 +4,7 @@ const corsHeaders = {
   "Access-Control-Allow-Methods": "POST, OPTIONS",
 };
 
-const ALLOWED_HOSTS = [/^([a-z0-9-]+\.)*yimg\.jp$/, /^shopping\.yahoo\.co\.jp$/];
+const ALLOWED_HOSTS = [/^([a-z0-9-]+\.)+yimg\.jp$/, /^shopping\.yahoo\.co\.jp$/];
 
 const ALLOWED_CONTENT_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
 const GENERIC_CONTENT_TYPES = ["application/octet-stream", "binary/octet-stream"];

--- a/supabase/functions/image-proxy/index.ts
+++ b/supabase/functions/image-proxy/index.ts
@@ -4,11 +4,7 @@ const corsHeaders = {
   "Access-Control-Allow-Methods": "POST, OPTIONS",
 };
 
-const ALLOWED_HOSTS = [
-  /^[a-z0-9-]+\.yimg\.jp$/,
-  /^shopping\.yahoo\.co\.jp$/,
-  /^item-shopping\.c\.yimg\.jp$/,
-];
+const ALLOWED_HOSTS = [/^([a-z0-9-]+\.)*yimg\.jp$/, /^shopping\.yahoo\.co\.jp$/];
 
 const ALLOWED_CONTENT_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
 const GENERIC_CONTENT_TYPES = ["application/octet-stream", "binary/octet-stream"];


### PR DESCRIPTION
### Motivation
- JAN/barcode lookup results sometimes include product images hosted on various `*.yimg.jp` subdomains which the proxy previously rejected, causing image download/upload to fail and saved items to lack images. 
- The change fixes the minimal allowlist mismatch so API-fetched product images can be downloaded via the `image-proxy` Edge Function and uploaded to Storage during item create/edit flows. 

### Description
- Updated `supabase/functions/image-proxy/index.ts` to replace narrow host patterns with a wildcard subdomain regex `^([a-z0-9-]+\.)*yimg\.jp$` so all `yimg.jp` subdomains are allowed. 
- Kept the existing `shopping.yahoo.co.jp` allow rule while removing redundant overly-specific patterns. 

### Testing
- Ran formatting and linting via `bun run format` and `bun run format:check` which passed after formatting. 
- Ran checks and typechecking via `bun run check` and `bun run typecheck` which passed with zero errors. 
- Ran production build via `bun run build` which completed successfully (Vite emitted a chunk-size warning but the build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a178b8f5a608330b4fe6206ab1d236a)