### PR TITLE
fix(validation): ItemForm の units フィールドが 0 以下の整数を許容するバリデーション漏れを修正

### DIFF
--- a/src/components/organisms/ItemForm.tsx
+++ b/src/components/organisms/ItemForm.tsx
@@ -180,6 +180,9 @@ export const ItemForm = ({
     if (unitsRaw.trim() === "" || isNaN(parsedUnits)) {
       setUnitsError(t("unitsRequired"));
       hasError = true;
+    } else if (parsedUnits <= 0) {
+      setUnitsError(t("unitsPositive"));
+      hasError = true;
     }
 
     const parsedContentAmount = Math.round(parseFloat(contentAmountRaw) * 100) / 100;

--- a/src/locales/en/items.json
+++ b/src/locales/en/items.json
@@ -98,6 +98,7 @@
   "consumeValidationError": "Enter a value greater than 0",
   "lookupFromHistory": "Found a match from your previously registered items",
   "unitsRequired": "Enter a quantity",
+  "unitsPositive": "Enter 1 or more",
   "contentAmountRequired": "Enter a value greater than 0",
   "stackSuccess": "Added as new stock to existing item",
   "stackBannerTitle": "This item is already in your inventory",

--- a/src/locales/ja/items.json
+++ b/src/locales/ja/items.json
@@ -98,6 +98,7 @@
   "consumeValidationError": "0より大きい値を入力してください",
   "lookupFromHistory": "過去に登録した商品データから候補を見つけました",
   "unitsRequired": "個数を入力してください",
+  "unitsPositive": "1以上の数を入力してください",
   "contentAmountRequired": "0より大きい数値を入力してください",
   "stackSuccess": "既存の在庫にロットを追加しました",
   "stackBannerTitle": "同じ商品が既に在庫にあります",

--- a/src/types/item.test.ts
+++ b/src/types/item.test.ts
@@ -5,8 +5,50 @@ import {
   DEFAULT_EXPIRY_WARNING_DAYS,
   formatRemaining,
   getExpiryStatus,
+  itemFormSchema,
   itemLotSchema,
 } from "./item";
+
+// --- itemFormSchema ---
+
+describe("itemFormSchema", () => {
+  const validForm = {
+    name: "テスト商品",
+    units: 1,
+    content_amount: 1,
+    content_unit: "個",
+  };
+
+  test("valid form parses correctly", () => {
+    const result = itemFormSchema.safeParse(validForm);
+    expect(result.success).toBe(true);
+  });
+
+  test("units=1 is valid", () => {
+    const result = itemFormSchema.safeParse({ ...validForm, units: 1 });
+    expect(result.success).toBe(true);
+  });
+
+  test("units=0 fails", () => {
+    const result = itemFormSchema.safeParse({ ...validForm, units: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  test("units=-1 fails", () => {
+    const result = itemFormSchema.safeParse({ ...validForm, units: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  test("units=2 is valid", () => {
+    const result = itemFormSchema.safeParse({ ...validForm, units: 2 });
+    expect(result.success).toBe(true);
+  });
+
+  test("empty name fails", () => {
+    const result = itemFormSchema.safeParse({ ...validForm, name: "" });
+    expect(result.success).toBe(false);
+  });
+});
 
 // --- itemLotSchema ---
 

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -44,7 +44,7 @@ export const itemFormSchema = z.object({
   barcode: z.string().optional(),
   category_id: z.string().uuid().nullable().optional(),
   storage_location_id: z.string().uuid().nullable().optional(),
-  units: z.coerce.number().int().min(0).default(1),
+  units: z.coerce.number().int().min(1).default(1),
   content_amount: z.coerce.number().positive().default(1),
   content_unit: z.string().default("個"),
   opened_remaining: z.coerce.number().min(0).nullable().optional(),


### PR DESCRIPTION
## 概要

新規/編集アイテムフォームの「個数（units）」フィールドで `0` や `-1` を入力してもエラーにならず、0個のアイテムが登録できてしまうバグを修正しました。

Closes #260

## 変更内容

### バグ修正
- **`src/components/organisms/ItemForm.tsx`**: `parsedUnits <= 0` チェックを追加。0以下の入力に `unitsPositive` エラーを表示
- **`src/types/item.ts`**: `itemFormSchema.units` の最小値を `min(0)` → `min(1)` に変更（既存アイテムの DB 表現スキーマ `itemSchema` と `itemLotSchema` は変更なし）

### i18n
- `src/locales/en/items.json`: `"unitsPositive": "Enter 1 or more"` を追加
- `src/locales/ja/items.json`: `"unitsPositive": "1以上の数を入力してください"` を追加

### テスト
- `src/types/item.test.ts`: `itemFormSchema` の units バリデーションテストを 5 件追加
  - `units=1` → 有効
  - `units=0` → 無効（修正のターゲット）
  - `units=-1` → 無効
  - `units=2` → 有効
  - `name=""` → 無効（既存動作の確認）

## テスト計画

- [x] `bun test` — 全 135 件パス
- [x] `bun run format:check` — 差分なし
- [x] `bun run check` (lint + typecheck) — エラーなし

https://claude.ai/code/session_01NfwzKV7HLchvM3LeEseCyh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfwzKV7HLchvM3LeEseCyh)_