### PR TITLE
fix: エラー時にダイアログが自動クローズされるバグと消費入力の空白バグを修正

### DIFF
--- a/src/routes/_auth.items.$itemId.consume.tsx
+++ b/src/routes/_auth.items.$itemId.consume.tsx
@@ -304,7 +304,12 @@ export const ItemConsumePage = () => {
               onClick={() => {
                 void handleSubmit();
               }}
-              disabled={consumeLot.isPending || !delta || parseFloat(delta) <= 0}
+              disabled={
+                consumeLot.isPending ||
+                !delta.trim() ||
+                isNaN(parseFloat(delta)) ||
+                parseFloat(delta) <= 0
+              }
             >
               {consumeLot.isPending ? <Spinner className="mr-2 h-4 w-4" /> : null}
               {t("consume")}

--- a/src/routes/_auth.items.$itemId.tsx
+++ b/src/routes/_auth.items.$itemId.tsx
@@ -85,7 +85,6 @@ const ItemDetailPage = () => {
       toast(t("deleteSuccess"), "success");
       void navigate({ to: "/" });
     } catch {
-      setShowDeleteConfirm(false);
       toast(t("common:unknownError"), "error");
     }
   };

--- a/src/routes/_auth.shopping.tsx
+++ b/src/routes/_auth.shopping.tsx
@@ -58,7 +58,6 @@ const ShoppingPage = () => {
       setDeleteId(null);
       toast(t("deleteSuccess"), "success");
     } catch {
-      setDeleteId(null);
       toast(t("common:unknownError"), "error");
     }
   };
@@ -80,7 +79,6 @@ const ShoppingPage = () => {
       setPendingPurchaseId(null);
       toast(t("purchaseSuccess"), "success");
     } catch {
-      setPendingPurchaseId(null);
       toast(t("purchaseError"), "error");
     }
   };


### PR DESCRIPTION
## 概要

- #275 購入エラー時に PurchaseDialog が即座にクローズされリトライ不可になるバグを修正
- #276 削除エラー時に ConfirmDialog が即座にクローズされリトライ不可になるバグを修正
- #277 消費ページの消費量入力で空白文字・非数値入力時に「消費する」ボタンが有効になるバグを修正

## 変更内容

### #275 / #276: エラー時のダイアログ自動クローズ問題

**問題**: `catch` ブロック内でダイアログの state をリセットしていたため、エラーが発生するとダイアログが閉じていた。ユーザーが入力した内容がリセットされ、再試行が困難だった。

**修正**: エラー時は state をリセットせず、ダイアログを開いたままにする。トースト通知のみ表示して再試行を可能にする。

| ファイル | 修正内容 |
|---------|---------|
| `src/routes/_auth.items.$itemId.tsx` | `handleDelete` の catch から `setShowDeleteConfirm(false)` を削除 |
| `src/routes/_auth.shopping.tsx` | `handleDelete` の catch から `setDeleteId(null)` を削除 |
| `src/routes/_auth.shopping.tsx` | `handlePurchase` の catch から `setPendingPurchaseId(null)` を削除 |

### #277: 消費量入力の disabled 判定改善

**問題**: `!delta || parseFloat(delta) <= 0` の判定では、空白文字（` `）や非数値文字列（`abc`）が通り抜けて消費ボタンが有効になっていた。

**修正**: `!delta.trim() || isNaN(parseFloat(delta)) || parseFloat(delta) <= 0` に変更し、空白・非数値文字列でもボタンが disabled になるようにした。

## テスト確認

- [x] format: `npx oxfmt --check .` 通過
- [x] typecheck: `npx tsc --noEmit` 通過
- [x] lint: `npx oxlint --config oxlint.json src` 通過（既存の warning のみ、新規エラーなし）

Closes #275
Closes #276
Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014t14S56hrpepXJJJKZof9J

---
_Generated by [Claude Code](https://claude.ai/code/session_014t14S56hrpepXJJJKZof9J)_