### PR TITLE
feat: Web Share APIでショッピングリスト共有機能を追加 (#279)

### DIFF
--- a/src/components/atoms/ShareButton.stories.tsx
+++ b/src/components/atoms/ShareButton.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ShareButton } from "./ShareButton";
+
+const meta = {
+  component: ShareButton,
+  tags: ["autodocs"],
+} satisfies Meta<typeof ShareButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: "買い物リスト",
+    text: "・牛乳\n・卵\n・パン",
+    label: "共有",
+  },
+};
+
+export const WithoutLabel: Story = {
+  args: {
+    title: "Shopping List",
+    text: "- Milk\n- Eggs\n- Bread",
+  },
+};

--- a/src/components/atoms/ShareButton.tsx
+++ b/src/components/atoms/ShareButton.tsx
@@ -1,0 +1,35 @@
+import { Share2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { canShare } from "@/lib/share";
+
+interface ShareButtonProps {
+  title: string;
+  text: string;
+  label?: string;
+}
+
+export const ShareButton = ({ title, text, label }: ShareButtonProps) => {
+  if (!canShare()) return null;
+
+  const handleShare = async () => {
+    try {
+      await navigator.share({ title, text });
+    } catch {
+      // User cancelled or share failed — no action needed
+    }
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      onClick={() => {
+        void handleShare();
+      }}
+    >
+      <Share2 className="h-4 w-4" />
+      {label}
+    </Button>
+  );
+};

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,0 +1,5 @@
+export const canShare = () => "share" in navigator;
+
+export const shareText = async (title: string, text: string): Promise<void> => {
+  await navigator.share({ title, text });
+};

--- a/src/locales/en/shopping.json
+++ b/src/locales/en/shopping.json
@@ -29,5 +29,7 @@
   "editSuccess": "Updated",
   "editCancel": "Cancel",
   "editSave": "Save",
-  "desiredUnitsLabel": "Desired qty"
+  "desiredUnitsLabel": "Desired qty",
+  "share": "Share",
+  "shareShoppingList": "Share Shopping List"
 }

--- a/src/locales/ja/shopping.json
+++ b/src/locales/ja/shopping.json
@@ -29,5 +29,7 @@
   "editSuccess": "更新しました",
   "editCancel": "キャンセル",
   "editSave": "保存",
-  "desiredUnitsLabel": "希望数量"
+  "desiredUnitsLabel": "希望数量",
+  "share": "共有",
+  "shareShoppingList": "買い物リストを共有"
 }

--- a/src/routes/_auth.shopping.tsx
+++ b/src/routes/_auth.shopping.tsx
@@ -3,6 +3,7 @@ import { Plus, ShoppingCart } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { ShareButton } from "@/components/atoms/ShareButton";
 import { Spinner } from "@/components/atoms/Spinner";
 import { ConfirmDialog } from "@/components/molecules/ConfirmDialog";
 import { ShoppingRow } from "@/components/molecules/ShoppingRow";
@@ -34,6 +35,7 @@ const ShoppingPage = () => {
   const [showClearPurchased, setShowClearPurchased] = useState(false);
 
   const { data: items = [], isLoading } = useShoppingList(tab);
+  const { data: plannedItems = [] } = useShoppingList("planned");
   const upsert = useUpsertShoppingItem();
   const deleteItem = useDeleteShoppingItem();
   const purchase = usePurchaseShoppingItem();
@@ -146,10 +148,25 @@ const ShoppingPage = () => {
           <ShoppingCart className="h-6 w-6" />
           <h1 className="text-2xl font-bold">{t("title")}</h1>
         </div>
-        <Button size="sm" onClick={() => setShowAdd((v) => !v)}>
-          <Plus className="mr-1 h-4 w-4" />
-          {t("addItem")}
-        </Button>
+        <div className="flex items-center gap-2">
+          {plannedItems.length > 0 && (
+            <ShareButton
+              title={t("shareShoppingList")}
+              text={plannedItems
+                .map((item) =>
+                  item.desired_units > 1
+                    ? `・${item.name} ×${item.desired_units}`
+                    : `・${item.name}`,
+                )
+                .join("\n")}
+              label={t("share")}
+            />
+          )}
+          <Button size="sm" onClick={() => setShowAdd((v) => !v)}>
+            <Plus className="mr-1 h-4 w-4" />
+            {t("addItem")}
+          </Button>
+        </div>
       </div>
 
       {/* Add form */}


### PR DESCRIPTION
## 概要

Web Share API を使ってショッピングリストをネイティブシェアシートで共有できる機能を追加した。`navigator.share` 非対応環境（デスクトップ Chrome 等）ではボタン自体が非表示になる。

## 変更内容

- `src/lib/share.ts`: `canShare()` ユーティリティを追加
- `src/components/atoms/ShareButton.tsx`: Share2 アイコンのボタンアトム。`navigator.share` 非対応時は `null` を返す
- `src/components/atoms/ShareButton.stories.tsx`: Default / WithoutLabel の2ストーリー
- `_auth.shopping.tsx`:
  - 予定リストに1件以上ある場合のみヘッダーに共有ボタンを表示
  - シェアテキスト形式: `・商品名 ×数量` を改行で結合
- `locales/ja/shopping.json`, `locales/en/shopping.json`: `share`・`shareShoppingList` キーを追加

## テスト

- typecheck: ✅ エラーなし
- lint: ✅ エラーなし（既存 warning 2件のみ）
- format: ✅ 差分なし

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Wr846zAxDd3ouFdv7pdGY

---
_Generated by [Claude Code](https://claude.ai/code/session_014Wr846zAxDd3ouFdv7pdGY)_