### PR TITLE
fix: バグ修正5件 (i18n/エラーハンドリング/ロット更新)

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,8 +1,12 @@
 import type { Decorator, Preview } from "@storybook/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import i18n from "i18next";
 import "../src/index.css";
 import "../src/lib/i18n";
 import { ToastProvider } from "../src/lib/toast";
+
+// VRT を安定させるため Storybook では常に日本語で描画する
+void i18n.changeLanguage("ja");
 
 const withProviders: Decorator = (Story) => {
   const queryClient = new QueryClient({

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,12 +1,8 @@
 import type { Decorator, Preview } from "@storybook/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import i18n from "i18next";
 import "../src/index.css";
 import "../src/lib/i18n";
 import { ToastProvider } from "../src/lib/toast";
-
-// VRT を安定させるため Storybook では常に日本語で描画する
-void i18n.changeLanguage("ja");
 
 const withProviders: Decorator = (Story) => {
   const queryClient = new QueryClient({

--- a/src/components/molecules/ExpiryCheckItem.tsx
+++ b/src/components/molecules/ExpiryCheckItem.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import { ColorDot } from "@/components/atoms/ColorDot";
 import { cn } from "@/lib/utils";
@@ -12,6 +13,7 @@ interface ExpiryCheckItemProps {
 
 export const ExpiryCheckItem = ({ item, categoryColor, onCheck }: ExpiryCheckItemProps) => {
   const [checked, setChecked] = useState(false);
+  const { i18n } = useTranslation();
 
   const handleChange = async () => {
     if (checked) return;
@@ -26,10 +28,13 @@ export const ExpiryCheckItem = ({ item, categoryColor, onCheck }: ExpiryCheckIte
   const expiryLabel = (() => {
     if (!item.expiry_date) return "";
     const parts = item.expiry_date.slice(0, 10).split("-").map(Number);
-    return new Date(parts[0] ?? 0, (parts[1] ?? 1) - 1, parts[2] ?? 1).toLocaleDateString("ja-JP", {
-      month: "short",
-      day: "numeric",
-    });
+    return new Date(parts[0] ?? 0, (parts[1] ?? 1) - 1, parts[2] ?? 1).toLocaleDateString(
+      i18n.language,
+      {
+        month: "short",
+        day: "numeric",
+      },
+    );
   })();
 
   return (

--- a/src/components/pages/EditItemPage.tsx
+++ b/src/components/pages/EditItemPage.tsx
@@ -48,6 +48,7 @@ export const EditItemPage = ({ itemId }: EditItemPageProps) => {
           itemId,
           values: {
             units: values.units,
+            opened_remaining: values.opened_remaining ?? null,
             purchase_date: values.purchase_date ?? null,
             expiry_date: values.expiry_date ?? null,
           },

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -18,15 +18,15 @@ export type {
 } from "@/types/stats";
 
 export const useCategoryStats = () => {
-  const { data: items = [] } = useItems({}, "created_at");
+  const { data: items = [], isLoading, isError } = useItems({}, "created_at");
   const { data: categories = [] } = useCategories();
   const categoryMap = Object.fromEntries(categories.map((c) => [c.id, c.name]));
-  return computeCategoryStats(items, categoryMap);
+  return { stats: computeCategoryStats(items, categoryMap), isLoading, isError };
 };
 
 export const useExpiryDistribution = (warningDays?: number) => {
-  const { data: items = [] } = useItems({}, "created_at");
-  return computeExpiryDistribution(items, warningDays);
+  const { data: items = [], isLoading, isError } = useItems({}, "created_at");
+  return { distribution: computeExpiryDistribution(items, warningDays), isLoading, isError };
 };
 
 export const useAllConsumptionLogs = () =>

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -18,10 +18,22 @@ export type {
 } from "@/types/stats";
 
 export const useCategoryStats = () => {
-  const { data: items = [], isLoading, isError } = useItems({}, "created_at");
-  const { data: categories = [] } = useCategories();
+  const {
+    data: items = [],
+    isLoading: itemsLoading,
+    isError: itemsError,
+  } = useItems({}, "created_at");
+  const {
+    data: categories = [],
+    isLoading: categoriesLoading,
+    isError: categoriesError,
+  } = useCategories();
   const categoryMap = Object.fromEntries(categories.map((c) => [c.id, c.name]));
-  return { stats: computeCategoryStats(items, categoryMap), isLoading, isError };
+  return {
+    stats: computeCategoryStats(items, categoryMap),
+    isLoading: itemsLoading || categoriesLoading,
+    isError: itemsError || categoriesError,
+  };
 };
 
 export const useExpiryDistribution = (warningDays?: number) => {
@@ -44,6 +56,6 @@ export const useAllConsumptionLogs = () =>
   });
 
 export const useMonthlyConsumption = (months = 6) => {
-  const { data: logs = [] } = useAllConsumptionLogs();
-  return computeMonthlyConsumption(logs, months);
+  const { data: logs = [], isLoading, isError } = useAllConsumptionLogs();
+  return { data: computeMonthlyConsumption(logs, months), isLoading, isError };
 };

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -11,6 +11,7 @@
   "masterData": "Master Data",
   "notifications": "Notification Settings",
   "saveSuccess": "Settings saved",
+  "daysBefore": "days before",
   "addCategory": "Add Category",
   "editCategory": "Edit Category",
   "addLocation": "Add Location",

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -11,6 +11,7 @@
   "masterData": "マスタデータ",
   "notifications": "通知設定",
   "saveSuccess": "設定を保存しました",
+  "daysBefore": "日前",
   "addCategory": "カテゴリを追加",
   "editCategory": "カテゴリを編集",
   "addLocation": "保管場所を追加",

--- a/src/routes/_auth.calendar.tsx
+++ b/src/routes/_auth.calendar.tsx
@@ -7,7 +7,7 @@ import { CalendarPage } from "@/components/pages/CalendarPage";
 import { LOTS_KEY, syncItemAggregate } from "@/hooks/useItemLots";
 import { useItemsWithExpiry } from "@/hooks/useItems";
 import { useCategories } from "@/hooks/useMasterData";
-import { OfflineError } from "@/lib/requireOnline";
+import { OfflineError, requireOnline } from "@/lib/requireOnline";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/lib/toast-context";
 import type { Item } from "@/types/item";
@@ -30,6 +30,7 @@ const CalendarRoutePage = () => {
 
   const handleCheck = async (item: Item) => {
     try {
+      requireOnline();
       const { data: lots, error } = await supabase
         .from("item_lots")
         .select("id, units, opened_remaining, expiry_date")
@@ -81,6 +82,7 @@ const CalendarRoutePage = () => {
 
   const handleUndo = async (itemId: string) => {
     try {
+      requireOnline();
       const pending = pendingRemovals[itemId];
       if (!pending) return;
       const { error } = await supabase
@@ -105,7 +107,6 @@ const CalendarRoutePage = () => {
       });
     } catch (err) {
       toast(err instanceof OfflineError ? t("offlineError") : t("unknownError"), "error");
-      throw err;
     }
   };
 

--- a/src/routes/_auth.calendar.tsx
+++ b/src/routes/_auth.calendar.tsx
@@ -1,12 +1,15 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import { CalendarPage } from "@/components/pages/CalendarPage";
 import { LOTS_KEY, syncItemAggregate } from "@/hooks/useItemLots";
 import { useItemsWithExpiry } from "@/hooks/useItems";
 import { useCategories } from "@/hooks/useMasterData";
+import { OfflineError } from "@/lib/requireOnline";
 import { supabase } from "@/lib/supabase";
+import { useToast } from "@/lib/toast-context";
 import type { Item } from "@/types/item";
 
 interface PendingLotRemoval {
@@ -22,76 +25,88 @@ const CalendarRoutePage = () => {
   const { data: items = [], isLoading } = useItemsWithExpiry();
   const { data: categories = [] } = useCategories();
   const [pendingRemovals, setPendingRemovals] = useState<Record<string, PendingLotRemoval>>({});
+  const { toast } = useToast();
+  const { t } = useTranslation("common");
 
   const handleCheck = async (item: Item) => {
-    const { data: lots, error } = await supabase
-      .from("item_lots")
-      .select("id, units, opened_remaining, expiry_date")
-      .eq("item_id", item.id)
-      .order("expiry_date", { ascending: true, nullsFirst: false })
-      .order("created_at", { ascending: true });
-    if (error) throw error;
+    try {
+      const { data: lots, error } = await supabase
+        .from("item_lots")
+        .select("id, units, opened_remaining, expiry_date")
+        .eq("item_id", item.id)
+        .order("expiry_date", { ascending: true, nullsFirst: false })
+        .order("created_at", { ascending: true });
+      if (error) throw error;
 
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const monthEnd = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const monthEnd = new Date(today.getFullYear(), today.getMonth() + 1, 0);
 
-    const targetLot = (lots ?? []).find((lot) => {
-      if (lot.units <= 0 && lot.opened_remaining === null) return false;
-      if (!lot.expiry_date) return false;
-      const [y, m, d] = lot.expiry_date.split("-").map(Number) as [number, number, number];
-      const exp = new Date(y, m - 1, d);
-      return exp <= monthEnd;
-    });
+      const targetLot = (lots ?? []).find((lot) => {
+        if (lot.units <= 0 && lot.opened_remaining === null) return false;
+        if (!lot.expiry_date) return false;
+        const [y, m, d] = lot.expiry_date.split("-").map(Number) as [number, number, number];
+        const exp = new Date(y, m - 1, d);
+        return exp <= monthEnd;
+      });
 
-    if (!targetLot) return;
+      if (!targetLot) return;
 
-    const { error: updateError } = await supabase
-      .from("item_lots")
-      .update({ units: 0, opened_remaining: null, updated_at: new Date().toISOString() })
-      .eq("id", targetLot.id);
-    if (updateError) throw updateError;
+      const { error: updateError } = await supabase
+        .from("item_lots")
+        .update({ units: 0, opened_remaining: null, updated_at: new Date().toISOString() })
+        .eq("id", targetLot.id);
+      if (updateError) throw updateError;
 
-    await syncItemAggregate(item.id);
-    await Promise.all([
-      qc.invalidateQueries({ queryKey: ["items"] }),
-      qc.invalidateQueries({ queryKey: [...LOTS_KEY, item.id] }),
-    ]);
-    setPendingRemovals((prev) => ({
-      ...prev,
-      [item.id]: {
-        lotId: targetLot.id,
-        itemId: item.id,
-        itemName: item.name,
-        units: targetLot.units,
-        openedRemaining: targetLot.opened_remaining,
-      },
-    }));
+      await syncItemAggregate(item.id);
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ["items"] }),
+        qc.invalidateQueries({ queryKey: [...LOTS_KEY, item.id] }),
+      ]);
+      setPendingRemovals((prev) => ({
+        ...prev,
+        [item.id]: {
+          lotId: targetLot.id,
+          itemId: item.id,
+          itemName: item.name,
+          units: targetLot.units,
+          openedRemaining: targetLot.opened_remaining,
+        },
+      }));
+    } catch (err) {
+      toast(err instanceof OfflineError ? t("offlineError") : t("unknownError"), "error");
+      throw err;
+    }
   };
 
   const handleUndo = async (itemId: string) => {
-    const pending = pendingRemovals[itemId];
-    if (!pending) return;
-    const { error } = await supabase
-      .from("item_lots")
-      .update({
-        units: pending.units,
-        opened_remaining: pending.openedRemaining,
-        updated_at: new Date().toISOString(),
-      })
-      .eq("id", pending.lotId);
-    if (error) throw error;
+    try {
+      const pending = pendingRemovals[itemId];
+      if (!pending) return;
+      const { error } = await supabase
+        .from("item_lots")
+        .update({
+          units: pending.units,
+          opened_remaining: pending.openedRemaining,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", pending.lotId);
+      if (error) throw error;
 
-    await syncItemAggregate(pending.itemId);
-    await Promise.all([
-      qc.invalidateQueries({ queryKey: ["items"] }),
-      qc.invalidateQueries({ queryKey: [...LOTS_KEY, pending.itemId] }),
-    ]);
-    setPendingRemovals((prev) => {
-      const next = { ...prev };
-      delete next[itemId];
-      return next;
-    });
+      await syncItemAggregate(pending.itemId);
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: ["items"] }),
+        qc.invalidateQueries({ queryKey: [...LOTS_KEY, pending.itemId] }),
+      ]);
+      setPendingRemovals((prev) => {
+        const next = { ...prev };
+        delete next[itemId];
+        return next;
+      });
+    } catch (err) {
+      toast(err instanceof OfflineError ? t("offlineError") : t("unknownError"), "error");
+      throw err;
+    }
   };
 
   return (

--- a/src/routes/_auth.settings.tsx
+++ b/src/routes/_auth.settings.tsx
@@ -96,7 +96,7 @@ const SettingsPage = () => {
                   void handleWarningDaysChange(parseInt(e.target.value, 10));
                 }}
               />
-              <Label>日前</Label>
+              <Label>{t("daysBefore")}</Label>
             </div>
           </section>
 

--- a/src/routes/_auth.stats.tsx
+++ b/src/routes/_auth.stats.tsx
@@ -19,10 +19,14 @@ const StatsPage = () => {
     isLoading: expiryLoading,
     isError: expiryError,
   } = useExpiryDistribution(userSettings?.expiry_warning_days);
-  const monthlyData = useMonthlyConsumption(6);
+  const {
+    data: monthlyData,
+    isLoading: monthlyLoading,
+    isError: monthlyError,
+  } = useMonthlyConsumption(6);
 
-  const isLoading = categoryLoading || expiryLoading;
-  const isError = categoryError || expiryError;
+  const isLoading = categoryLoading || expiryLoading || monthlyLoading;
+  const isError = categoryError || expiryError || monthlyError;
 
   if (isLoading) {
     return (

--- a/src/routes/_auth.stats.tsx
+++ b/src/routes/_auth.stats.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 
+import { Spinner } from "@/components/atoms/Spinner";
 import { CategoryChart } from "@/components/organisms/CategoryChart";
 import { ConsumptionChart } from "@/components/organisms/ConsumptionChart";
 import { ExpiryChart } from "@/components/organisms/ExpiryChart";
@@ -10,10 +11,35 @@ import { useUserSettings } from "@/hooks/useUserSettings";
 
 const StatsPage = () => {
   const { t } = useTranslation("stats");
-  const stats = useCategoryStats();
+  const { t: tc } = useTranslation("common");
+  const { stats, isLoading: categoryLoading, isError: categoryError } = useCategoryStats();
   const { data: userSettings } = useUserSettings();
-  const distribution = useExpiryDistribution(userSettings?.expiry_warning_days);
+  const {
+    distribution,
+    isLoading: expiryLoading,
+    isError: expiryError,
+  } = useExpiryDistribution(userSettings?.expiry_warning_days);
   const monthlyData = useMonthlyConsumption(6);
+
+  const isLoading = categoryLoading || expiryLoading;
+  const isError = categoryError || expiryError;
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-destructive p-4 text-destructive">
+        <p className="font-medium">{tc("error")}</p>
+        <p className="text-sm text-muted-foreground">{tc("unknownError")}</p>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-4">


### PR DESCRIPTION
## 概要

コードレビューで発見した5件のバグ修正。

Closes #184
Closes #185
Closes #186
Closes #187
Closes #188

---

## バグ修正

### #184 EditItemPage: 複数ロット編集時に opened_remaining が保存されない
- **ファイル**: `src/components/pages/EditItemPage.tsx`
- **修正内容**: `updateLot.mutateAsync` の `values` に `opened_remaining: values.opened_remaining ?? null` を追加
- `useUpdateLot` フックは `opened_remaining` をサポート済みだったが、呼び出し側が渡していなかった

### #185 設定画面の「日前」ラベルが i18n 未対応
- **ファイル**: `src/routes/_auth.settings.tsx`, `src/locales/en/settings.json`, `src/locales/ja/settings.json`
- **修正内容**: ハードコードされた `<Label>日前</Label>` を `<Label>{t("daysBefore")}</Label>` に変更し、両ロケールに `"daysBefore"` キーを追加（ja: `"日前"`, en: `"days before"`）

### #186 ExpiryCheckItem の日付ロケールが「ja-JP」ハードコード
- **ファイル**: `src/components/molecules/ExpiryCheckItem.tsx`
- **修正内容**: `toLocaleDateString("ja-JP", ...)` を `toLocaleDateString(i18n.language, ...)` に変更
- `useTranslation` を import して `i18n.language` を取得するよう修正

### #187 Stats 画面でデータ読み込み中・エラー時の表示状態がない
- **ファイル**: `src/hooks/useStats.ts`, `src/routes/_auth.stats.tsx`
- **修正内容**:
  - `useCategoryStats` / `useExpiryDistribution` が `{ stats/distribution, isLoading, isError }` を返すよう変更
  - Stats 画面で `isLoading` 時に `Spinner`、`isError` 時にエラーメッセージを表示

### #188 Calendar の onCheck/onUndo エラーがユーザーに通知されない
- **ファイル**: `src/routes/_auth.calendar.tsx`
- **修正内容**: `handleCheck` / `handleUndo` を try-catch で囲み、エラー時に `useToast` でトーストを表示
- `OfflineError` の場合は `offlineError`、それ以外は `unknownError` トーストを表示

---

## テスト結果

- `bun test`: 114 pass / 0 fail ✅
- `bun run build`: ✅
- `bun run typecheck`: ✅
- `npx oxfmt .`: ✅

https://claude.ai/code/session_011wE1rHn6S5hPr7nCj6D5Rx

---
_Generated by [Claude Code](https://claude.ai/code/session_011wE1rHn6S5hPr7nCj6D5Rx)_