### PR TITLE
fix: バグ修正3件（computeConsumption error path / カレンダーサイレントリターン / PurchaseDialog アンマウント）

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@happy-dom/global-registrator": "^20.10.3",
+        "@happy-dom/global-registrator": "^20.10.4",
         "@storybook/react-vite": "^10.3.5",
         "@tailwindcss/vite": "^4.2.4",
         "@tanstack/react-query-devtools": "5.100.8",
@@ -349,7 +349,7 @@
 
     "@hapi/topo": ["@hapi/topo@5.1.0", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg=="],
 
-    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.3", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.3" } }, "sha512-rw10ox5gAdKT5UScrrhLRE8y9t2xzvRx2lUNwbXlPogJixYGciElqywuLlcmX+Rgcif0sF2wWUwqUEob1BKZTA=="],
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.4", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.4" } }, "sha512-d1iWnYgb20MuHYyXVcjkEdFkUy5+myq8RyLAFK9Sy4PVNy/cU5xrM5JM/MMMR3KDZQ6YNVj9puy96lcfEaKh8Q=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
@@ -1163,7 +1163,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "happy-dom": ["happy-dom@20.10.3", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-Hjdiy8RziuCcn5z04QI/rlsNuQoG8P0xxjgvsSMpi89cvIXIOcucQtiHS1yHSShxoBcSCeYqAskINmTiy/mlfw=="],
+    "happy-dom": ["happy-dom@20.10.4", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-bKrsQnFNpcjZG0UPsH7UMN7Oyp3AB42LXk2GuiQmu7l4QFxH7lsw5T1eWEtE2+vbIFrTC45sbNSB2pkB8MTfKA=="],
 
     "hard-rejection": ["hard-rejection@2.1.0", "", {}, "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@happy-dom/global-registrator": "^20.10.3",
+    "@happy-dom/global-registrator": "^20.10.4",
     "@storybook/react-vite": "^10.3.5",
     "@tailwindcss/vite": "^4.2.4",
     "@tanstack/react-query-devtools": "5.100.8",

--- a/src/locales/en/calendar.json
+++ b/src/locales/en/calendar.json
@@ -19,5 +19,6 @@
   "nextMonth": "Next month",
   "selectYearMonth": "Select year and month",
   "prevYear": "Previous year",
-  "nextYear": "Next year"
+  "nextYear": "Next year",
+  "noEligibleLot": "No lot expiring this month found"
 }

--- a/src/locales/ja/calendar.json
+++ b/src/locales/ja/calendar.json
@@ -19,5 +19,6 @@
   "nextMonth": "次の月",
   "selectYearMonth": "年月を選択",
   "prevYear": "前の年",
-  "nextYear": "次の年"
+  "nextYear": "次の年",
+  "noEligibleLot": "今月中に期限を迎えるロットが見つかりません"
 }

--- a/src/routes/_auth.calendar.tsx
+++ b/src/routes/_auth.calendar.tsx
@@ -43,6 +43,7 @@ const CalendarRoutePage = () => {
   const [pendingRemovals, setPendingRemovals] = useState<Record<string, PendingLotRemoval>>({});
   const { toast } = useToast();
   const { t } = useTranslation("common");
+  const { t: tc } = useTranslation("calendar");
 
   const handleCheck = async (item: Item) => {
     try {
@@ -72,7 +73,10 @@ const CalendarRoutePage = () => {
         return exp <= monthEnd;
       });
 
-      if (!targetLot) return;
+      if (!targetLot) {
+        toast(tc("noEligibleLot"), "warning");
+        return;
+      }
 
       const { error: updateError } = await supabase
         .from("item_lots")

--- a/src/routes/_auth.shopping.tsx
+++ b/src/routes/_auth.shopping.tsx
@@ -63,11 +63,12 @@ const ShoppingPage = () => {
   const handlePurchase = async (values: ItemFormValues) => {
     if (!pendingPurchaseId) return;
     const id = pendingPurchaseId;
-    setPendingPurchaseId(null);
     try {
       await purchase.mutateAsync({ shoppingItemId: id, itemValues: values });
+      setPendingPurchaseId(null);
       toast(t("purchaseSuccess"), "success");
     } catch {
+      setPendingPurchaseId(null);
       toast(t("purchaseError"), "error");
     }
   };

--- a/src/types/item.test.ts
+++ b/src/types/item.test.ts
@@ -173,14 +173,17 @@ describe("computeConsumption", () => {
     expect(r.opened_remaining_after).toBe(400);
   });
 
-  test("consume more than total stock => error", () => {
+  test("consume more than total stock => error with null opened_remaining_after", () => {
     const r = computeConsumption({ ...baseItem, units: 1, opened_remaining: 200 }, 800);
     expect(r.error).toBeDefined();
+    expect(r.units_after).toBe(0);
+    expect(r.opened_remaining_after).toBeNull();
   });
 
-  test("units=0 consume => error", () => {
+  test("units=0 consume => error with null opened_remaining_after", () => {
     const r = computeConsumption({ ...baseItem, units: 0, opened_remaining: 0 }, 1);
     expect(r.error).toBeDefined();
+    expect(r.opened_remaining_after).toBeNull();
   });
 
   test("consume exact total (single unit, full)", () => {
@@ -197,9 +200,10 @@ describe("computeConsumption", () => {
     expect(r.error).toBeUndefined();
   });
 
-  test("opened: consume more than opened with no sealed units left => error", () => {
+  test("opened: consume more than opened with no sealed units left => error with null opened_remaining_after", () => {
     // units=1 (the open unit), opened=200, delta=300: only 200 available, not 800
     const r = computeConsumption({ ...baseItem, units: 1, opened_remaining: 200 }, 300);
     expect(r.error).toBeDefined();
+    expect(r.opened_remaining_after).toBeNull();
   });
 });

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -145,7 +145,7 @@ export const computeConsumption = (
         : units * contentAmount;
 
   if (delta > totalBefore) {
-    return { units_after: 0, opened_remaining_after: 0, error: "insufficientStock" };
+    return { units_after: 0, opened_remaining_after: null, error: "insufficientStock" };
   }
 
   // Round to avoid floating-point noise (DB stores numeric(12,2))


### PR DESCRIPTION
## Summary

今回のバグ洗い出しセッションで発見した3件のバグを修正します。

### #268: `computeConsumption` の error path で `opened_remaining_after` が `null` ではなく `0` を返す

- `src/types/item.ts:148`：insufficientStock エラー時の戻り値 `opened_remaining_after: 0` → `null` に修正
- `opened_remaining = null` は「未開封」を意味するDB仕様のため、エラー時は `0` ではなく `null` が正しい
- `src/types/item.test.ts`：error path で `opened_remaining_after` が `null` であることを検証するテストを追加

Closes #268

### #269: カレンダーページで対象ロットが見つからない場合フィードバックなしでサイレントリターン

- `src/routes/_auth.calendar.tsx:75`：`if (!targetLot) return` をトースト通知付きに変更
- 期限日のないロットのみを持つアイテムをチェックした場合など、対象ロットがない状況でユーザーに warning を表示
- `src/locales/ja/calendar.json`, `src/locales/en/calendar.json`：`noEligibleLot` キーを追加

Closes #269

### #270: `PurchaseDialog` が `purchase.mutateAsync` 完了前にアンマウントされローディング状態が表示されない

- `src/routes/_auth.shopping.tsx`：`setPendingPurchaseId(null)` を `mutateAsync` 完了後（成功時・失敗時両方）に移動
- これにより `isSubmitting={purchase.isPending}` が正しく機能し、購入処理中のスピナーが表示されるようになる

Closes #270

## Test plan

- [x] `bun test` — 129件すべてパス
- [x] `bun run format:check` — 差分なし
- [x] `bun run check` (lint + typecheck) — エラーなし
- [x] `bun run build` — ビルド成功

https://claude.ai/code/session_0167F1z83mK9FnL19WFviAcc

---
_Generated by [Claude Code](https://claude.ai/code/session_0167F1z83mK9FnL19WFviAcc)_