### PR TITLE
feat: ショッピングリストアイテムのインライン編集機能 (#271)

### DIFF
--- a/src/components/molecules/ShoppingRow.stories.tsx
+++ b/src/components/molecules/ShoppingRow.stories.tsx
@@ -18,6 +18,7 @@ export const Default: Story = {
     desiredUnits: 2,
     onPurchase: () => {},
     onDelete: () => {},
+    onEdit: () => {},
   },
 };
 
@@ -29,6 +30,7 @@ export const WithNote: Story = {
     note: "無添加のもの",
     onPurchase: () => {},
     onDelete: () => {},
+    onEdit: () => {},
   },
 };
 
@@ -39,5 +41,28 @@ export const Purchased: Story = {
     desiredUnits: 3,
     isPurchased: true,
     onDelete: () => {},
+  },
+};
+
+export const EditMode: Story = {
+  args: {
+    id: "4",
+    name: "牛乳",
+    desiredUnits: 2,
+    note: "低脂肪",
+    isEditing: true,
+    onEditSave: () => {},
+    onEditCancel: () => {},
+  },
+};
+
+export const EditModeNoNote: Story = {
+  args: {
+    id: "5",
+    name: "卵",
+    desiredUnits: 1,
+    isEditing: true,
+    onEditSave: () => {},
+    onEditCancel: () => {},
   },
 };

