### PR TITLE
fix: ショッピングリスト購入処理のバグ修正3件（ロット未作成・重複防止・i18n）

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@happy-dom/global-registrator": "^20.9.0",
+        "@happy-dom/global-registrator": "^20.10.2",
         "@storybook/react-vite": "^10.3.5",
         "@tailwindcss/vite": "^4.2.4",
         "@tanstack/react-query-devtools": "5.100.8",
@@ -349,7 +349,7 @@
 
     "@hapi/topo": ["@hapi/topo@5.1.0", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg=="],
 
-    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.9.0" } }, "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw=="],
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.2", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.2" } }, "sha512-/DC0hluanNJDVPUu69cidD46sGwzt8MJATiGx7WgCScn+ZH48fJQ0fvTfMPXY82/ASXWxnNo8P4BdHyU/dI/EA=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
@@ -833,6 +833,8 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
+
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
     "cache-base": ["cache-base@1.0.1", "", { "dependencies": { "collection-visit": "^1.0.0", "component-emitter": "^1.2.1", "get-value": "^2.0.6", "has-value": "^1.0.0", "isobject": "^3.0.1", "set-value": "^2.0.0", "to-object-path": "^0.3.0", "union-value": "^1.0.0", "unset-value": "^1.0.0" } }, "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ=="],
@@ -1161,7 +1163,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
+    "happy-dom": ["happy-dom@20.10.2", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-5p9Sxis3eowDJKqx90QCsgbNA02XXqJ59NOHvD4V6cxp+rP4d/xOyVx7uY3hS8hiUbY1VeiFH8lbJ81AyuDVLQ=="],
 
     "hard-rejection": ["hard-rejection@2.1.0", "", {}, "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA=="],
 
@@ -2092,6 +2094,8 @@
     "global-prefix/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "which": "./bin/which" } }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
 
     "globby/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "happy-dom/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "has-values/is-number": ["is-number@3.0.0", "", { "dependencies": { "kind-of": "^3.0.2" } }, "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@happy-dom/global-registrator": "^20.9.0",
+    "@happy-dom/global-registrator": "^20.10.2",
     "@storybook/react-vite": "^10.3.5",
     "@tailwindcss/vite": "^4.2.4",
     "@tanstack/react-query-devtools": "5.100.8",

--- a/src/hooks/useShoppingList.test.ts
+++ b/src/hooks/useShoppingList.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import { lotValuesFromForm } from "@/hooks/useShoppingList";
+import type { ItemFormValues } from "@/types/item";
+
+const makeFormValues = (overrides: Partial<ItemFormValues> = {}): ItemFormValues => ({
+  name: "テスト商品",
+  barcode: "",
+  category_id: null,
+  storage_location_id: null,
+  units: 1,
+  content_amount: 1,
+  content_unit: "個",
+  opened_remaining: null,
+  purchase_date: "",
+  expiry_date: "",
+  notes: "",
+  image_path: "",
+  ...overrides,
+});
+
+describe("lotValuesFromForm", () => {
+  test("通常値を正しくマッピングする", () => {
+    const values = makeFormValues({
+      units: 3,
+      opened_remaining: 150,
+      purchase_date: "2026-06-01",
+      expiry_date: "2026-12-31",
+    });
+    expect(lotValuesFromForm(values)).toEqual({
+      units: 3,
+      opened_remaining: 150,
+      purchase_date: "2026-06-01",
+      expiry_date: "2026-12-31",
+    });
+  });
+
+  test("units が undefined のとき 1 にフォールバックする", () => {
+    const values = makeFormValues({ units: undefined });
+    expect(lotValuesFromForm(values).units).toBe(1);
+  });
+
+  test("opened_remaining が null のとき null を維持する", () => {
+    const values = makeFormValues({ opened_remaining: null });
+    expect(lotValuesFromForm(values).opened_remaining).toBeNull();
+  });
+
+  test("purchase_date が空文字のとき null になる", () => {
+    const values = makeFormValues({ purchase_date: "" });
+    expect(lotValuesFromForm(values).purchase_date).toBeNull();
+  });
+
+  test("expiry_date が空文字のとき null になる", () => {
+    const values = makeFormValues({ expiry_date: "" });
+    expect(lotValuesFromForm(values).expiry_date).toBeNull();
+  });
+
+  test("purchase_date が undefined のとき null になる", () => {
+    const values = makeFormValues({ purchase_date: undefined });
+    expect(lotValuesFromForm(values).purchase_date).toBeNull();
+  });
+
+  test("expiry_date が undefined のとき null になる", () => {
+    const values = makeFormValues({ expiry_date: undefined });
+    expect(lotValuesFromForm(values).expiry_date).toBeNull();
+  });
+
+  test("有効な日付文字列はそのまま保持される", () => {
+    const values = makeFormValues({
+      purchase_date: "2026-01-15",
+      expiry_date: "2026-07-20",
+    });
+    const result = lotValuesFromForm(values);
+    expect(result.purchase_date).toBe("2026-01-15");
+    expect(result.expiry_date).toBe("2026-07-20");
+  });
+});

--- a/src/hooks/useShoppingList.ts
+++ b/src/hooks/useShoppingList.ts
@@ -1,10 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 
+import { createLot, LOTS_KEY, syncItemAggregate } from "@/hooks/useItemLots";
 import { OfflineError, requireOnline } from "@/lib/requireOnline";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/lib/toast-context";
-import type { ItemFormValues } from "@/types/item";
+import type { Item, ItemFormValues } from "@/types/item";
 
 type ShoppingStatus = "planned" | "purchased";
 
@@ -122,6 +123,25 @@ export const useDeleteShoppingItem = () => {
   });
 };
 
