### PR TITLE
feat: アイテム複製（Clone）機能を追加 (#238)

### DIFF
--- a/src/components/pages/NewItemPage.tsx
+++ b/src/components/pages/NewItemPage.tsx
@@ -4,15 +4,20 @@ import { ArrowLeft, PackagePlus } from "lucide-react";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { Spinner } from "@/components/atoms/Spinner";
 import { ItemForm } from "@/components/organisms/ItemForm";
 import { Button } from "@/components/ui/button";
 import { downloadExternalImageAsFile, uploadItemImage } from "@/hooks/useItemImage";
-import { findActiveItemByBarcode, useCreateItem } from "@/hooks/useItems";
+import { findActiveItemByBarcode, useCreateItem, useItem } from "@/hooks/useItems";
 import { OfflineError } from "@/lib/requireOnline";
 import { useToast } from "@/lib/toast-context";
 import type { Item, ItemFormValues } from "@/types/item";
 
-export const NewItemPage = () => {
+interface NewItemPageProps {
+  cloneFrom?: string;
+}
+
+export const NewItemPage = ({ cloneFrom }: NewItemPageProps) => {
   const { t } = useTranslation("items");
   const navigate = useNavigate();
   const qc = useQueryClient();
@@ -22,6 +27,8 @@ export const NewItemPage = () => {
   const pendingImageUrlRef = useRef<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [existingItem, setExistingItem] = useState<Item | null>(null);
+
+  const { data: cloneSource, isLoading: isCloneLoading } = useItem(cloneFrom ?? "");
 
   const handleBarcodeScanned = async (barcode: string, source: "db" | "api" | null) => {
     if (source !== "db") {
@@ -62,7 +69,7 @@ export const NewItemPage = () => {
         toast(t("stackSuccess"), "success");
         void navigate({ to: "/items/$itemId", params: { itemId: item.id } });
       } else {
-        toast(t("createSuccess"), "success");
+        toast(cloneFrom ? t("cloneSuccess") : t("createSuccess"), "success");
         void navigate({ to: "/" });
       }
     } catch {
@@ -72,13 +79,36 @@ export const NewItemPage = () => {
     }
   };
 
+  const cloneDefaultValues: Partial<ItemFormValues> | undefined = cloneSource
+    ? {
+        name: cloneSource.name,
+        barcode: cloneSource.barcode ?? "",
+        category_id: cloneSource.category_id,
+        storage_location_id: cloneSource.storage_location_id,
+        content_amount: cloneSource.content_amount,
+        content_unit: cloneSource.content_unit,
+        units: 1,
+        purchase_date: "",
+        expiry_date: "",
+        notes: "",
+      }
+    : undefined;
+
+  if (cloneFrom && isCloneLoading) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
   return (
     <div className="mx-auto max-w-2xl space-y-4">
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon" onClick={() => void navigate({ to: "/" })}>
           <ArrowLeft className="h-5 w-5" />
         </Button>
-        <h1 className="text-xl font-bold">{t("addItem")}</h1>
+        <h1 className="text-xl font-bold">{cloneFrom ? t("cloneItem") : t("addItem")}</h1>
       </div>
 
       {existingItem && (
@@ -108,6 +138,7 @@ export const NewItemPage = () => {
           void handleBarcodeScanned(barcode, source);
         }}
         submitLabel={existingItem ? t("stackSubmitLabel") : undefined}
+        defaultValues={cloneDefaultValues}
       />
     </div>
   );

--- a/src/locales/en/items.json
+++ b/src/locales/en/items.json
@@ -126,5 +126,7 @@
   "consumeAll": "Use all ({{amount}}{{unit}})",
   "consumeAllTitle": "Use all stock",
   "consumeAllConfirm": "Use all stock in this lot ({{amount}}{{unit}})?",
-  "consumeAllConfirmLabel": "Use all"
+  "consumeAllConfirmLabel": "Use all",
+  "cloneItem": "Duplicate Item",
+  "cloneSuccess": "Item duplicated and added"
 }

--- a/src/locales/ja/items.json
+++ b/src/locales/ja/items.json
@@ -125,5 +125,7 @@
   "consumeAll": "全量消費 ({{amount}}{{unit}})",
   "consumeAllTitle": "全量消費の確認",
   "consumeAllConfirm": "このロットの全量（{{amount}}{{unit}}）を消費しますか？",
-  "consumeAllConfirmLabel": "全量消費する"
+  "consumeAllConfirmLabel": "全量消費する",
+  "cloneItem": "複製して追加",
+  "cloneSuccess": "複製して在庫を追加しました"
 }

--- a/src/routes/_auth.items.$itemId.tsx
+++ b/src/routes/_auth.items.$itemId.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Outlet, useNavigate, useRouterState } from "@tanstack/
 import {
   ArrowLeft,
   Calendar,
+  Copy,
   Edit,
   Hash,
   History,
@@ -189,6 +190,14 @@ const ItemDetailPage = () => {
             onClick={() => void navigate({ to: "/items/$itemId/edit", params: { itemId } })}
           >
             <Edit className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            aria-label={t("cloneItem")}
+            onClick={() => void navigate({ to: "/items/new", search: { cloneFrom: itemId } })}
+          >
+            <Copy className="h-4 w-4" />
           </Button>
           <Button
             variant="destructive"

--- a/src/routes/_auth.items.new.tsx
+++ b/src/routes/_auth.items.new.tsx
@@ -1,7 +1,18 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
 
 import { NewItemPage } from "@/components/pages/NewItemPage";
 
+const searchSchema = z.object({
+  cloneFrom: z.string().optional(),
+});
+
+const NewItemRoute = () => {
+  const { cloneFrom } = Route.useSearch();
+  return <NewItemPage cloneFrom={cloneFrom} />;
+};
+
 export const Route = createFileRoute("/_auth/items/new")({
-  component: NewItemPage,
+  validateSearch: searchSchema,
+  component: NewItemRoute,
 });


### PR DESCRIPTION
## 概要

在庫詳細画面にコピーボタンを追加し、既存アイテムの情報を引き継いだ状態で新規登録フォームを開けるようにした。

## 変更内容

- `_auth.items.$itemId.tsx`: ヘッダーに Copy アイコンボタンを追加。クリックで `/items/new?cloneFrom=<itemId>` に遷移
- `_auth.items.new.tsx`: `validateSearch` で `cloneFrom?: string` を受け取り、`NewItemPage` へ props として渡す
- `NewItemPage.tsx`: `cloneFrom` が指定された場合は元アイテムを fetch してフォームに初期値をセット
  - 引き継ぐ項目: 商品名・バーコード・カテゴリ・保管場所・内包量・単位
  - リセットする項目: 個数=1、購入日・賞味期限・メモ=空
  - ロード中はスピナーを表示
  - ページタイトルが「複製して追加」に変わる
- `locales/ja/items.json`, `locales/en/items.json`: `cloneItem`・`cloneSuccess` キーを追加

## テスト

- typecheck: ✅ エラーなし
- lint: ✅ エラーなし（既存 warning 2件のみ）
- format: ✅ 差分なし

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Wr846zAxDd3ouFdv7pdGY

---
_Generated by [Claude Code](https://claude.ai/code/session_014Wr846zAxDd3ouFdv7pdGY)_