### PR TITLE
fix: カレンダー消費ログ未記録・EditItemPage opened_remaining バグを修正

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@happy-dom/global-registrator": "^20.10.2",
+        "@happy-dom/global-registrator": "^20.10.3",
         "@storybook/react-vite": "^10.3.5",
         "@tailwindcss/vite": "^4.2.4",
         "@tanstack/react-query-devtools": "5.100.8",
@@ -349,7 +349,7 @@
 
     "@hapi/topo": ["@hapi/topo@5.1.0", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg=="],
 
-    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.2", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.2" } }, "sha512-/DC0hluanNJDVPUu69cidD46sGwzt8MJATiGx7WgCScn+ZH48fJQ0fvTfMPXY82/ASXWxnNo8P4BdHyU/dI/EA=="],
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.3", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.3" } }, "sha512-rw10ox5gAdKT5UScrrhLRE8y9t2xzvRx2lUNwbXlPogJixYGciElqywuLlcmX+Rgcif0sF2wWUwqUEob1BKZTA=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
@@ -1163,7 +1163,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "happy-dom": ["happy-dom@20.10.2", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-5p9Sxis3eowDJKqx90QCsgbNA02XXqJ59NOHvD4V6cxp+rP4d/xOyVx7uY3hS8hiUbY1VeiFH8lbJ81AyuDVLQ=="],
+    "happy-dom": ["happy-dom@20.10.3", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-Hjdiy8RziuCcn5z04QI/rlsNuQoG8P0xxjgvsSMpi89cvIXIOcucQtiHS1yHSShxoBcSCeYqAskINmTiy/mlfw=="],
 
     "hard-rejection": ["hard-rejection@2.1.0", "", {}, "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@happy-dom/global-registrator": "^20.10.2",
+    "@happy-dom/global-registrator": "^20.10.3",
     "@storybook/react-vite": "^10.3.5",
     "@tailwindcss/vite": "^4.2.4",
     "@tanstack/react-query-devtools": "5.100.8",

--- a/src/components/pages/EditItemPage.tsx
+++ b/src/components/pages/EditItemPage.tsx
@@ -157,7 +157,7 @@ export const EditItemPage = ({ itemId }: EditItemPageProps) => {
           units: selectedLot?.units ?? item.units,
           content_amount: item.content_amount,
           content_unit: item.content_unit,
-          opened_remaining: item.opened_remaining,
+          opened_remaining: selectedLot?.opened_remaining ?? item.opened_remaining,
           purchase_date: selectedLot?.purchase_date ?? item.purchase_date ?? undefined,
           expiry_date: selectedLot?.expiry_date ?? item.expiry_date ?? undefined,
           notes: item.notes ?? undefined,

--- a/src/routes/-_auth.calendar.test.ts
+++ b/src/routes/-_auth.calendar.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+
+import { computeCalendarDelta } from "./_auth.calendar";
+
+describe("computeCalendarDelta", () => {
+  test("封印済みユニットのみの場合: units × contentAmount", () => {
+    expect(computeCalendarDelta(3, null, 500)).toBe(1500);
+  });
+
+  test("units=1 封印済みのみの場合", () => {
+    expect(computeCalendarDelta(1, null, 200)).toBe(200);
+  });
+
+  test("units=0 かつ openedRemaining あり: opened_remaining のみ", () => {
+    expect(computeCalendarDelta(0, 150, 500)).toBe(150);
+  });
+
+  test("units=2 かつ openedRemaining あり: (units-1)*contentAmount + openedRemaining", () => {
+    // 2本中1本開封済み(残250mL) + 未開封1本(500mL) = 750mL
+    expect(computeCalendarDelta(2, 250, 500)).toBe(750);
+  });
+
+  test("units=1 かつ openedRemaining あり: openedRemaining のみ（封印ゼロ）", () => {
+    // 1本のみ開封中で残300mL（未開封は0）
+    expect(computeCalendarDelta(1, 300, 500)).toBe(300);
+  });
+
+  test("openedRemaining=0 の場合: 0 を返す（全量消費済み）", () => {
+    expect(computeCalendarDelta(1, 0, 500)).toBe(0);
+  });
+
+  test("contentAmount が小数の場合も正確に計算する", () => {
+    expect(computeCalendarDelta(2, null, 1.5)).toBeCloseTo(3.0);
+  });
+});

--- a/src/routes/_auth.calendar.tsx
+++ b/src/routes/_auth.calendar.tsx
@@ -18,7 +18,23 @@ interface PendingLotRemoval {
   itemName: string;
   units: number;
   openedRemaining: number | null;
+  logId: string | null;
 }
+
+/**
+ * カレンダーの「消費済み」チェック操作での消費量を計算する。
+ * opened_remaining がある場合は開封済み分の残量も含める。
+ */
+export const computeCalendarDelta = (
+  units: number,
+  openedRemaining: number | null,
+  contentAmount: number,
+): number => {
+  if (openedRemaining !== null) {
+    return Math.max(0, units - 1) * contentAmount + openedRemaining;
+  }
+  return units * contentAmount;
+};
 
 const CalendarRoutePage = () => {
   const qc = useQueryClient();
@@ -31,6 +47,11 @@ const CalendarRoutePage = () => {
   const handleCheck = async (item: Item) => {
     try {
       requireOnline();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) throw new Error("Not authenticated");
+
       const { data: lots, error } = await supabase
         .from("item_lots")
         .select("id, units, opened_remaining, expiry_date")
@@ -59,10 +80,33 @@ const CalendarRoutePage = () => {
         .eq("id", targetLot.id);
       if (updateError) throw updateError;
 
+      // 消費ログを記録（non-fatal: ロット更新は完了しているためエラーを無視）
+      const deltaAmount = computeCalendarDelta(
+        targetLot.units,
+        targetLot.opened_remaining,
+        item.content_amount,
+      );
+      const { data: logData } = await supabase
+        .from("consumption_logs")
+        .insert({
+          user_id: user.id,
+          item_id: item.id,
+          delta_amount: deltaAmount,
+          delta_unit: item.content_unit,
+          units_before: targetLot.units,
+          units_after: 0,
+          opened_remaining_before: targetLot.opened_remaining,
+          opened_remaining_after: null,
+        })
+        .select("id")
+        .single();
+
       await syncItemAggregate(item.id);
       await Promise.all([
         qc.invalidateQueries({ queryKey: ["items"] }),
         qc.invalidateQueries({ queryKey: [...LOTS_KEY, item.id] }),
+        qc.invalidateQueries({ queryKey: ["consumption-logs", item.id] }),
+        qc.invalidateQueries({ queryKey: ["consumption-logs-all"] }),
       ]);
       setPendingRemovals((prev) => ({
         ...prev,
@@ -72,6 +116,7 @@ const CalendarRoutePage = () => {
           itemName: item.name,
           units: targetLot.units,
           openedRemaining: targetLot.opened_remaining,
+          logId: logData?.id ?? null,
         },
       }));
     } catch (err) {
@@ -95,10 +140,17 @@ const CalendarRoutePage = () => {
         .eq("id", pending.lotId);
       if (error) throw error;
 
+      // 消費ログを削除（non-fatal: ロット復元は完了しているためエラーを無視）
+      if (pending.logId) {
+        await supabase.from("consumption_logs").delete().eq("id", pending.logId);
+      }
+
       await syncItemAggregate(pending.itemId);
       await Promise.all([
         qc.invalidateQueries({ queryKey: ["items"] }),
         qc.invalidateQueries({ queryKey: [...LOTS_KEY, pending.itemId] }),
+        qc.invalidateQueries({ queryKey: ["consumption-logs", pending.itemId] }),
+        qc.invalidateQueries({ queryKey: ["consumption-logs-all"] }),
       ]);
       setPendingRemovals((prev) => {
         const next = { ...prev };


### PR DESCRIPTION
## 概要

2件のバグを修正します。

### Bug 1: カレンダーの「消費済み」チェックが consumption_logs に記録されない (#254)

カレンダーページでアイテムをチェックしてもデータが記録されておらず、消費履歴・統計ページに反映されないバグを修正。

**変更内容:**
- `_auth.calendar.tsx: handleCheck` で `consumption_logs` への INSERT を追加
- `computeCalendarDelta()` を追加し、opened_remaining を含む消費量を正確に計算
- `handleUndo` 時に対応する consumption_log を削除（non-fatal）
- `consumption-logs` のキャッシュ invalidation を追加（詳細ページ・統計への即時反映）

### Bug 2: EditItemPage の opened_remaining が複数ロット時に item 集約値になる (#252)

ロットセレクターで特定ロットを選択しても `opened_remaining` が常に item 集約値（通常 null）になるバグを修正。

**変更内容:**
- `EditItemPage.tsx: defaultValues.opened_remaining` を `selectedLot?.opened_remaining ?? item.opened_remaining` に変更（1行）

## テスト

- `src/routes/-_auth.calendar.test.ts` を新規追加（`computeCalendarDelta` の単体テスト 7 件）
- 全テスト通過 (129 tests pass)
- lint / typecheck / format / build すべてグリーン

## チェックリスト

- [x] `bun run format:check` ✅
- [x] `bun run check` (lint + typecheck) ✅
- [x] `bun test` (129 tests pass) ✅
- [x] `bun run build` ✅

Closes #254
Closes #252

https://claude.ai/code/session_01QQb57GLY2sSCbLVaSdDBEo

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQb57GLY2sSCbLVaSdDBEo)_