+const markShoppingItemPurchased = async (shoppingItemId: string, itemId: string) => {
+  const { error } = await supabase
+    .from("shopping_list_items")
+    .update({
+      status: "purchased",
+      purchased_at: new Date().toISOString(),
+      created_item_id: itemId,
+    })
+    .eq("id", shoppingItemId);
+  if (error) throw new Error(error.message);
+};
+
+export const lotValuesFromForm = (itemValues: ItemFormValues) => ({
+  units: itemValues.units ?? 1,
+  opened_remaining: itemValues.opened_remaining ?? null,
+  purchase_date: itemValues.purchase_date || null,
+  expiry_date: itemValues.expiry_date || null,
+});
+
 export const usePurchaseShoppingItem = () => {
   const qc = useQueryClient();
   const { toast } = useToast();
@@ -134,6 +154,50 @@ export const usePurchaseShoppingItem = () => {
       } = await supabase.auth.getUser();
       if (!user) throw new Error("Not authenticated");
 
+      // Fix #212: バーコードが一致するアクティブなアイテムにスタック
+      if (itemValues.barcode) {
+        const { data: activeItem } = await supabase
+          .from("items")
+          .select("*")
+          .eq("user_id", user.id)
+          .eq("barcode", itemValues.barcode)
+          .is("deleted_at", null)
+          .limit(1)
+          .maybeSingle();
+
+        if (activeItem) {
+          await createLot(user.id, activeItem.id, lotValuesFromForm(itemValues));
+          await syncItemAggregate(activeItem.id);
+          await markShoppingItemPurchased(shoppingItemId, activeItem.id);
+          return activeItem as Item;
+        }
+
+        // Fix #212: ソフトデリート済みアイテムを復活
+        const { data: deletedItem } = await supabase
+          .from("items")
+          .select("*")
+          .eq("user_id", user.id)
+          .eq("barcode", itemValues.barcode)
+          .not("deleted_at", "is", null)
+          .limit(1)
+          .maybeSingle();
+
+        if (deletedItem) {
+          const { data: revived, error: reviveError } = await supabase
+            .from("items")
+            .update({ deleted_at: null, updated_at: new Date().toISOString() })
+            .eq("id", deletedItem.id)
+            .select()
+            .single();
+          if (reviveError) throw reviveError;
+          await createLot(user.id, deletedItem.id, lotValuesFromForm(itemValues));
+          await syncItemAggregate(deletedItem.id);
+          await markShoppingItemPurchased(shoppingItemId, revived.id);
+          return revived as Item;
+        }
+      }
+
+      // バーコードなし or 既存アイテムなし → 新規作成
       const { data: newItem, error: itemError } = await supabase
         .from("items")
         .insert({
@@ -154,22 +218,18 @@ export const usePurchaseShoppingItem = () => {
         .single();
       if (itemError) throw new Error(itemError.message);
 
-      const { error: shoppingError } = await supabase
-        .from("shopping_list_items")
-        .update({
-          status: "purchased",
-          purchased_at: new Date().toISOString(),
-          created_item_id: newItem.id,
-        })
-        .eq("id", shoppingItemId);
-      if (shoppingError) throw new Error(shoppingError.message);
+      // Fix #211: 新規アイテムのロットを作成
+      await createLot(user.id, newItem.id, lotValuesFromForm(itemValues));
 
-      return newItem;
+      await markShoppingItemPurchased(shoppingItemId, newItem.id);
+
+      return newItem as Item;
     },
-    onSuccess: async () => {
+    onSuccess: async (data) => {
       await Promise.all([
         qc.invalidateQueries({ queryKey: [QUERY_KEY] }),
         qc.invalidateQueries({ queryKey: ["items"] }),
+        qc.invalidateQueries({ queryKey: [...LOTS_KEY, data.id] }),
       ]);
     },
     onError: (error) => {

--- a/src/routes/_auth.items.$itemId.tsx
+++ b/src/routes/_auth.items.$itemId.tsx
@@ -44,7 +44,7 @@ const DetailRow = ({ icon, label, value }: { icon: ReactNode; label: string; val
 );
 
 const ItemDetailPage = () => {
-  const { t } = useTranslation("items");
+  const { t, i18n } = useTranslation("items");
   const { t: tc } = useTranslation("common");
   const { itemId } = Route.useParams();
   const navigate = useNavigate();
@@ -410,7 +410,7 @@ const ItemDetailPage = () => {
                           </p>
                         </div>
                         <p className="text-xs text-muted-foreground">
-                          {new Date(log.occurred_at).toLocaleDateString()}
+                          {new Date(log.occurred_at).toLocaleDateString(i18n.language)}
                         </p>
                       </div>
                     </CardContent>


### PR DESCRIPTION
## 概要

コードレビューで発見した3件のバグ修正。

Closes #211
Closes #212
Closes #213

---

## バグ修正

### #211 usePurchaseShoppingItem がロット（item_lots）を作成しない

- **ファイル**: `src/hooks/useShoppingList.ts`
- **修正内容**: ショッピングリストの「購入済みにする」処理でアイテムを新規作成した際、`createLot` が呼ばれていなかった
- 正規の `createItem` フローでは必ず `createLot` を呼んでいるが、ショッピングリスト購入経由ではスキップされており、ロットタブが空・消費ページが異常になっていた
- 新規アイテム作成後に `createLot(user.id, newItem.id, lotValuesFromForm(itemValues))` を追加
- `onSuccess` で `LOTS_KEY` のキャッシュ無効化も追加

### #212 usePurchaseShoppingItem がバーコード重複チェック（スタック・復活）を行わない

- **ファイル**: `src/hooks/useShoppingList.ts`
- **修正内容**: バーコードがある場合は既存アクティブアイテムへのスタック、ソフトデリート済みアイテムの復活を試みるよう修正
- `createItem` の `tryStackToActiveItem` / `tryReviveItem` と同等のロジックをインライン実装
- スタック・復活成功時は新規作成をスキップし、既存アイテムを返す

### #213 アイテム詳細の消費ログ日付表示が i18n 未対応

- **ファイル**: `src/routes/_auth.items.$itemId.tsx`
- **修正内容**: 消費履歴タブの `new Date(log.occurred_at).toLocaleDateString()` に `i18n.language` を引数として追加
- `const { t, i18n } = useTranslation("items")` で `i18n` を取得し、ロケール引数に渡す

---

## テスト

- `src/hooks/useShoppingList.test.ts` を新規追加
  - `lotValuesFromForm` の純粋関数テスト（8ケース）
- `bun test`: 122 pass / 0 fail ✅
- `bun run build`: ✅
- `bun run typecheck`: ✅
- `bun run format:check`: ✅
- `bun run lint`: ✅

https://claude.ai/code/session_01Mo1HuDDTjH7XWTc3QveKz7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mo1HuDDTjH7XWTc3QveKz7)_