### PR TITLE
feat: ダッシュボードのソート・フィルター設定をlocalStorageに永続化 (#225)

### DIFF
--- a/src/routes/_auth.index.tsx
+++ b/src/routes/_auth.index.tsx
@@ -29,9 +29,14 @@ const DashboardPage = () => {
   const [categoryId, setCategoryId] = useState("");
   const [locationId, setLocationId] = useState("");
   const [expiryFilter, setExpiryFilter] = useState("");
-  const [sort, setSort] = useState<ItemSortKey>("created_at");
+  const [sort, setSort] = useState<ItemSortKey>(
+    () => (localStorage.getItem("dashboard.sort") as ItemSortKey) ?? "created_at",
+  );
   const [showFilters, setShowFilters] = useState(false);
-  const [hideEmpty, setHideEmpty] = useState(true);
+  const [hideEmpty, setHideEmpty] = useState(() => {
+    const saved = localStorage.getItem("dashboard.hideEmpty");
+    return saved !== null ? saved === "true" : true;
+  });
   const [quickConsumingId, setQuickConsumingId] = useState<string | null>(null);
 
   const handleQuickConsume = async (item: Item) => {
@@ -225,7 +230,14 @@ const DashboardPage = () => {
             </div>
             <div>
               <label className="mb-1 block text-xs text-muted-foreground">{tc("sort")}</label>
-              <Select value={sort} onChange={(e) => setSort(e.target.value as ItemSortKey)}>
+              <Select
+                value={sort}
+                onChange={(e) => {
+                  const v = e.target.value as ItemSortKey;
+                  setSort(v);
+                  localStorage.setItem("dashboard.sort", v);
+                }}
+              >
                 <option value="created_at">{t("sortByCreatedAt")}</option>
                 <option value="expiry_date">{t("sortByExpiry")}</option>
                 <option value="purchase_date">{t("sortByPurchaseDate")}</option>
@@ -236,7 +248,10 @@ const DashboardPage = () => {
             <input
               type="checkbox"
               checked={hideEmpty}
-              onChange={(e) => setHideEmpty(e.target.checked)}
+              onChange={(e) => {
+                setHideEmpty(e.target.checked);
+                localStorage.setItem("dashboard.hideEmpty", String(e.target.checked));
+              }}
               className="rounded"
             />
             {t("hideEmpty")}


### PR DESCRIPTION
## Summary

- ダッシュボードの「ソート順」と「空アイテム非表示」設定を `localStorage` に永続化
- ページリロード・画面遷移後も前回の設定が引き継がれるようになる
- デフォルト値: sort=`created_at`、hideEmpty=`true`（既存動作と同一）

## 変更内容

- `src/routes/_auth.index.tsx`
  - `sort` の初期値を `localStorage.getItem("dashboard.sort")` から取得
  - `hideEmpty` の初期値を `localStorage.getItem("dashboard.hideEmpty")` から取得
  - それぞれの変更時に `localStorage.setItem` で保存

## Test plan

- [ ] ソート順を変更してリロード → 変更後のソート順が維持される
- [ ] 「空アイテムを非表示」チェックを外してリロード → 非表示設定が維持される
- [ ] 初回アクセス（localStorage なし）でデフォルト値が適用される

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Wr846zAxDd3ouFdv7pdGY

---
_Generated by [Claude Code](https://claude.ai/code/session_014Wr846zAxDd3ouFdv7pdGY)_