### PR TITLE
fix: バグ修正8件 (i18n/エラーハンドリング/バリデーション/FABパディング)

### DIFF
--- a/src/components/molecules/ExpiryCheckItem.tsx
+++ b/src/components/molecules/ExpiryCheckItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { ColorDot } from "@/components/atoms/ColorDot";
@@ -14,14 +14,18 @@ interface ExpiryCheckItemProps {
 export const ExpiryCheckItem = ({ item, categoryColor, onCheck }: ExpiryCheckItemProps) => {
   const [checked, setChecked] = useState(false);
   const { i18n } = useTranslation();
+  const isProcessingRef = useRef(false);
 
   const handleChange = async () => {
-    if (checked) return;
+    if (checked || isProcessingRef.current) return;
+    isProcessingRef.current = true;
     setChecked(true);
     try {
       await onCheck(item);
     } catch {
       setChecked(false);
+    } finally {
+      isProcessingRef.current = false;
     }
   };
 

--- a/src/components/molecules/QuickAddSelect.tsx
+++ b/src/components/molecules/QuickAddSelect.tsx
@@ -1,5 +1,6 @@
 import { Check, ChevronDown, Loader2, Plus, X } from "lucide-react";
 import { type KeyboardEvent, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -28,14 +29,20 @@ export const QuickAddSelect = ({
   value,
   onChange,
   options,
-  placeholder = "選択",
+  placeholder,
   onAdd,
   onDelete,
-  addLabel = "追加",
-  confirmLabel = "確認",
-  cancelLabel = "キャンセル",
-  addErrorMessage = "追加に失敗しました",
+  addLabel,
+  confirmLabel,
+  cancelLabel,
+  addErrorMessage,
 }: QuickAddSelectProps) => {
+  const { t } = useTranslation();
+  const resolvedPlaceholder = placeholder ?? t("common:select");
+  const resolvedAddLabel = addLabel ?? t("common:add");
+  const resolvedConfirmLabel = confirmLabel ?? t("common:confirm");
+  const resolvedCancelLabel = cancelLabel ?? t("common:cancel");
+  const resolvedAddErrorMessage = addErrorMessage ?? t("items:addError");
   const [isOpen, setIsOpen] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState("");
@@ -90,7 +97,7 @@ export const QuickAddSelect = ({
       setInputValue("");
       setIsOpen(false);
     } catch {
-      setAddError(addErrorMessage);
+      setAddError(resolvedAddErrorMessage);
     } finally {
       setIsAdding(false);
     }
@@ -116,7 +123,7 @@ export const QuickAddSelect = ({
         onChange("");
       }
     } catch (err) {
-      setDeleteError(err instanceof Error ? err.message : "削除できません");
+      setDeleteError(err instanceof Error ? err.message : t("common:unknownError"));
     } finally {
       setDeletingId(null);
     }
@@ -137,7 +144,7 @@ export const QuickAddSelect = ({
         aria-expanded={isOpen}
       >
         <span className={selectedOption ? "text-foreground" : "text-muted-foreground"}>
-          {selectedOption?.label ?? placeholder}
+          {selectedOption?.label ?? resolvedPlaceholder}
         </span>
         <ChevronDown
           className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${isOpen ? "rotate-180" : ""}`}
@@ -155,7 +162,7 @@ export const QuickAddSelect = ({
               className={`w-full px-3 py-2 text-left text-sm text-muted-foreground hover:bg-accent ${!value ? "bg-accent/50 font-medium" : ""}`}
               onClick={() => handleSelect("")}
             >
-              {placeholder}
+              {resolvedPlaceholder}
             </button>
 
             {options.map((option) => (
@@ -176,7 +183,7 @@ export const QuickAddSelect = ({
                     className="mr-2 shrink-0 rounded p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive disabled:opacity-40"
                     onClick={(e) => void handleDelete(e, option.value)}
                     disabled={!!deletingId}
-                    aria-label="削除"
+                    aria-label={t("common:delete")}
                   >
                     {deletingId === option.value ? (
                       <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -204,7 +211,7 @@ export const QuickAddSelect = ({
                     value={inputValue}
                     onChange={(e) => setInputValue(e.target.value)}
                     onKeyDown={handleKeyDown}
-                    placeholder={addLabel}
+                    placeholder={resolvedAddLabel}
                     className="h-8 flex-1 text-base sm:text-sm"
                     disabled={isAdding}
                   />
@@ -215,7 +222,7 @@ export const QuickAddSelect = ({
                     className="h-8 w-8 shrink-0"
                     onClick={() => void handleConfirmAdd()}
                     disabled={isAdding || !inputValue.trim()}
-                    aria-label={confirmLabel}
+                    aria-label={resolvedConfirmLabel}
                   >
                     {isAdding ? (
                       <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -230,7 +237,7 @@ export const QuickAddSelect = ({
                     className="h-8 w-8 shrink-0"
                     onClick={handleCancelAdd}
                     disabled={isAdding}
-                    aria-label={cancelLabel}
+                    aria-label={resolvedCancelLabel}
                   >
                     <X className="h-3.5 w-3.5" />
                   </Button>
@@ -244,7 +251,7 @@ export const QuickAddSelect = ({
                 onClick={handleOpenAdd}
               >
                 <Plus className="h-3.5 w-3.5" />
-                {addLabel}
+                {resolvedAddLabel}
               </button>
             )}
           </div>

--- a/src/components/organisms/BarcodeScanner.tsx
+++ b/src/components/organisms/BarcodeScanner.tsx
@@ -115,7 +115,7 @@ export const BarcodeScanner = ({ onScan, onClose }: BarcodeScannerProps) => {
       cancelled = true;
       controlsRef.current?.stop();
     };
-  }, [startScanning]);
+  }, [startScanning, t]);
 
   const handleSwitchCamera = () => {
     if (devices.length <= 1) return;

--- a/src/components/organisms/BarcodeScanner.tsx
+++ b/src/components/organisms/BarcodeScanner.tsx
@@ -49,11 +49,11 @@ export const BarcodeScanner = ({ onScan, onClose }: BarcodeScannerProps) => {
         controlsRef.current = controls;
         setIsStarting(false);
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Camera access denied");
+        setError(err instanceof Error ? err.message : t("scannerCameraAccessDenied"));
         setIsStarting(false);
       }
     },
-    [onScan],
+    [onScan, t],
   );
 
   useEffect(() => {
@@ -103,7 +103,7 @@ export const BarcodeScanner = ({ onScan, onClose }: BarcodeScannerProps) => {
         }
       } catch (err) {
         if (!cancelled) {
-          setError(err instanceof Error ? err.message : "Camera access denied");
+          setError(err instanceof Error ? err.message : t("scannerCameraAccessDenied"));
           setIsStarting(false);
         }
       }

--- a/src/components/organisms/ExpiryCalendar.tsx
+++ b/src/components/organisms/ExpiryCalendar.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import { ColorDot } from "@/components/atoms/ColorDot";
 import { Button } from "@/components/ui/button";
@@ -21,22 +22,8 @@ const getFirstDayOfMonth = (year: number, month: number) => new Date(year, month
 const toDateKey = (date: Date) =>
   `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
 
-const MONTH_LABELS = [
-  "1月",
-  "2月",
-  "3月",
-  "4月",
-  "5月",
-  "6月",
-  "7月",
-  "8月",
-  "9月",
-  "10月",
-  "11月",
-  "12月",
-];
-
 export const ExpiryCalendar = ({ items, categories, labels }: ExpiryCalendarProps) => {
+  const { i18n, t } = useTranslation("calendar");
   const today = new Date();
   const [year, setYear] = useState(today.getFullYear());
   const [month, setMonth] = useState(today.getMonth());
@@ -44,6 +31,14 @@ export const ExpiryCalendar = ({ items, categories, labels }: ExpiryCalendarProp
   const [pickerYear, setPickerYear] = useState(today.getFullYear());
   const [selectedDateKey, setSelectedDateKey] = useState<string | null>(null);
   const pickerRef = useRef<HTMLDivElement>(null);
+
+  const monthLabels = Array.from({ length: 12 }, (_, i) =>
+    new Date(2000, i, 1).toLocaleDateString(i18n.language, { month: "short" }),
+  );
+  // Jan 4, 1970 (Unix epoch + 3 days) was a Sunday
+  const dayLabels = Array.from({ length: 7 }, (_, i) =>
+    new Date(1970, 0, 4 + i).toLocaleDateString(i18n.language, { weekday: "narrow" }),
+  );
 
   const prevMonth = () => {
     if (month === 0) {
@@ -91,23 +86,24 @@ export const ExpiryCalendar = ({ items, categories, labels }: ExpiryCalendarProp
   const todayKey = toDateKey(today);
   const selectedItems = selectedDateKey ? (itemsByDate.get(selectedDateKey) ?? []) : [];
 
-  const DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"];
-
   return (
     <div className="rounded-lg border bg-background p-3">
       {/* Header */}
       <div className="relative mb-3 flex items-center justify-between">
-        <Button variant="ghost" size="icon" onClick={prevMonth} aria-label="前の月">
+        <Button variant="ghost" size="icon" onClick={prevMonth} aria-label={t("prevMonth")}>
           <ChevronLeft className="h-4 w-4" />
         </Button>
         <button
           className="rounded px-2 py-1 text-sm font-semibold hover:bg-muted"
           onClick={openPicker}
-          aria-label="年月を選択"
+          aria-label={t("selectYearMonth")}
         >
-          {year}年{month + 1}月
+          {new Date(year, month, 1).toLocaleDateString(i18n.language, {
+            year: "numeric",
+            month: "long",
+          })}
         </button>
-        <Button variant="ghost" size="icon" onClick={nextMonth} aria-label="次の月">
+        <Button variant="ghost" size="icon" onClick={nextMonth} aria-label={t("nextMonth")}>
           <ChevronRight className="h-4 w-4" />
         </Button>
 
@@ -130,24 +126,28 @@ export const ExpiryCalendar = ({ items, categories, labels }: ExpiryCalendarProp
                   size="icon"
                   className="h-7 w-7"
                   onClick={() => setPickerYear((y) => y - 1)}
-                  aria-label="前の年"
+                  aria-label={t("prevYear")}
                 >
                   <ChevronLeft className="h-3 w-3" />
                 </Button>
-                <span className="text-sm font-semibold">{pickerYear}年</span>
+                <span className="text-sm font-semibold">
+                  {new Date(pickerYear, 0, 1).toLocaleDateString(i18n.language, {
+                    year: "numeric",
+                  })}
+                </span>
                 <Button
                   variant="ghost"
                   size="icon"
                   className="h-7 w-7"
                   onClick={() => setPickerYear((y) => y + 1)}
-                  aria-label="次の年"
+                  aria-label={t("nextYear")}
                 >
                   <ChevronRight className="h-3 w-3" />
                 </Button>
               </div>
               {/* Month grid */}
               <div className="grid grid-cols-4 gap-1">
-                {MONTH_LABELS.map((label, i) => (
+                {monthLabels.map((label, i) => (
                   <button
                     key={label}
                     className={`rounded py-1.5 text-xs font-medium transition-colors ${
@@ -168,9 +168,9 @@ export const ExpiryCalendar = ({ items, categories, labels }: ExpiryCalendarProp
 
       {/* Day labels */}
       <div className="mb-1 grid grid-cols-7 text-center">
-        {DAY_LABELS.map((d, i) => (
+        {dayLabels.map((d, i) => (
           <div
-            key={d}
+            key={i}
             className={`text-xs font-medium ${i === 0 ? "text-red-500" : i === 6 ? "text-blue-500" : "text-muted-foreground"}`}
           >
             {d}

--- a/src/components/organisms/ItemForm.tsx
+++ b/src/components/organisms/ItemForm.tsx
@@ -123,6 +123,7 @@ export const ItemForm = ({
     } catch {
       setLookupResult(null);
       toast(t("barcodeLookupError"), "error");
+      onBarcodeScanned?.(barcode, null);
     }
   };
 

--- a/src/components/organisms/ItemForm.tsx
+++ b/src/components/organisms/ItemForm.tsx
@@ -23,6 +23,7 @@ import {
   useDeleteStorageLocation,
   useStorageLocations,
 } from "@/hooks/useMasterData";
+import { useToast } from "@/lib/toast-context";
 import { CONTENT_UNITS, type ItemFormValues } from "@/types/item";
 
 interface ItemFormProps {
@@ -47,6 +48,7 @@ export const ItemForm = ({
 }: ItemFormProps) => {
   const { t } = useTranslation("items");
   const { t: ts } = useTranslation("settings");
+  const { toast } = useToast();
   const { data: categories = [] } = useCategories();
   const { data: locations = [] } = useStorageLocations();
   const { lookup, isLoading: isLookingUp, error: lookupError } = useBarcodeLookup();
@@ -105,18 +107,23 @@ export const ItemForm = ({
     setLookupResult(undefined);
     setLookupSource(null);
     if (navigator.vibrate) navigator.vibrate(100);
-    const result = await lookup(barcode);
-    setLookupResult(result.product);
-    setLookupSource(result.source);
-    if (result.product?.name) set("name", result.product.name);
-    if (result.product?.image_url && !localPreviewUrl) {
-      setBarcodeImageUrl(result.product.image_url);
-      // DB ヒット時は既にStorage済みの画像なので再アップロード不要。プレビュー表示のみ。
-      if (result.source !== "db") {
-        onPendingImageUrlChange?.(result.product.image_url);
+    try {
+      const result = await lookup(barcode);
+      setLookupResult(result.product);
+      setLookupSource(result.source);
+      if (result.product?.name) set("name", result.product.name);
+      if (result.product?.image_url && !localPreviewUrl) {
+        setBarcodeImageUrl(result.product.image_url);
+        // DB ヒット時は既にStorage済みの画像なので再アップロード不要。プレビュー表示のみ。
+        if (result.source !== "db") {
+          onPendingImageUrlChange?.(result.product.image_url);
+        }
       }
+      onBarcodeScanned?.(barcode, result.source);
+    } catch {
+      setLookupResult(null);
+      toast(t("barcodeLookupError"), "error");
     }
-    onBarcodeScanned?.(barcode, result.source);
   };
 
   const handleAddCategory = async (name: string) => {
@@ -323,7 +330,7 @@ export const ItemForm = ({
               }}
               className="w-24"
             />
-            <span className="text-sm text-muted-foreground">点</span>
+            <span className="text-sm text-muted-foreground">{t("unitsLabel")}</span>
           </div>
           {unitsError && <p className="text-sm text-destructive">{unitsError}</p>}
         </div>

--- a/src/components/organisms/NotificationSettings.tsx
+++ b/src/components/organisms/NotificationSettings.tsx
@@ -63,8 +63,13 @@ export const NotificationSettings = () => {
   };
 
   const handleEmailAddressBlur = async (address: string) => {
+    const trimmed = address.trim();
+    if (trimmed && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+      toast(t("invalidEmailAddress"), "error");
+      return;
+    }
     try {
-      await updatePrefs.mutateAsync({ email_address: address.trim() || null });
+      await updatePrefs.mutateAsync({ email_address: trimmed || null });
     } catch {
       toast(t("common:unknownError"), "error");
     }

--- a/src/locales/en/calendar.json
+++ b/src/locales/en/calendar.json
@@ -14,5 +14,10 @@
   "noItemsOnDate": "No items expiring on this date",
   "expiryItemsOnDate": "Items expiring on {{date}}",
   "undo": "Undo",
-  "pendingRemovalMessage": "You can undo removed lots"
+  "pendingRemovalMessage": "You can undo removed lots",
+  "prevMonth": "Previous month",
+  "nextMonth": "Next month",
+  "selectYearMonth": "Select year and month",
+  "prevYear": "Previous year",
+  "nextYear": "Next year"
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -32,5 +32,6 @@
   "unknownError": "An error occurred",
   "offlineError": "Cannot perform this action while offline",
   "enabled": "Enabled",
-  "disabled": "Disabled"
+  "disabled": "Disabled",
+  "select": "Select"
 }

--- a/src/locales/en/items.json
+++ b/src/locales/en/items.json
@@ -44,6 +44,8 @@
   "scannerHint": "Point the camera at a barcode to scan",
   "scannerError": "Camera Error",
   "scannerRetry": "Retry",
+  "scannerCameraAccessDenied": "Camera access denied",
+  "barcodeLookupError": "Failed to retrieve product information",
   "scannerManualInput": "Manual Input",
   "scannerManualPlaceholder": "Type barcode and press Enter",
   "scannerSwitchCamera": "Switch Camera",
@@ -57,6 +59,7 @@
     "unknown": "No Expiry"
   },
   "totalAmount": "Total",
+  "unitsLabel": "items",
   "unitsDisplay": "{{units}} units",
   "remainingDisplay": "({{amount}}{{unit}} left)",
   "emptyStock": "Used up",

--- a/src/locales/en/notifications.json
+++ b/src/locales/en/notifications.json
@@ -8,5 +8,6 @@
   "thresholdDays": "Days before to notify",
   "daysBefore": "days",
   "notifyAt": "Notification time",
-  "saveSuccess": "Notification settings saved"
+  "saveSuccess": "Notification settings saved",
+  "invalidEmailAddress": "Please enter a valid email address"
 }

--- a/src/locales/ja/calendar.json
+++ b/src/locales/ja/calendar.json
@@ -14,5 +14,10 @@
   "noItemsOnDate": "この日に期限を迎えるアイテムはありません",
   "expiryItemsOnDate": "{{date}} の期限アイテム",
   "undo": "取り消す",
-  "pendingRemovalMessage": "削除したロットを取り消せます"
+  "pendingRemovalMessage": "削除したロットを取り消せます",
+  "prevMonth": "前の月",
+  "nextMonth": "次の月",
+  "selectYearMonth": "年月を選択",
+  "prevYear": "前の年",
+  "nextYear": "次の年"
 }

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -32,5 +32,6 @@
   "unknownError": "エラーが発生しました",
   "offlineError": "オフラインのため操作できません",
   "enabled": "有効",
-  "disabled": "無効"
+  "disabled": "無効",
+  "select": "選択"
 }

--- a/src/locales/ja/items.json
+++ b/src/locales/ja/items.json
@@ -44,6 +44,8 @@
   "scannerHint": "バーコードにカメラを向けてください",
   "scannerError": "カメラエラー",
   "scannerRetry": "再試行",
+  "scannerCameraAccessDenied": "カメラへのアクセスが拒否されました",
+  "barcodeLookupError": "商品情報の取得に失敗しました",
   "scannerManualInput": "手動入力",
   "scannerManualPlaceholder": "バーコードを入力して確定",
   "scannerSwitchCamera": "カメラを切り替え",
@@ -57,6 +59,7 @@
     "unknown": "期限不明"
   },
   "totalAmount": "総量",
+  "unitsLabel": "点",
   "unitsDisplay": "{{units}}点",
   "remainingDisplay": "(残: {{amount}}{{unit}})",
   "emptyStock": "使い切り",

--- a/src/locales/ja/notifications.json
+++ b/src/locales/ja/notifications.json
@@ -8,5 +8,6 @@
   "thresholdDays": "通知する日数前",
   "daysBefore": "日前",
   "notifyAt": "通知時刻",
-  "saveSuccess": "通知設定を保存しました"
+  "saveSuccess": "通知設定を保存しました",
+  "invalidEmailAddress": "有効なメールアドレスを入力してください"
 }

--- a/src/routes/_auth.tsx
+++ b/src/routes/_auth.tsx
@@ -99,7 +99,7 @@ const AuthLayout = () => {
 
       {/* Page content */}
       <main className="flex-1 lg:pl-64">
-        <div className="mx-auto max-w-4xl px-4 py-6">
+        <div className="mx-auto max-w-4xl px-4 pt-6 pb-24 lg:py-6">
           <Outlet />
         </div>
       </main>


### PR DESCRIPTION
## 概要

コードレビューで発見した8件のバグ修正。

Closes #193
Closes #194
Closes #195
Closes #196
Closes #197
Closes #198
Closes #199
Closes #112

---

## バグ修正

### #193 ItemForm の「点」ラベルが i18n 未対応
- **ファイル**: `src/components/organisms/ItemForm.tsx`, `src/locales/{ja,en}/items.json`
- **修正内容**: `<span>点</span>` → `<span>{t("unitsLabel")}</span>` に変更し、両ロケールに `"unitsLabel"` キーを追加（ja: `"点"`, en: `"items"`）

### #194 QuickAddSelect の props デフォルト値がすべて日本語ハードコード
- **ファイル**: `src/components/molecules/QuickAddSelect.tsx`, `src/locales/{ja,en}/common.json`
- **修正内容**: 
  - `useTranslation()` を追加し、デストラクチャ時のデフォルト値を削除
  - 関数本体で `resolved*` 変数として `?? t("common:...")` にフォールバック
  - 削除エラー文字列「削除できません」も `t("common:unknownError")` に変更
  - 削除ボタンの `aria-label="削除"` も `t("common:delete")` に変更
  - `"select"` キーを common.json に追加（ja: `"選択"`, en: `"Select"`）

### #195 BarcodeScanner のカメラエラーメッセージが英語ハードコード
- **ファイル**: `src/components/organisms/BarcodeScanner.tsx`, `src/locales/{ja,en}/items.json`
- **修正内容**: フォールバック文字列 `"Camera access denied"` → `t("scannerCameraAccessDenied")` に変更（2箇所）
- `useCallback` の依存配列に `t` を追加

### #196 ItemForm の handleBarcodeScan で lookup 失敗時に例外がキャッチされない
- **ファイル**: `src/components/organisms/ItemForm.tsx`
- **修正内容**: `await lookup(barcode)` を try-catch で囲み、失敗時に `setLookupResult(null)` + `toast(t("barcodeLookupError"), "error")` を表示
- `useToast` を import し `toast` を利用可能に

### #197 ExpiryCalendar の月名（MONTH_LABELS）が日本語ハードコード
- **ファイル**: `src/components/organisms/ExpiryCalendar.tsx`, `src/locales/{ja,en}/calendar.json`
- **修正内容**:
  - ハードコードされた `MONTH_LABELS`・`DAY_LABELS` 配列を削除
  - `useTranslation("calendar")` を追加し、Intl API で動的生成:
    ```ts
    const monthLabels = Array.from({ length: 12 }, (_, i) =>
      new Date(2000, i, 1).toLocaleDateString(i18n.language, { month: "short" })
    );
    const dayLabels = Array.from({ length: 7 }, (_, i) =>
      new Date(1970, 0, 4 + i).toLocaleDateString(i18n.language, { weekday: "narrow" })
    );
    ```
  - 年月ヘッダー `{year}年{month + 1}月` → `Intl.DateTimeFormat` で locale-aware に変更
  - aria-label の日本語ハードコードを `t("prevMonth")` 等に変更
  - calendar.json に `prevMonth`, `nextMonth`, `selectYearMonth`, `prevYear`, `nextYear` を追加
  - 曜日の重複キー問題（英語で "S", "T" が重複）を `key={i}` に変更して解消

### #198 ExpiryCheckItem で非同期処理中の二重送信防止がない
- **ファイル**: `src/components/molecules/ExpiryCheckItem.tsx`
- **修正内容**: `useRef` で `isProcessingRef` を追加し、レンダリングサイクルに依存しない処理中フラグで二重送信を防止
  ```ts
  const isProcessingRef = useRef(false);
  if (checked || isProcessingRef.current) return;
  isProcessingRef.current = true;
  // ... finally: isProcessingRef.current = false;
  ```

### #199 NotificationSettings のメールアドレス入力にバリデーションがない
- **ファイル**: `src/components/organisms/NotificationSettings.tsx`, `src/locales/{ja,en}/notifications.json`
- **修正内容**: `handleEmailAddressBlur` にメールアドレス形式チェックを追加
  ```ts
  if (trimmed && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
    toast(t("invalidEmailAddress"), "error");
    return;
  }
  ```
- notifications.json に `invalidEmailAddress` キーを追加

### #112 モバイルでボトムナビがリストの最下部コンテンツに被る
- **ファイル**: `src/routes/_auth.tsx`
- **修正内容**: メインコンテンツエリアの `py-6` を `pt-6 pb-24 lg:py-6` に変更し、モバイルでのボトムナビ（約56px + Add Item ボタンの突き出し分）をパディングで確保

---

## テスト結果

- `bun test`: 114 pass / 0 fail ✅
- `bun run build`: ✅
- `npx tsc --noEmit`: ✅
- `npx oxfmt --check .`: ✅

https://claude.ai/code/session_013yjWdui8MF9kc6Buw1URK9

---
_Generated by [Claude Code](https://claude.ai/code/session_013yjWdui8MF9kc6Buw1URK9)_