### PR TITLE
fix: バグ修正5件 + PRのIssueリンク必須化CI追加

### DIFF
--- a/.github/workflows/pr-issue-link-check.yml
+++ b/.github/workflows/pr-issue-link-check.yml
@@ -8,7 +8,7 @@ jobs:
   check:
     name: Require Issue Link
     runs-on: ubuntu-latest
-    # dependabot と codex の自動PRはスキップ
+    # dependabot の自動PRはスキップ。緊急対応は 'skip-issue-link' ラベルで除外可能
     if: |
       github.actor != 'dependabot[bot]' &&
       !contains(github.event.pull_request.labels.*.name, 'skip-issue-link')

--- a/.github/workflows/pr-issue-link-check.yml
+++ b/.github/workflows/pr-issue-link-check.yml
@@ -1,0 +1,27 @@
+name: PR Issue Link Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  check:
+    name: Require Issue Link
+    runs-on: ubuntu-latest
+    # dependabot と codex の自動PRはスキップ
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-issue-link')
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body ?? '';
+            const hasLink = /(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#\d+/i.test(body);
+            if (!hasLink) {
+              core.setFailed(
+                'PR bodyにIssueリンクがありません。\n' +
+                '例: "Closes #123" や "Fixes #123" を追加してください。\n' +
+                '緊急対応の場合は "skip-issue-link" ラベルを付けてください。'
+              );
+            }

--- a/src/components/molecules/ItemCard.tsx
+++ b/src/components/molecules/ItemCard.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { ExpiryBadge } from "@/components/atoms/ExpiryBadge";
 import { ItemImage } from "@/components/atoms/ItemImage";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
+import { parseLocalDate } from "@/lib/dateUtils";
 import { cn } from "@/lib/utils";
 import { formatRemaining, getExpiryStatus, type Item } from "@/types/item";
 
@@ -54,7 +55,7 @@ export const ItemCard = ({ item, categoryName, locationName, warningDays }: Item
             {item.expiry_date && (
               <div className="flex items-center gap-1">
                 <Calendar className="h-3 w-3" />
-                <span>{new Date(item.expiry_date).toLocaleDateString(i18n.language)}</span>
+                <span>{parseLocalDate(item.expiry_date).toLocaleDateString(i18n.language)}</span>
               </div>
             )}
           </div>

--- a/src/components/organisms/ItemForm.tsx
+++ b/src/components/organisms/ItemForm.tsx
@@ -109,7 +109,9 @@ export const ItemForm = ({
     setLookupResult(result.product);
     setLookupSource(result.source);
     if (result.product?.name) set("name", result.product.name);
-    if (result.product?.image_url && !localPreviewUrl) {
+    if (result.product?.image_path && !localPreviewUrl) {
+      set("image_path", result.product.image_path);
+    } else if (result.product?.image_url && !localPreviewUrl) {
       setBarcodeImageUrl(result.product.image_url);
       onPendingImageUrlChange?.(result.product.image_url);
     }

--- a/src/components/organisms/ItemForm.tsx
+++ b/src/components/organisms/ItemForm.tsx
@@ -109,11 +109,12 @@ export const ItemForm = ({
     setLookupResult(result.product);
     setLookupSource(result.source);
     if (result.product?.name) set("name", result.product.name);
-    if (result.product?.image_path && !localPreviewUrl) {
-      set("image_path", result.product.image_path);
-    } else if (result.product?.image_url && !localPreviewUrl) {
+    if (result.product?.image_url && !localPreviewUrl) {
       setBarcodeImageUrl(result.product.image_url);
-      onPendingImageUrlChange?.(result.product.image_url);
+      // DB ヒット時は既にStorage済みの画像なので再アップロード不要。プレビュー表示のみ。
+      if (result.source !== "db") {
+        onPendingImageUrlChange?.(result.product.image_url);
+      }
     }
     onBarcodeScanned?.(barcode, result.source);
   };

--- a/src/hooks/useBarcodeLookup.ts
+++ b/src/hooks/useBarcodeLookup.ts
@@ -4,7 +4,10 @@ import { supabase } from "@/lib/supabase";
 
 export interface ProductInfo {
   name: string;
+  /** External image URL (from barcode API). Use onPendingImageUrlChange to download & upload. */
   image_url?: string;
+  /** Supabase Storage path (from local DB hit). Set directly to form's image_path. */
+  image_path?: string;
   description?: string;
   brand?: string;
 }

--- a/src/hooks/useBarcodeLookup.ts
+++ b/src/hooks/useBarcodeLookup.ts
@@ -6,8 +6,6 @@ export interface ProductInfo {
   name: string;
   /** External image URL (from barcode API). Use onPendingImageUrlChange to download & upload. */
   image_url?: string;
-  /** Supabase Storage path (from local DB hit). Set directly to form's image_path. */
-  image_path?: string;
   description?: string;
   brand?: string;
 }

--- a/src/hooks/useShoppingList.ts
+++ b/src/hooks/useShoppingList.ts
@@ -87,7 +87,11 @@ export const useUpsertShoppingItem = () => {
       await qc.invalidateQueries({ queryKey: [QUERY_KEY] });
     },
     onError: (error) => {
-      if (error instanceof OfflineError) toast(t("offlineError"), "error");
+      if (error instanceof OfflineError) {
+        toast(t("offlineError"), "error");
+      } else {
+        toast(t("unknownError"), "error");
+      }
     },
   });
 };
@@ -173,7 +177,11 @@ export const usePurchaseShoppingItem = () => {
       ]);
     },
     onError: (error) => {
-      if (error instanceof OfflineError) toast(t("offlineError"), "error");
+      if (error instanceof OfflineError) {
+        toast(t("offlineError"), "error");
+      } else {
+        toast(t("unknownError"), "error");
+      }
     },
   });
 };

