### PR TITLE
feat: バーコード手動入力後の商品検索ボタンを追加 (#223)

### DIFF
--- a/src/components/organisms/ItemForm.stories.tsx
+++ b/src/components/organisms/ItemForm.stories.tsx
@@ -63,3 +63,12 @@ export const StackMode: Story = {
     submitLabel: "追加購入として登録",
   },
 };
+
+/** バーコードが入力済みで検索ボタンが有効な状態 */
+export const WithBarcodeEntered: Story = {
+  args: {
+    defaultValues: {
+      barcode: "4901234567890",
+    },
+  },
+};

--- a/src/components/organisms/ItemForm.tsx
+++ b/src/components/organisms/ItemForm.tsx
@@ -1,4 +1,4 @@
-import { Barcode, Loader2 } from "lucide-react";
+import { Barcode, Loader2, Search } from "lucide-react";
 import { type FormEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -226,7 +226,29 @@ export const ItemForm = ({
               value={values.barcode ?? ""}
               onChange={(e) => set("barcode", e.target.value)}
               placeholder={t("barcodePlaceholder")}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && values.barcode) {
+                  e.preventDefault();
+                  void handleBarcodeScan(values.barcode);
+                }
+              }}
             />
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={() => {
+                if (values.barcode) void handleBarcodeScan(values.barcode);
+              }}
+              disabled={isLookingUp || !values.barcode}
+              title={t("searchBarcode")}
+            >
+              {isLookingUp ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Search className="h-4 w-4" />
+              )}
+            </Button>
             <Button
               type="button"
               variant="outline"
@@ -235,11 +257,7 @@ export const ItemForm = ({
               disabled={isLookingUp}
               title={t("scanBarcode")}
             >
-              {isLookingUp ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Barcode className="h-4 w-4" />
-              )}
+              <Barcode className="h-4 w-4" />
             </Button>
           </div>
         </div>

--- a/src/locales/en/items.json
+++ b/src/locales/en/items.json
@@ -40,6 +40,7 @@
   "consumeError": "Failed to record consumption",
   "insufficientStock": "Insufficient stock",
   "scanBarcode": "Scan Barcode",
+  "searchBarcode": "Search product by barcode",
   "scannerStarting": "Starting camera...",
   "scannerHint": "Point the camera at a barcode to scan",
   "scannerError": "Camera Error",

--- a/src/locales/ja/items.json
+++ b/src/locales/ja/items.json
@@ -40,6 +40,7 @@
   "consumeError": "消費の記録に失敗しました",
   "insufficientStock": "在庫が不足しています",
   "scanBarcode": "バーコードをスキャン",
+  "searchBarcode": "バーコードで商品を検索",
   "scannerStarting": "カメラを起動中...",
   "scannerHint": "バーコードにカメラを向けてください",
   "scannerError": "カメラエラー",


### PR DESCRIPTION
## Summary

- アイテムフォームのバーコード欄横に検索ボタン（虫眼鏡アイコン）を追加
- カメラなし・スキャン困難な環境でもバーコード番号を手動入力して商品情報を取得できる
- Enterキー押下でも同様に検索を実行
- バーコード未入力時は検索ボタンを無効化

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `src/components/organisms/ItemForm.tsx` | 検索ボタン追加、Enterキー対応 |
| `src/locales/ja/items.json` | `searchBarcode` キー追加 |
| `src/locales/en/items.json` | `searchBarcode` キー追加 |
| `src/components/organisms/ItemForm.stories.tsx` | `WithBarcodeEntered` ストーリー追加 |

## Test plan

- [ ] バーコード欄に数字を入力すると検索ボタンが有効になる
- [ ] 検索ボタンをタップすると商品情報が取得される（既存のスキャンと同じ挙動）
- [ ] Enterキーでも商品検索が実行される
- [ ] バーコード未入力時は検索ボタンが無効（disabled）
- [ ] スキャンボタン（カメラアイコン）は従来通り動作する

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Wr846zAxDd3ouFdv7pdGY

---
_Generated by [Claude Code](https://claude.ai/code/session_014Wr846zAxDd3ouFdv7pdGY)_