### PR TITLE
fix: バグ修正5件（画像孤立・日付i18n・トーストaria-label・PasswordStrength・useConsumeLot onError）

### DIFF
--- a/src/components/atoms/PasswordStrength.tsx
+++ b/src/components/atoms/PasswordStrength.tsx
@@ -1,8 +1,12 @@
+import { useTranslation } from "react-i18next";
+
 interface PasswordStrengthProps {
   password: string;
 }
 
 const PasswordStrength = ({ password }: PasswordStrengthProps) => {
+  const { t } = useTranslation("auth");
+
   if (!password) return null;
 
   const checks = {
@@ -19,11 +23,10 @@ const PasswordStrength = ({ password }: PasswordStrengthProps) => {
   return (
     <ul className="mt-1 space-y-0.5 text-xs text-muted-foreground">
       <li className={checks.length ? "text-green-600" : "text-destructive"}>
-        {checks.length ? "✓" : "✗"} 8文字以上
+        {checks.length ? "✓" : "✗"} {t("passwordMinLength")}
       </li>
       <li className={typeCount >= 3 ? "text-green-600" : "text-destructive"}>
-        {typeCount >= 3 ? "✓" : "✗"} 大文字・小文字・数字・記号のうち3種類以上（現在: {typeCount}
-        種類）
+        {typeCount >= 3 ? "✓" : "✗"} {t("passwordComplexity", { count: typeCount })}
       </li>
     </ul>
   );

--- a/src/components/pages/EditItemPage.tsx
+++ b/src/components/pages/EditItemPage.tsx
@@ -9,7 +9,11 @@ import { ItemForm } from "@/components/organisms/ItemForm";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Select } from "@/components/ui/select";
-import { downloadExternalImageAsFile, uploadItemImage } from "@/hooks/useItemImage";
+import {
+  downloadExternalImageAsFile,
+  removeItemImageFile,
+  uploadItemImage,
+} from "@/hooks/useItemImage";
 import { useItemLots, useUpdateLot } from "@/hooks/useItemLots";
 import { useItem, useUpdateItem } from "@/hooks/useItems";
 import { OfflineError } from "@/lib/requireOnline";
@@ -70,6 +74,14 @@ export const EditItemPage = ({ itemId }: EditItemPageProps) => {
           await qc.invalidateQueries({ queryKey: ["items"] });
           void navigate({ to: "/items/$itemId", params: { itemId } });
           return;
+        }
+      } else if (oldImagePath && !values.image_path) {
+        // Image was deleted without a replacement — clean up the orphaned storage file.
+        // Non-fatal: DB is already updated above, so we just swallow the error.
+        try {
+          await removeItemImageFile(oldImagePath);
+        } catch {
+          // storage cleanup failure is non-fatal
         }
       }
       toast(t("updateSuccess"), "success");

--- a/src/hooks/useItemImage.ts
+++ b/src/hooks/useItemImage.ts
@@ -5,6 +5,11 @@ import { OfflineError, requireOnline } from "@/lib/requireOnline";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/lib/toast-context";
 
+export const removeItemImageFile = async (imagePath: string): Promise<void> => {
+  requireOnline();
+  await supabase.storage.from(BUCKET).remove([imagePath]);
+};
+
 export const downloadExternalImageAsFile = async (imageUrl: string): Promise<File> => {
   const { data, error } = await supabase.functions.invoke<{ data: string; contentType: string }>(
     "image-proxy",

--- a/src/hooks/useItemLots.ts
+++ b/src/hooks/useItemLots.ts
@@ -1,7 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 
-import { requireOnline } from "@/lib/requireOnline";
+import { OfflineError, requireOnline } from "@/lib/requireOnline";
 import { supabase } from "@/lib/supabase";
+import { useToast } from "@/lib/toast-context";
 import { computeConsumption, type Item, type ItemLot } from "@/types/item";
 
 export const LOTS_KEY = ["item-lots"] as const;
@@ -164,6 +166,8 @@ export const useItemLots = (itemId: string) =>
 
 export const useConsumeLot = () => {
   const qc = useQueryClient();
+  const { toast } = useToast();
+  const { t } = useTranslation("common");
   return useMutation({
     mutationFn: consumeLot,
     onSuccess: async (_data, variables) => {
@@ -173,6 +177,10 @@ export const useConsumeLot = () => {
         qc.invalidateQueries({ queryKey: ["consumption-logs", variables.lot.item_id] }),
         qc.invalidateQueries({ queryKey: ["consumption-logs-all"] }),
       ]);
+    },
+    onError: (error) => {
+      if (error instanceof OfflineError) toast(t("offlineError"), "error");
+      else toast(t("unknownError"), "error");
     },
   });
 };

--- a/src/lib/toast.tsx
+++ b/src/lib/toast.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import { type Toast, ToastContext, type ToastVariant } from "@/lib/toast-context";
 
@@ -18,10 +19,12 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
     [dismiss],
   );
 
+  const { t } = useTranslation("common");
+
   return (
     <ToastContext value={{ toasts, toast, dismiss }}>
       {children}
-      <ToastContainer toasts={toasts} onDismiss={dismiss} />
+      <ToastContainer toasts={toasts} onDismiss={dismiss} closeLabel={t("close")} />
     </ToastContext>
   );
 };