--- a/src/locales/en/items.json
+++ b/src/locales/en/items.json
@@ -112,5 +112,7 @@
   "lotsLoadError": "Failed to load stock lots. Please try again later.",
   "back": "Back",
   "noStockToConsume": "No stock available to use",
-  "editLot": "Select lot to edit"
+  "editLot": "Select lot to edit",
+  "itemCountLabel": "{{count}} items",
+  "itemCountLabelFiltered": "{{filtered}} / {{total}} items"
 }

--- a/src/locales/en/items.json
+++ b/src/locales/en/items.json
@@ -113,6 +113,7 @@
   "back": "Back",
   "noStockToConsume": "No stock available to use",
   "editLot": "Select lot to edit",
-  "itemCountLabel": "{{count}} items",
+  "itemCountLabel_one": "{{count}} item",
+  "itemCountLabel_other": "{{count}} items",
   "itemCountLabelFiltered": "{{filtered}} / {{total}} items"
 }

--- a/src/locales/ja/items.json
+++ b/src/locales/ja/items.json
@@ -112,5 +112,7 @@
   "lotsLoadError": "在庫ロットの読み込みに失敗しました。時間をおいて再試行してください。",
   "back": "戻る",
   "noStockToConsume": "使用できる在庫がありません",
-  "editLot": "編集するロットを選択"
+  "editLot": "編集するロットを選択",
+  "itemCountLabel": "{{count}}件",
+  "itemCountLabelFiltered": "{{filtered}} / {{total}}件"
 }

--- a/src/routes/_auth.index.tsx
+++ b/src/routes/_auth.index.tsx
@@ -43,7 +43,7 @@ const DashboardPage = () => {
   const filtered = items.filter((item) => {
     if (hideEmpty && item.units === 0) return false;
     if (expiryFilter && expiryFilter !== "all") {
-      const status = getExpiryStatus(item.expiry_date);
+      const status = getExpiryStatus(item.expiry_date, warningDays);
       if (status !== expiryFilter) return false;
     }
     return true;
@@ -67,7 +67,11 @@ const DashboardPage = () => {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold">{t("title")}</h1>
-          <p className="text-sm text-muted-foreground">{items.length}件</p>
+          <p className="text-sm text-muted-foreground">
+            {filtered.length === items.length
+              ? `${items.length}件`
+              : `${filtered.length} / ${items.length}件`}
+          </p>
         </div>
         <div className="flex items-center gap-2">
           <Link to="/items/new">

--- a/src/routes/_auth.index.tsx
+++ b/src/routes/_auth.index.tsx
@@ -69,8 +69,8 @@ const DashboardPage = () => {
           <h1 className="text-2xl font-bold">{t("title")}</h1>
           <p className="text-sm text-muted-foreground">
             {filtered.length === items.length
-              ? `${items.length}件`
-              : `${filtered.length} / ${items.length}件`}
+              ? t("itemCountLabel", { count: items.length })
+              : t("itemCountLabelFiltered", { filtered: filtered.length, total: items.length })}
           </p>
         </div>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## 概要

コードレビューで発見した5件のバグ修正と、PRのトレーサビリティ向上のためのCI追加。

Closes #172
Closes #174
Closes #175
Closes #176
Closes #177
Closes #179

---

## バグ修正

### #172 賞味期限フィルターがユーザー設定の警告日数を無視していた
- **ファイル**: `src/routes/_auth.index.tsx`
- **修正内容**: `getExpiryStatus(item.expiry_date)` → `getExpiryStatus(item.expiry_date, warningDays)` に変更
- urgentItems 計算では正しく `warningDays` を使用していたが、フィルター側が未使用だった

### #175 バーコードDBルックアップで画像パスが無視されていた
- **ファイル**: `src/hooks/useBarcodeLookup.ts`
- **修正内容**: ローカルDBヒット時に `image_path` を `product.image_url` として返却するよう追加
- `SELECT "name, image_path"` で取得済みだったが返却値に含まれていなかった

### #176 ダッシュボードのアイテム数がフィルター後の件数を反映していなかった
- **ファイル**: `src/routes/_auth.index.tsx`
- **修正内容**: フィルター適用時は「3 / 10件」形式で表示するよう変更

### #174 ショッピングリストのエラーハンドリング不備（OfflineError 以外が無言失敗）
- **ファイル**: `src/hooks/useShoppingList.ts`
- **修正内容**: `useUpsertShoppingItem` / `usePurchaseShoppingItem` の `onError` で OfflineError 以外のエラーも `unknownError` トーストを表示するよう修正

### #177 ItemCard の賞味期限表示でタイムゾーンにより日付が1日ずれる可能性
- **ファイル**: `src/components/molecules/ItemCard.tsx`
- **修正内容**: `new Date(item.expiry_date)` → `parseLocalDate(item.expiry_date)` に変更し、ローカルタイムとして解釈するよう修正
- `getExpiryStatus` と表示ロジックのタイムゾーン処理を統一

---

## 新機能

### #179 PRのIssueリンク必須化CI
- **ファイル**: `.github/workflows/pr-issue-link-check.yml`
- PR body に `Closes #NNN` / `Fixes #NNN` / `Resolves #NNN` がない場合にCIを失敗させる
- dependabot と `skip-issue-link` ラベル付きPRは除外

---

## テスト結果

- `bun test`: 114 pass / 0 fail ✅
- `bun run build`: ✅
- `bun run typecheck`: ✅
- `npx oxfmt --check .`: ✅

https://claude.ai/code/session_01PtPXMU73wKhy5BjxLvUPna

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtPXMU73wKhy5BjxLvUPna)_