--- a/src/components/molecules/ShoppingRow.tsx
+++ b/src/components/molecules/ShoppingRow.tsx
@@ -1,7 +1,9 @@
-import { CheckCircle2, ShoppingCart, Trash2 } from "lucide-react";
+import { CheckCircle2, Pencil, ShoppingCart, Trash2 } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 interface ShoppingRowProps {
   id: string;
@@ -9,8 +11,15 @@ interface ShoppingRowProps {
   desiredUnits: number;
   note?: string | null;
   isPurchased?: boolean;
+  isEditing?: boolean;
   onPurchase?: (id: string) => void;
   onDelete?: (id: string) => void;
+  onEdit?: (id: string) => void;
+  onEditSave?: (
+    id: string,
+    data: { name: string; desiredUnits: number; note: string | null },
+  ) => void;
+  onEditCancel?: () => void;
 }
 
 export const ShoppingRow = ({
@@ -19,10 +28,86 @@ export const ShoppingRow = ({
   desiredUnits,
   note,
   isPurchased,
+  isEditing,
   onPurchase,
   onDelete,
+  onEdit,
+  onEditSave,
+  onEditCancel,
 }: ShoppingRowProps) => {
   const { t } = useTranslation("shopping");
+
+  const [editName, setEditName] = useState(name);
+  const [editUnits, setEditUnits] = useState(String(desiredUnits));
+  const [editNote, setEditNote] = useState(note ?? "");
+
+  const resetEditState = () => {
+    setEditName(name);
+    setEditUnits(String(desiredUnits));
+    setEditNote(note ?? "");
+  };
+
+  const handleEditStart = () => {
+    resetEditState();
+    onEdit?.(id);
+  };
+
+  const handleSave = () => {
+    const parsedUnits = parseInt(editUnits, 10);
+    onEditSave?.(id, {
+      name: editName.trim() || name,
+      desiredUnits: isNaN(parsedUnits) || parsedUnits <= 0 ? 1 : parsedUnits,
+      note: editNote.trim() || null,
+    });
+  };
+
+  const handleCancel = () => {
+    resetEditState();
+    onEditCancel?.();
+  };
+
+  if (isEditing) {
+    return (
+      <div className="space-y-2 rounded-lg border p-3">
+        <Input
+          value={editName}
+          onChange={(e) => setEditName(e.target.value)}
+          placeholder={t("itemNamePlaceholder")}
+          autoFocus
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSave();
+            if (e.key === "Escape") handleCancel();
+          }}
+        />
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <Input
+              type="number"
+              min={1}
+              value={editUnits}
+              onChange={(e) => setEditUnits(e.target.value)}
+              placeholder={t("desiredUnitsLabel")}
+            />
+          </div>
+          <div className="flex-[2]">
+            <Input
+              value={editNote}
+              onChange={(e) => setEditNote(e.target.value)}
+              placeholder={t("notePlaceholder")}
+            />
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Button size="sm" className="flex-1" onClick={handleSave} disabled={!editName.trim()}>
+            {t("editSave")}
+          </Button>
+          <Button size="sm" variant="outline" onClick={handleCancel}>
+            {t("editCancel")}
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div
@@ -46,12 +131,24 @@ export const ShoppingRow = ({
             {t("markPurchased")}
           </Button>
         )}
+        {!isPurchased && onEdit && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-muted-foreground hover:text-foreground"
+            onClick={handleEditStart}
+            aria-label={t("editItem")}
+          >
+            <Pencil className="h-4 w-4" />
+          </Button>
+        )}
         {onDelete && (
           <Button
             variant="ghost"
             size="icon"
             className="text-muted-foreground hover:text-destructive"
             onClick={() => onDelete(id)}
+            aria-label={t("common:delete")}
           >
             <Trash2 className="h-4 w-4" />
           </Button>

--- a/src/locales/en/shopping.json
+++ b/src/locales/en/shopping.json
@@ -24,5 +24,10 @@
   "clearPurchasedTitle": "Clear purchased items",
   "clearPurchasedConfirm": "Delete all purchased items? This cannot be undone.",
   "clearPurchasedConfirmLabel": "Delete all",
-  "clearPurchasedSuccess": "Purchased items cleared"
+  "clearPurchasedSuccess": "Purchased items cleared",
+  "editItem": "Edit",
+  "editSuccess": "Updated",
+  "editCancel": "Cancel",
+  "editSave": "Save",
+  "desiredUnitsLabel": "Desired qty"
 }

--- a/src/locales/ja/shopping.json
+++ b/src/locales/ja/shopping.json
@@ -24,5 +24,10 @@
   "clearPurchasedTitle": "購入済みアイテムを削除",
   "clearPurchasedConfirm": "購入済みのアイテムをすべて削除しますか？この操作は取り消せません。",
   "clearPurchasedConfirmLabel": "すべて削除",
-  "clearPurchasedSuccess": "購入済みアイテムを削除しました"
+  "clearPurchasedSuccess": "購入済みアイテムを削除しました",
+  "editItem": "編集",
+  "editSuccess": "更新しました",
+  "editCancel": "キャンセル",
+  "editSave": "保存",
+  "desiredUnitsLabel": "希望数量"
 }

--- a/src/routes/_auth.shopping.tsx
+++ b/src/routes/_auth.shopping.tsx
@@ -29,6 +29,7 @@ const ShoppingPage = () => {
   const [addNote, setAddNote] = useState("");
   const [showAdd, setShowAdd] = useState(false);
   const [pendingPurchaseId, setPendingPurchaseId] = useState<string | null>(null);
+  const [editId, setEditId] = useState<string | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [showClearPurchased, setShowClearPurchased] = useState(false);
 
@@ -69,6 +70,24 @@ const ShoppingPage = () => {
       toast(t("clearPurchasedSuccess"), "success");
     } catch {
       // Error toast is handled by useDeleteAllPurchasedItems.onError
+    }
+  };
+
+  const handleEdit = async (
+    id: string,
+    data: { name: string; desiredUnits: number; note: string | null },
+  ) => {
+    try {
+      await upsert.mutateAsync({
+        id,
+        name: data.name,
+        desired_units: data.desiredUnits,
+        note: data.note,
+      });
+      setEditId(null);
+      toast(t("editSuccess"), "success");
+    } catch {
+      toast(t("common:unknownError"), "error");
     }
   };
 
@@ -243,8 +262,14 @@ const ShoppingPage = () => {
               desiredUnits={item.desired_units}
               note={item.note}
               isPurchased={item.status === "purchased"}
+              isEditing={editId === item.id}
               onPurchase={tab === "planned" ? (id) => setPendingPurchaseId(id) : undefined}
               onDelete={(id) => setDeleteId(id)}
+              onEdit={tab === "planned" ? (id) => setEditId(id) : undefined}
+              onEditSave={(id, data) => {
+                void handleEdit(id, data);
+              }}
+              onEditCancel={() => setEditId(null)}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary

- ショッピングリストのアイテムを追加後に編集できるようになる
- 鉛筆アイコンボタンからインラインフォームで名前・希望数量・メモを変更可能
- Enter/Escapeキーショートカット対応
- 購入済みアイテムには編集ボタンを表示しない

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/components/molecules/ShoppingRow.tsx` | 編集ボタン・インライン編集フォーム追加 |
| `src/routes/_auth.shopping.tsx` | `editId` state・`handleEdit` ハンドラー追加 |
| `src/locales/ja/shopping.json` | `editItem`/`editSuccess`/`editSave`/`editCancel`/`desiredUnitsLabel` 追加 |
| `src/locales/en/shopping.json` | 同上（英語） |
| `src/components/molecules/ShoppingRow.stories.tsx` | `EditMode`/`EditModeNoNote` ストーリー追加 |

## Test plan

- [ ] 予定タブのアイテムに鉛筆ボタンが表示される
- [ ] 鉛筆ボタンをタップするとインラインフォームが開く
- [ ] 名前・数量・メモを変更して「保存」でDB更新される
- [ ] Enterキーで保存、Escapeキーでキャンセル
- [ ] 「キャンセル」で元の値に戻る
- [ ] 購入済みタブのアイテムには編集ボタンが表示されない

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Wr846zAxDd3ouFdv7pdGY

---
_Generated by [Claude Code](https://claude.ai/code/session_014Wr846zAxDd3ouFdv7pdGY)_