@@ -36,9 +39,11 @@ const variantClasses: Record<ToastVariant, string> = {
 const ToastContainer = ({
   toasts,
   onDismiss,
+  closeLabel,
 }: {
   toasts: Toast[];
   onDismiss: (id: string) => void;
+  closeLabel: string;
 }) => {
   if (toasts.length === 0) return null;
   return (
@@ -57,7 +62,7 @@ const ToastContainer = ({
           <button
             onClick={() => onDismiss(t.id)}
             className="ml-2 opacity-70 hover:opacity-100"
-            aria-label="閉じる"
+            aria-label={closeLabel}
           >
             ×
           </button>

--- a/src/locales/en/auth.json
+++ b/src/locales/en/auth.json
@@ -47,5 +47,8 @@
   "changePassword": "Change Password",
   "backToEmail": "Back to email entry",
   "backToSignIn": "Back to Sign In",
-  "resetSuccess": "Password changed. Please sign in with your new password."
+  "resetSuccess": "Password changed. Please sign in with your new password.",
+  "validationError": "Validation error",
+  "passwordMinLength": "At least 8 characters",
+  "passwordComplexity": "At least 3 of: uppercase, lowercase, numbers, symbols (current: {{count}})"
 }

--- a/src/locales/ja/auth.json
+++ b/src/locales/ja/auth.json
@@ -47,5 +47,8 @@
   "changePassword": "パスワードを変更する",
   "backToEmail": "メールアドレス入力に戻る",
   "backToSignIn": "サインインに戻る",
-  "resetSuccess": "パスワードを変更しました。新しいパスワードでサインインしてください。"
+  "resetSuccess": "パスワードを変更しました。新しいパスワードでサインインしてください。",
+  "validationError": "バリデーションエラー",
+  "passwordMinLength": "8文字以上",
+  "passwordComplexity": "大文字・小文字・数字・記号のうち3種類以上（現在: {{count}}種類）"
 }

--- a/src/routes/_auth.items.$itemId.consume.tsx
+++ b/src/routes/_auth.items.$itemId.consume.tsx
@@ -60,7 +60,7 @@ export const ItemConsumePage = () => {
       return;
     }
     if (!preview || preview.error) {
-      setValidationError(preview?.error ?? t("consumeValidationError"));
+      setValidationError(preview?.error ? t(preview.error) : t("consumeValidationError"));
       return;
     }
     try {
@@ -251,7 +251,7 @@ export const ItemConsumePage = () => {
               </p>
             </div>
           )}
-          {preview?.error && <p className="text-sm text-destructive">{preview.error}</p>}
+          {preview?.error && <p className="text-sm text-destructive">{t(preview.error)}</p>}
 
           <Button
             className="w-full"

--- a/src/routes/_auth.items.$itemId.consume.tsx
+++ b/src/routes/_auth.items.$itemId.consume.tsx
@@ -14,7 +14,7 @@ import { useToast } from "@/lib/toast-context";
 import { computeConsumption, type ItemLot } from "@/types/item";
 
 export const ItemConsumePage = () => {
-  const { t } = useTranslation("items");
+  const { t, i18n } = useTranslation("items");
   const { itemId } = Route.useParams();
   const { lotId: preselectedLotId } = Route.useSearch();
   const navigate = useNavigate();
@@ -195,12 +195,14 @@ export const ItemConsumePage = () => {
                   </p>
                   {lot.expiry_date && (
                     <p className="text-xs text-muted-foreground">
-                      {t("expiryDate")}: {parseLocalDate(lot.expiry_date).toLocaleDateString()}
+                      {t("expiryDate")}:{" "}
+                      {parseLocalDate(lot.expiry_date).toLocaleDateString(i18n.language)}
                     </p>
                   )}
                   {lot.purchase_date && (
                     <p className="text-xs text-muted-foreground">
-                      {t("purchaseDate")}: {parseLocalDate(lot.purchase_date).toLocaleDateString()}
+                      {t("purchaseDate")}:{" "}
+                      {parseLocalDate(lot.purchase_date).toLocaleDateString(i18n.language)}
                     </p>
                   )}
                 </button>

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -145,7 +145,7 @@ export const computeConsumption = (
         : units * contentAmount;
 
   if (delta > totalBefore) {
-    return { units_after: 0, opened_remaining_after: 0, error: "在庫が不足しています" };
+    return { units_after: 0, opened_remaining_after: 0, error: "insufficientStock" };
   }
 
   // Round to avoid floating-point noise (DB stores numeric(12,2))


### PR DESCRIPTION
## 概要

コードレビューで発見した5件のバグを修正します。

### 修正内容

- **Closes #244** — `EditItemPage` で画像を削除してから保存した場合、DB の `image_path` は更新されるが Supabase Storage の旧ファイルが削除されずに孤立していた問題を修正。`removeItemImageFile` ユーティリティを `useItemImage.ts` に追加し、`updateItem` 成功後に孤立ファイルを削除する。

- **Closes #243** — 消費ページ（`_auth.items.$itemId.consume.tsx`）のロット選択 UI で表示される期限日・購入日が `toLocaleDateString()` に `i18n.language` を渡していなかった問題を修正。Issue #219（詳細タブ）と同種のバグだが消費ページは別コードブロック。

- **Closes #245** — `toast.tsx` の閉じるボタンの `aria-label` が `"閉じる"` と日本語ハードコードされていた問題を修正。`ToastProvider` に `useTranslation` を追加し、`t("close")` を `closeLabel` として `ToastContainer` に渡す。

- **Closes #246** — `PasswordStrength` コンポーネントのメッセージ（「8文字以上」「大文字・小文字...3種類以上」）が日本語ハードコードだった問題を修正。`useTranslation("auth")` を追加し、`auth` 名前空間に `passwordMinLength` / `passwordComplexity` キーを追加（日英両対応）。

- **Closes #247** — `useConsumeLot` フックに `onError` ハンドラが未実装で、他の mutation フックとの一貫性がなかった問題を修正。オフラインエラー検出・トースト通知を追加。

## 変更ファイル一覧

| ファイル | 変更内容 |
|---|---|
| `src/hooks/useItemImage.ts` | `removeItemImageFile` 関数追加 |
| `src/components/pages/EditItemPage.tsx` | 画像削除時の孤立ファイル削除処理追加 |
| `src/routes/_auth.items.$itemId.consume.tsx` | toLocaleDateString に i18n.language を渡す |
| `src/lib/toast.tsx` | closeLabel prop 追加、useTranslation 対応 |
| `src/components/atoms/PasswordStrength.tsx` | useTranslation("auth") で i18n 対応 |
| `src/hooks/useItemLots.ts` | useConsumeLot に onError ハンドラ追加 |
| `src/locales/ja/auth.json` | passwordMinLength / passwordComplexity キー追加 |
| `src/locales/en/auth.json` | passwordMinLength / passwordComplexity キー追加 |

## テスト計画

- [ ] アイテム編集で既存画像を削除して保存 → Storage にファイルが残っていないことを確認
- [ ] 英語設定で消費ページを開き、複数ロットがある場合に日付が英語フォーマット（M/D/YYYY）で表示されることを確認
- [ ] トーストを表示して閉じるボタンのスクリーンリーダー読み上げが英語設定時に "Close" になることを確認
- [ ] 英語設定でログイン/新規登録ページを開き、パスワード強度メッセージが英語で表示されることを確認
- [ ] `bun test` 全 122 テスト pass 確認 ✓

https://claude.ai/code/session_01L5svxWPgY8d71dSeVsU43z

---
_Generated by [Claude Code](https://claude.ai/code/session_01L5svxWPgY8d71dSeVsU43z)_