### PR TITLE
fix(barcode): DB lookup から画像 URL を返す + スペック更新

### DIFF
--- a/docs/specs/features/barcode.md
+++ b/docs/specs/features/barcode.md
@@ -32,9 +32,12 @@
 2. `getUserMedia` でカメラ取得（背面優先）
 3. `BrowserMultiFormatReader` でフレーム解析
 4. 値が取れたら `useBarcodeLookup` に渡す
-5. Edge Function `barcode-lookup` が外部 API（Open Food Facts など）を叩く
-6. 成功なら `ProductInfo` を返す → フォーム自動入力
-7. 失敗 / 未ヒットでもバーコード文字列はフォームに残す
+5. **DB優先**: `items` テーブルをバーコードで検索（`deleted_at IS NULL`）
+   - ヒットした場合 → 商品名・画像（署名付きURL）を返す（外部 API は呼ばない）
+   - 未ヒットの場合 → 次ステップへ
+6. Edge Function `barcode-lookup` が外部 API（Yahoo Shopping など）を叩く
+7. 成功なら `ProductInfo` を返す → フォーム自動入力
+8. 失敗 / 未ヒットでもバーコード文字列はフォームに残す
 
 ## API
 
@@ -59,7 +62,10 @@ Edge Function 実装: `supabase/functions/barcode-lookup/index.ts`
 - 読取失敗時のフォールバック導線整備
 - `barcode-lookup` の戻り値にカテゴリ候補を入れる（マッチがあれば）
 
+## 実装済み（v1）
+
+- DB優先ルックアップ: 同じバーコードで過去登録済みのアイテムがあれば外部 API を叩かずにその商品名・画像を返す
+
 ## Backlog
 
 - 複数バーコード一括読取
-- 履歴に基づく予測補完（同じバーコードの再読取 → 既存 item を提案）

--- a/src/hooks/useBarcodeLookup.ts
+++ b/src/hooks/useBarcodeLookup.ts
@@ -59,8 +59,15 @@ export const useBarcodeLookup = () => {
         .maybeSingle<ItemLookupRow>();
 
       if (!localError && localData?.name) {
+        let image_url: string | undefined;
+        if (localData.image_path) {
+          const { data: signedData } = await supabase.storage
+            .from("item-images")
+            .createSignedUrl(localData.image_path, 60 * 50);
+          image_url = signedData?.signedUrl ?? undefined;
+        }
         return {
-          product: { name: localData.name },
+          product: { name: localData.name, image_url },
           source: "db",
         };
       }


### PR DESCRIPTION
## 調査結果

バーコードスキャン時の挙動を確認した結果、**DB優先ルックアップ（過去登録アイテム検索 → APIスキップ）は既に正しく実装されていました**。

`useBarcodeLookup.ts` の処理フロー:
1. `items` テーブルをバーコードで検索 (`deleted_at IS NULL`)
2. ヒット → 商品情報を返してそのままリターン（外部APIは呼ばない）✅
3. 未ヒット → Edge Function `barcode-lookup` を呼ぶ ✅

## 修正内容

### 1. DBヒット時に画像を返していない問題を修正

`useBarcodeLookup.ts` では `image_path` をSELECTしていましたが、戻り値に含めておらず「死にコード」になっていました。

**修正後**: `image_path` が存在する場合は署名付きURLを取得して `image_url` として返すことで、`ProductLookupResult` に画像が表示されます。

```ts
// Before
return { product: { name: localData.name }, source: "db" };

// After
let image_url: string | undefined;
if (localData.image_path) {
  const { data: signedData } = await supabase.storage
    .from("item-images")
    .createSignedUrl(localData.image_path, 60 * 50);
  image_url = signedData?.signedUrl ?? undefined;
}
return { product: { name: localData.name, image_url }, source: "db" };
```

### 2. `barcode.md` スペックを実態に合わせて更新

- 処理フローにDB優先ステップを追記
- Backlogに残っていた「履歴に基づく予測補完」を「実装済み」セクションに移動

Closes #175

## Test plan

- [ ] バーコードスキャンで過去登録済みアイテムがヒットした場合、外部APIが呼ばれないことを確認
- [ ] DBヒット時に `ProductLookupResult` に商品名 + 画像が表示されることを確認
- [ ] DBミスヒット時は引き続き外部APIが呼ばれることを確認

https://claude.ai/code/session_01GxrUGT7p82XfSDvaxPJW1V

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxrUGT7p82XfSDvaxPJW1V)_