### PR TITLE
feat: 消費ページに全量消費ボタンを追加 (#256)

### DIFF
--- a/src/locales/en/items.json
+++ b/src/locales/en/items.json
@@ -120,5 +120,9 @@
   "itemCountLabel_other": "{{count}} items",
   "itemCountLabelFiltered": "{{filtered}} / {{total}} items",
   "quickConsume": "Use 1 unit",
-  "quickConsumeSuccess": "Used 1 {{name}}"
+  "quickConsumeSuccess": "Used 1 {{name}}",
+  "consumeAll": "Use all ({{amount}}{{unit}})",
+  "consumeAllTitle": "Use all stock",
+  "consumeAllConfirm": "Use all stock in this lot ({{amount}}{{unit}})?",
+  "consumeAllConfirmLabel": "Use all"
 }

--- a/src/locales/ja/items.json
+++ b/src/locales/ja/items.json
@@ -119,5 +119,9 @@
   "itemCountLabel": "{{count}}件",
   "itemCountLabelFiltered": "{{filtered}} / {{total}}件",
   "quickConsume": "1個消費",
-  "quickConsumeSuccess": "{{name}}を1個消費しました"
+  "quickConsumeSuccess": "{{name}}を1個消費しました",
+  "consumeAll": "全量消費 ({{amount}}{{unit}})",
+  "consumeAllTitle": "全量消費の確認",
+  "consumeAllConfirm": "このロットの全量（{{amount}}{{unit}}）を消費しますか？",
+  "consumeAllConfirmLabel": "全量消費する"
 }

--- a/src/routes/_auth.items.$itemId.consume.tsx
+++ b/src/routes/_auth.items.$itemId.consume.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Spinner } from "@/components/atoms/Spinner";
+import { ConfirmDialog } from "@/components/molecules/ConfirmDialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -25,6 +26,7 @@ export const ItemConsumePage = () => {
   const [selectedLotId, setSelectedLotId] = useState<string | null>(preselectedLotId ?? null);
   const [delta, setDelta] = useState("");
   const [validationError, setValidationError] = useState("");
+  const [showConsumeAll, setShowConsumeAll] = useState(false);
 
   const isLoading = itemLoading || lotsLoading;
 
@@ -65,6 +67,17 @@ export const ItemConsumePage = () => {
     }
     try {
       await consumeLot.mutateAsync({ lot: selectedLot, item, deltaAmount: amount });
+      toast(t("consumeSuccess"), "success");
+      void navigate({ to: "/items/$itemId", params: { itemId } });
+    } catch {
+      toast(t("consumeError"), "error");
+    }
+  };
+
+  const handleConsumeAll = async (totalAmount: number) => {
+    if (!item || !selectedLot) return;
+    try {
+      await consumeLot.mutateAsync({ lot: selectedLot, item, deltaAmount: totalAmount });
       toast(t("consumeSuccess"), "success");
       void navigate({ to: "/items/$itemId", params: { itemId } });
     } catch {
@@ -134,8 +147,31 @@ export const ItemConsumePage = () => {
         })
     : null;
 
+  const totalLotAmount = selectedLot
+    ? selectedLot.opened_remaining !== null && selectedLot.opened_remaining !== undefined
+      ? selectedLot.opened_remaining + Math.max(0, selectedLot.units - 1) * item.content_amount
+      : selectedLot.units * item.content_amount
+    : 0;
+
   return (
     <div className="mx-auto max-w-2xl space-y-6">
+      {showConsumeAll && (
+        <ConfirmDialog
+          open={showConsumeAll}
+          title={t("consumeAllTitle")}
+          message={t("consumeAllConfirm", {
+            amount: totalLotAmount,
+            unit: item.content_unit,
+          })}
+          confirmLabel={t("consumeAllConfirmLabel")}
+          isConfirming={consumeLot.isPending}
+          onConfirm={() => {
+            setShowConsumeAll(false);
+            void handleConsumeAll(totalLotAmount);
+          }}
+          onCancel={() => setShowConsumeAll(false)}
+        />
+      )}
       <div className="flex items-center gap-3">
         <Button
           variant="ghost"
@@ -253,16 +289,26 @@ export const ItemConsumePage = () => {
           )}
           {preview?.error && <p className="text-sm text-destructive">{t(preview.error)}</p>}
 
-          <Button
-            className="w-full"
-            onClick={() => {
-              void handleSubmit();
-            }}
-            disabled={consumeLot.isPending || !delta || parseFloat(delta) <= 0}
-          >
-            {consumeLot.isPending ? <Spinner className="mr-2 h-4 w-4" /> : null}
-            {t("consume")}
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              className="flex-1"
+              onClick={() => setShowConsumeAll(true)}
+              disabled={consumeLot.isPending || totalLotAmount <= 0}
+            >
+              {t("consumeAll", { amount: totalLotAmount, unit: item.content_unit })}
+            </Button>
+            <Button
+              className="flex-1"
+              onClick={() => {
+                void handleSubmit();
+              }}
+              disabled={consumeLot.isPending || !delta || parseFloat(delta) <= 0}
+            >
+              {consumeLot.isPending ? <Spinner className="mr-2 h-4 w-4" /> : null}
+              {t("consume")}
+            </Button>
+          </div>
         </>
       )}
 


### PR DESCRIPTION
## Summary

- 消費ページ（`_auth.items.$itemId.consume.tsx`）に「全量消費」ボタンを追加
- 選択ロットの総量を自動計算して表示（開封残量がある場合は `opened_remaining + (units - 1) × content_amount`）
- ConfirmDialog で確認後に消費実行することで誤操作を防止
- 通常の消費ボタンと横並びに配置し、どちらからでも操作可能

Closes #256

## Test plan

- [ ] 消費ページにロット選択後「全量消費 (Xmg)」ボタンが表示される
- [ ] ボタンタップで確認ダイアログが表示される
- [ ] 確認後に全量が消費され、詳細ページに戻る
- [ ] 開封残量あり（`opened_remaining` != null）の場合に正しい総量が計算される
- [ ] キャンセル時はダイアログが閉じるだけで消費されない

https://claude.ai/code/session_01YGPBtfyNLnWW1K54jwrE3W

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGPBtfyNLnWW1K54jwrE3W)_