### PR TITLE
feat: アイテムカードにクイック消費ボタンを追加 (#226)

### DIFF
--- a/src/components/molecules/ItemCard.stories.tsx
+++ b/src/components/molecules/ItemCard.stories.tsx
@@ -174,3 +174,27 @@ export const MultiLotStacked: Story = {
     locationName: "洗面台",
   },
 };
+
+export const WithQuickConsume: Story = {
+  args: {
+    item: {
+      ...baseItem,
+      name: "牛乳",
+      units: 3,
+      content_amount: 1000,
+      content_unit: "mL",
+      category_id: null,
+      barcode: null,
+      storage_location_id: null,
+      expiry_date: "2099-06-01",
+      purchase_date: null,
+      notes: null,
+      image_path: null,
+    },
+    categoryName: "食品",
+    locationName: "冷蔵庫",
+    onQuickConsume: (item) => {
+      console.log("Quick consume:", item.name);
+    },
+  },
+};

--- a/src/components/molecules/ItemCard.tsx
+++ b/src/components/molecules/ItemCard.tsx
@@ -1,9 +1,10 @@
 import { Link } from "@tanstack/react-router";
-import { Calendar, MapPin, Tag } from "lucide-react";
+import { Calendar, MapPin, Minus, Tag } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { ExpiryBadge } from "@/components/atoms/ExpiryBadge";
 import { ItemImage } from "@/components/atoms/ItemImage";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { parseLocalDate } from "@/lib/dateUtils";
 import { cn } from "@/lib/utils";
@@ -14,9 +15,16 @@ interface ItemCardProps {
   categoryName?: string | undefined;
   locationName?: string | undefined;
   warningDays?: number;
+  onQuickConsume?: (item: Item) => void;
 }
 
-export const ItemCard = ({ item, categoryName, locationName, warningDays }: ItemCardProps) => {
+export const ItemCard = ({
+  item,
+  categoryName,
+  locationName,
+  warningDays,
+  onQuickConsume,
+}: ItemCardProps) => {
   const { t, i18n } = useTranslation("items");
   const expiryStatus = getExpiryStatus(item.expiry_date, warningDays);
   const isUrgent = expiryStatus === "expired" || expiryStatus === "expiring-soon";
@@ -82,7 +90,24 @@ export const ItemCard = ({ item, categoryName, locationName, warningDays }: Item
               </span>
             )}
           </span>
-          <ExpiryBadge expiryDate={item.expiry_date} warningDays={warningDays} />
+          <div className="flex items-center gap-1">
+            {!isEmpty && onQuickConsume && (
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-7 w-7 shrink-0"
+                aria-label={t("quickConsume")}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onQuickConsume(item);
+                }}
+              >
+                <Minus className="h-3.5 w-3.5" />
+              </Button>
+            )}
+            <ExpiryBadge expiryDate={item.expiry_date} warningDays={warningDays} />
+          </div>
         </CardFooter>
       </Card>
     </Link>

--- a/src/locales/en/items.json
+++ b/src/locales/en/items.json
@@ -118,5 +118,7 @@
   "editLot": "Select lot to edit",
   "itemCountLabel_one": "{{count}} item",
   "itemCountLabel_other": "{{count}} items",
-  "itemCountLabelFiltered": "{{filtered}} / {{total}} items"
+  "itemCountLabelFiltered": "{{filtered}} / {{total}} items",
+  "quickConsume": "Use 1 unit",
+  "quickConsumeSuccess": "Used 1 {{name}}"
 }

--- a/src/locales/ja/items.json
+++ b/src/locales/ja/items.json
@@ -117,5 +117,7 @@
   "noStockToConsume": "使用できる在庫がありません",
   "editLot": "編集するロットを選択",
   "itemCountLabel": "{{count}}件",
-  "itemCountLabelFiltered": "{{filtered}} / {{total}}件"
+  "itemCountLabelFiltered": "{{filtered}} / {{total}}件",
+  "quickConsume": "1個消費",
+  "quickConsumeSuccess": "{{name}}を1個消費しました"
 }

--- a/src/routes/_auth.index.tsx
+++ b/src/routes/_auth.index.tsx
@@ -8,10 +8,12 @@ import { ItemCard } from "@/components/molecules/ItemCard";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
+import { useConsumeItem } from "@/hooks/useConsumeItem";
 import { type ItemFilters, type ItemSortKey, useItems } from "@/hooks/useItems";
 import { useCategories, useStorageLocations } from "@/hooks/useMasterData";
 import { useUserSettings } from "@/hooks/useUserSettings";
-import { getExpiryStatus } from "@/types/item";
+import { useToast } from "@/lib/toast-context";
+import { getExpiryStatus, type Item } from "@/types/item";
 
 const DashboardPage = () => {
   const { t } = useTranslation("items");
@@ -20,6 +22,8 @@ const DashboardPage = () => {
   const { data: locations = [] } = useStorageLocations();
   const { data: userSettings } = useUserSettings();
   const warningDays = userSettings?.expiry_warning_days;
+  const consumeItem = useConsumeItem();
+  const { toast } = useToast();
 
   const [search, setSearch] = useState("");
   const [categoryId, setCategoryId] = useState("");
@@ -28,6 +32,15 @@ const DashboardPage = () => {
   const [sort, setSort] = useState<ItemSortKey>("created_at");
   const [showFilters, setShowFilters] = useState(false);
   const [hideEmpty, setHideEmpty] = useState(true);
+
+  const handleQuickConsume = async (item: Item) => {
+    try {
+      await consumeItem.mutateAsync({ item, deltaAmount: item.content_amount });
+      toast(t("quickConsumeSuccess", { name: item.name }), "success");
+    } catch {
+      toast(t("consumeError"), "error");
+    }
+  };
 
   const filters: ItemFilters = {
     search: search || undefined,
@@ -263,6 +276,9 @@ const DashboardPage = () => {
                 item.storage_location_id ? locationMap[item.storage_location_id] : undefined
               }
               warningDays={warningDays}
+              onQuickConsume={(i) => {
+                void handleQuickConsume(i);
+              }}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary

- ダッシュボードのアイテムカード右下に「−」ボタン（Minus アイコン）を追加
- 在庫がある場合のみ表示され、タップすると FIFO で先頭ロットから 1 ユニット（`content_amount` 分）を消費
- カード全体のリンク遷移をブロックし (`e.preventDefault` / `e.stopPropagation`)、消費後はトーストで通知
- `ItemCard` に `onQuickConsume?: (item: Item) => void` prop を追加（後方互換あり）
- Storybook に `WithQuickConsume` ストーリーを追加

Closes #226

## Test plan

- [ ] ダッシュボードで在庫のあるアイテムカード右下に「−」ボタンが表示される
- [ ] ボタンタップで詳細ページへ遷移しない（カードリンクがブロックされる）
- [ ] 消費後にトースト「〇〇を1個消費しました」が表示される
- [ ] 消費後にカードの在庫表示が更新される
- [ ] 在庫 0 のカードにはボタンが表示されない

https://claude.ai/code/session_01YGPBtfyNLnWW1K54jwrE3W

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGPBtfyNLnWW1K54jwrE3W)_