### PR TITLE
refactor: クリーンアーキテクチャに従い型定義をドメイン層に集約

### DIFF
--- a/src/hooks/useBarcodeLookup.ts
+++ b/src/hooks/useBarcodeLookup.ts
@@ -1,14 +1,9 @@
 import { useState } from "react";
 
 import { supabase } from "@/lib/supabase";
+import type { BarcodeLookupResult, BarcodeLookupSource, ProductInfo } from "@/types/barcode";
 
-export interface ProductInfo {
-  name: string;
-  /** External image URL (from barcode API). Use onPendingImageUrlChange to download & upload. */
-  image_url?: string;
-  description?: string;
-  brand?: string;
-}
+export type { BarcodeLookupResult, BarcodeLookupSource, ProductInfo };
 
 interface LookupResult {
   product: {
@@ -22,13 +17,6 @@ interface LookupResult {
 interface ItemLookupRow {
   name: string;
   image_path: string | null;
-}
-
-export type BarcodeLookupSource = "db" | "api";
-
-export interface BarcodeLookupResult {
-  product: ProductInfo | null;
-  source: BarcodeLookupSource | null;
 }
 
 export const useBarcodeLookup = () => {

--- a/src/hooks/useCalendarConsume.ts
+++ b/src/hooks/useCalendarConsume.ts
@@ -1,0 +1,146 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { LOTS_KEY, syncItemAggregate } from "@/hooks/useItemLots";
+import { OfflineError, requireOnline } from "@/lib/requireOnline";
+import { supabase } from "@/lib/supabase";
+import { useToast } from "@/lib/toast-context";
+import { computeCalendarDelta, type PendingLotRemoval } from "@/types/calendar";
+import type { Item } from "@/types/item";
+
+const invalidateCalendarQueries = async (qc: ReturnType<typeof useQueryClient>, itemId: string) => {
+  await Promise.all([
+    qc.invalidateQueries({ queryKey: ["items"] }),
+    qc.invalidateQueries({ queryKey: [...LOTS_KEY, itemId] }),
+    qc.invalidateQueries({ queryKey: ["consumption-logs", itemId] }),
+    qc.invalidateQueries({ queryKey: ["consumption-logs-all"] }),
+  ]);
+};
+
+export const useCalendarConsume = () => {
+  const qc = useQueryClient();
+  const { toast } = useToast();
+  const { t } = useTranslation("common");
+  const { t: tc } = useTranslation("calendar");
+  const [pendingRemovals, setPendingRemovals] = useState<Record<string, PendingLotRemoval>>({});
+
+  const check = async (item: Item): Promise<void> => {
+    try {
+      requireOnline();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) throw new Error("Not authenticated");
+
+      const { data: lots, error } = await supabase
+        .from("item_lots")
+        .select("id, units, opened_remaining, expiry_date")
+        .eq("item_id", item.id)
+        .order("expiry_date", { ascending: true, nullsFirst: false })
+        .order("created_at", { ascending: true });
+      if (error) throw error;
+
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const monthEnd = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+
+      const targetLot = (lots ?? []).find((lot) => {
+        if (lot.units <= 0 && lot.opened_remaining === null) return false;
+        if (!lot.expiry_date) return false;
+        const [y, m, d] = lot.expiry_date.split("-").map(Number) as [number, number, number];
+        const exp = new Date(y, m - 1, d);
+        return exp <= monthEnd;
+      });
+
+      if (!targetLot) {
+        toast(tc("noEligibleLot"), "warning");
+        return;
+      }
+
+      const { error: updateError } = await supabase
+        .from("item_lots")
+        .update({ units: 0, opened_remaining: null, updated_at: new Date().toISOString() })
+        .eq("id", targetLot.id);
+      if (updateError) throw updateError;
+
+      const deltaAmount = computeCalendarDelta(
+        targetLot.units,
+        targetLot.opened_remaining,
+        item.content_amount,
+      );
+      const { data: logData } = await supabase
+        .from("consumption_logs")
+        .insert({
+          user_id: user.id,
+          item_id: item.id,
+          delta_amount: deltaAmount,
+          delta_unit: item.content_unit,
+          units_before: targetLot.units,
+          units_after: 0,
+          opened_remaining_before: targetLot.opened_remaining,
+          opened_remaining_after: null,
+        })
+        .select("id")
+        .single();
+
+      await syncItemAggregate(item.id);
+      await invalidateCalendarQueries(qc, item.id);
+
+      setPendingRemovals((prev) => ({
+        ...prev,
+        [item.id]: {
+          lotId: targetLot.id,
+          itemId: item.id,
+          itemName: item.name,
+          units: targetLot.units,
+          openedRemaining: targetLot.opened_remaining,
+          logId: logData?.id ?? null,
+        },
+      }));
+    } catch (err) {
+      toast(err instanceof OfflineError ? t("offlineError") : t("unknownError"), "error");
+      throw err;
+    }
+  };
+
+  const undo = async (itemId: string): Promise<void> => {
+    try {
+      requireOnline();
+      const pending = pendingRemovals[itemId];
+      if (!pending) return;
+
+      const { error } = await supabase
+        .from("item_lots")
+        .update({
+          units: pending.units,
+          opened_remaining: pending.openedRemaining,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", pending.lotId);
+      if (error) throw error;
+
+      if (pending.logId) {
+        await supabase.from("consumption_logs").delete().eq("id", pending.logId);
+      }
+
+      await syncItemAggregate(pending.itemId);
+      await invalidateCalendarQueries(qc, pending.itemId);
+
+      setPendingRemovals((prev) => {
+        const next = { ...prev };
+        delete next[itemId];
+        return next;
+      });
+    } catch (err) {
+      toast(err instanceof OfflineError ? t("offlineError") : t("unknownError"), "error");
+    }
+  };
+
+  const pendingRemovalList = Object.values(pendingRemovals).map(({ itemId, itemName }) => ({
+    itemId,
+    itemName,
+  }));
+
+  return { check, undo, pendingRemovalList };
+};

--- a/src/hooks/useConsumeItem.ts
+++ b/src/hooks/useConsumeItem.ts
@@ -5,12 +5,7 @@ import { consumeLot as consumeLotFn, LOTS_KEY } from "@/hooks/useItemLots";
 import { OfflineError, requireOnline } from "@/lib/requireOnline";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/lib/toast-context";
-import { computeConsumption, type Item } from "@/types/item";
-
-interface ConsumeParams {
-  item: Item;
-  deltaAmount: number;
-}
+import { computeConsumption, type ConsumeParams, type Item } from "@/types/item";
 
 /** Consume from a single-lot item (backward compat path). */
 const consumeItem = async ({ item, deltaAmount }: ConsumeParams): Promise<Item> => {

--- a/src/hooks/useItemLots.ts
+++ b/src/hooks/useItemLots.ts
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { OfflineError, requireOnline } from "@/lib/requireOnline";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/lib/toast-context";
-import { computeConsumption, type Item, type ItemLot } from "@/types/item";
+import { computeConsumption, type ConsumeLotParams, type ItemLot } from "@/types/item";
 
 export const LOTS_KEY = ["item-lots"] as const;
 
@@ -102,12 +102,6 @@ export const syncItemAggregate = async (itemId: string): Promise<void> => {
     .eq("id", itemId);
   if (updateError) throw updateError;
 };
-
-interface ConsumeLotParams {
-  lot: ItemLot;
-  item: Pick<Item, "content_amount" | "content_unit">;
-  deltaAmount: number;
-}
 
 export const consumeLot = async ({
   lot,

--- a/src/hooks/useItems.ts
+++ b/src/hooks/useItems.ts
@@ -6,17 +6,9 @@ import { upsertItemInListCache } from "@/lib/itemCache";
 import { OfflineError, requireOnline } from "@/lib/requireOnline";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/lib/toast-context";
-import type { Item, ItemFormValues } from "@/types/item";
+import type { Item, ItemFilters, ItemFormValues, ItemSortKey } from "@/types/item";
 
-/** Filters applied server-side (Supabase query). Client-only filters such as
- *  expiryStatus and hideEmpty are handled by the caller after fetching. */
-export interface ItemFilters {
-  search?: string;
-  categoryId?: string;
-  storageLocationId?: string;
-}
-
-export type ItemSortKey = "expiry_date" | "purchase_date" | "created_at";
+export type { ItemFilters, ItemSortKey };
 
 const ITEMS_KEY = ["items"] as const;
 

--- a/src/hooks/useNotificationPreferences.ts
+++ b/src/hooks/useNotificationPreferences.ts
@@ -4,17 +4,9 @@ import { useTranslation } from "react-i18next";
 import { OfflineError, requireOnline } from "@/lib/requireOnline";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/lib/toast-context";
+import type { NotificationPreferences, UpdatePrefs } from "@/types/user";
 
-export interface NotificationPreferences {
-  user_id: string;
-  push_enabled: boolean;
-  email_enabled: boolean;
-  email_address: string | null;
-  threshold_days: number;
-  notify_at: string;
-}
-
-type UpdatePrefs = Partial<Omit<NotificationPreferences, "user_id">>;
+export type { NotificationPreferences };
 
 const PREFS_KEY = ["notification-preferences"] as const;
 

--- a/src/hooks/useShoppingList.ts
+++ b/src/hooks/useShoppingList.ts
@@ -6,35 +6,12 @@ import { OfflineError, requireOnline } from "@/lib/requireOnline";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/lib/toast-context";
 import type { Item, ItemFormValues } from "@/types/item";
-
-type ShoppingStatus = "planned" | "purchased";
-
-interface ShoppingItem {
-  id: string;
-  user_id: string;
-  name: string;
-  desired_units: number;
-  note: string | null;
-  linked_item_id: string | null;
-  status: ShoppingStatus;
-  purchased_at: string | null;
-  created_item_id: string | null;
-  created_at: string;
-  updated_at: string;
-}
-
-interface UpsertShoppingItemInput {
-  id?: string;
-  name: string;
-  desired_units?: number;
-  note?: string | null;
-  linked_item_id?: string | null;
-}
-
-interface PurchaseInput {
-  shoppingItemId: string;
-  itemValues: ItemFormValues;
-}
+import type {
+  PurchaseInput,
+  ShoppingItem,
+  ShoppingStatus,
+  UpsertShoppingItemInput,
+} from "@/types/shopping";
 
 const QUERY_KEY = "shopping";
 

--- a/src/lib/itemCache.ts
+++ b/src/lib/itemCache.ts
@@ -1,5 +1,4 @@
-import type { ItemSortKey } from "@/hooks/useItems";
-import type { Item } from "@/types/item";
+import type { Item, ItemSortKey } from "@/types/item";
 
 const compareNullableDatesAsc = (
   a: string | null | undefined,

--- a/src/routes/_auth.calendar.tsx
+++ b/src/routes/_auth.calendar.tsx
@@ -1,182 +1,25 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { useState } from "react";
-import { useTranslation } from "react-i18next";
 
 import { CalendarPage } from "@/components/pages/CalendarPage";
-import { LOTS_KEY, syncItemAggregate } from "@/hooks/useItemLots";
+import { useCalendarConsume } from "@/hooks/useCalendarConsume";
 import { useItemsWithExpiry } from "@/hooks/useItems";
 import { useCategories } from "@/hooks/useMasterData";
-import { OfflineError, requireOnline } from "@/lib/requireOnline";
-import { supabase } from "@/lib/supabase";
-import { useToast } from "@/lib/toast-context";
-import type { Item } from "@/types/item";
 
-interface PendingLotRemoval {
-  lotId: string;
-  itemId: string;
-  itemName: string;
-  units: number;
-  openedRemaining: number | null;
-  logId: string | null;
-}
-
-/**
- * カレンダーの「消費済み」チェック操作での消費量を計算する。
- * opened_remaining がある場合は開封済み分の残量も含める。
- */
-export const computeCalendarDelta = (
-  units: number,
-  openedRemaining: number | null,
-  contentAmount: number,
-): number => {
-  if (openedRemaining !== null) {
-    return Math.max(0, units - 1) * contentAmount + openedRemaining;
-  }
-  return units * contentAmount;
-};
+export { computeCalendarDelta } from "@/types/calendar";
 
 const CalendarRoutePage = () => {
-  const qc = useQueryClient();
   const { data: items = [], isLoading } = useItemsWithExpiry();
   const { data: categories = [] } = useCategories();
-  const [pendingRemovals, setPendingRemovals] = useState<Record<string, PendingLotRemoval>>({});
-  const { toast } = useToast();
-  const { t } = useTranslation("common");
-  const { t: tc } = useTranslation("calendar");
-
-  const handleCheck = async (item: Item) => {
-    try {
-      requireOnline();
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) throw new Error("Not authenticated");
-
-      const { data: lots, error } = await supabase
-        .from("item_lots")
-        .select("id, units, opened_remaining, expiry_date")
-        .eq("item_id", item.id)
-        .order("expiry_date", { ascending: true, nullsFirst: false })
-        .order("created_at", { ascending: true });
-      if (error) throw error;
-
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
-      const monthEnd = new Date(today.getFullYear(), today.getMonth() + 1, 0);
-
-      const targetLot = (lots ?? []).find((lot) => {
-        if (lot.units <= 0 && lot.opened_remaining === null) return false;
-        if (!lot.expiry_date) return false;
-        const [y, m, d] = lot.expiry_date.split("-").map(Number) as [number, number, number];
-        const exp = new Date(y, m - 1, d);
-        return exp <= monthEnd;
-      });
-
-      if (!targetLot) {
-        toast(tc("noEligibleLot"), "warning");
-        return;
-      }
-
-      const { error: updateError } = await supabase
-        .from("item_lots")
-        .update({ units: 0, opened_remaining: null, updated_at: new Date().toISOString() })
-        .eq("id", targetLot.id);
-      if (updateError) throw updateError;
-
-      // 消費ログを記録（non-fatal: ロット更新は完了しているためエラーを無視）
-      const deltaAmount = computeCalendarDelta(
-        targetLot.units,
-        targetLot.opened_remaining,
-        item.content_amount,
-      );
-      const { data: logData } = await supabase
-        .from("consumption_logs")
-        .insert({
-          user_id: user.id,
-          item_id: item.id,
-          delta_amount: deltaAmount,
-          delta_unit: item.content_unit,
-          units_before: targetLot.units,
-          units_after: 0,
-          opened_remaining_before: targetLot.opened_remaining,
-          opened_remaining_after: null,
-        })
-        .select("id")
-        .single();
-
-      await syncItemAggregate(item.id);
-      await Promise.all([
-        qc.invalidateQueries({ queryKey: ["items"] }),
-        qc.invalidateQueries({ queryKey: [...LOTS_KEY, item.id] }),
-        qc.invalidateQueries({ queryKey: ["consumption-logs", item.id] }),
-        qc.invalidateQueries({ queryKey: ["consumption-logs-all"] }),
-      ]);
-      setPendingRemovals((prev) => ({
-        ...prev,
-        [item.id]: {
-          lotId: targetLot.id,
-          itemId: item.id,
-          itemName: item.name,
-          units: targetLot.units,
-          openedRemaining: targetLot.opened_remaining,
-          logId: logData?.id ?? null,
-        },
-      }));
-    } catch (err) {
-      toast(err instanceof OfflineError ? t("offlineError") : t("unknownError"), "error");
-      throw err;
-    }
-  };
-
-  const handleUndo = async (itemId: string) => {
-    try {
-      requireOnline();
-      const pending = pendingRemovals[itemId];
-      if (!pending) return;
-      const { error } = await supabase
-        .from("item_lots")
-        .update({
-          units: pending.units,
-          opened_remaining: pending.openedRemaining,
-          updated_at: new Date().toISOString(),
-        })
-        .eq("id", pending.lotId);
-      if (error) throw error;
-
-      // 消費ログを削除（non-fatal: ロット復元は完了しているためエラーを無視）
-      if (pending.logId) {
-        await supabase.from("consumption_logs").delete().eq("id", pending.logId);
-      }
-
-      await syncItemAggregate(pending.itemId);
-      await Promise.all([
-        qc.invalidateQueries({ queryKey: ["items"] }),
-        qc.invalidateQueries({ queryKey: [...LOTS_KEY, pending.itemId] }),
-        qc.invalidateQueries({ queryKey: ["consumption-logs", pending.itemId] }),
-        qc.invalidateQueries({ queryKey: ["consumption-logs-all"] }),
-      ]);
-      setPendingRemovals((prev) => {
-        const next = { ...prev };
-        delete next[itemId];
-        return next;
-      });
-    } catch (err) {
-      toast(err instanceof OfflineError ? t("offlineError") : t("unknownError"), "error");
-    }
-  };
+  const { check, undo, pendingRemovalList } = useCalendarConsume();
 
   return (
     <CalendarPage
       items={items}
       categories={categories}
       isLoading={isLoading}
-      onCheck={handleCheck}
-      onUndo={handleUndo}
-      pendingRemovals={Object.values(pendingRemovals).map(({ itemId, itemName }) => ({
-        itemId,
-        itemName,
-      }))}
+      onCheck={check}
+      onUndo={undo}
+      pendingRemovals={pendingRemovalList}
     />
   );
 };

--- a/src/types/barcode.ts
+++ b/src/types/barcode.ts
@@ -1,0 +1,14 @@
+export interface ProductInfo {
+  name: string;
+  /** External image URL (from barcode API). Use onPendingImageUrlChange to download & upload. */
+  image_url?: string;
+  description?: string;
+  brand?: string;
+}
+
+export type BarcodeLookupSource = "db" | "api";
+
+export interface BarcodeLookupResult {
+  product: ProductInfo | null;
+  source: BarcodeLookupSource | null;
+}

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -1,0 +1,19 @@
+export interface PendingLotRemoval {
+  lotId: string;
+  itemId: string;
+  itemName: string;
+  units: number;
+  openedRemaining: number | null;
+  logId: string | null;
+}
+
+export const computeCalendarDelta = (
+  units: number,
+  openedRemaining: number | null,
+  contentAmount: number,
+): number => {
+  if (openedRemaining !== null) {
+    return Math.max(0, units - 1) * contentAmount + openedRemaining;
+  }
+  return units * contentAmount;
+};

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -90,6 +90,27 @@ export type UserSettings = z.infer<typeof userSettingsSchema>;
 
 export type ExpiryStatus = "expired" | "expiring-soon" | "ok" | "unknown";
 
+/** Filters applied server-side (Supabase query). Client-only filters such as
+ *  expiryStatus and hideEmpty are handled by the caller after fetching. */
+export interface ItemFilters {
+  search?: string;
+  categoryId?: string;
+  storageLocationId?: string;
+}
+
+export type ItemSortKey = "expiry_date" | "purchase_date" | "created_at";
+
+export interface ConsumeParams {
+  item: Item;
+  deltaAmount: number;
+}
+
+export interface ConsumeLotParams {
+  lot: ItemLot;
+  item: Pick<Item, "content_amount" | "content_unit">;
+  deltaAmount: number;
+}
+
 export const DEFAULT_EXPIRY_WARNING_DAYS = 3;
 
 export const CONTENT_UNITS = ["個", "枚", "本", "袋", "mL", "L", "g", "kg"] as const;

--- a/src/types/shopping.ts
+++ b/src/types/shopping.ts
@@ -1,0 +1,30 @@
+import type { ItemFormValues } from "@/types/item";
+
+export type ShoppingStatus = "planned" | "purchased";
+
+export interface ShoppingItem {
+  id: string;
+  user_id: string;
+  name: string;
+  desired_units: number;
+  note: string | null;
+  linked_item_id: string | null;
+  status: ShoppingStatus;
+  purchased_at: string | null;
+  created_item_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UpsertShoppingItemInput {
+  id?: string;
+  name: string;
+  desired_units?: number;
+  note?: string | null;
+  linked_item_id?: string | null;
+}
+
+export interface PurchaseInput {
+  shoppingItemId: string;
+  itemValues: ItemFormValues;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,10 @@
+export interface NotificationPreferences {
+  user_id: string;
+  push_enabled: boolean;
+  email_enabled: boolean;
+  email_address: string | null;
+  threshold_days: number;
+  notify_at: string;
+}
+
+export type UpdatePrefs = Partial<Omit<NotificationPreferences, "user_id">>;


### PR DESCRIPTION
## 概要

監査により発見されたClean Architecture違反を修正。型定義をドメイン層（`src/types/`）に集約し、プレゼンテーション層からの直接Supabase呼び出しを排除した。

Closes #293

## 違反と対応

### 1. 型定義のフック層への漏れ → `src/types/` へ移動

| 新ファイル | 移動した型 | 元の場所 |
|---|---|---|
| `types/shopping.ts` | `ShoppingStatus`, `ShoppingItem`, `UpsertShoppingItemInput`, `PurchaseInput` | `hooks/useShoppingList.ts` |
| `types/barcode.ts` | `ProductInfo`, `BarcodeLookupSource`, `BarcodeLookupResult` | `hooks/useBarcodeLookup.ts` |
| `types/user.ts` | `NotificationPreferences`, `UpdatePrefs` | `hooks/useNotificationPreferences.ts` |
| `types/calendar.ts` | `PendingLotRemoval`, `computeCalendarDelta` | `routes/_auth.calendar.tsx` |
| `types/item.ts`（拡張） | `ItemFilters`, `ItemSortKey`, `ConsumeParams`, `ConsumeLotParams` | `hooks/useItems.ts`, `hooks/useConsumeItem.ts`, `hooks/useItemLots.ts` |

### 2. 依存方向の逆転を修正

- `lib/itemCache.ts` が `hooks/useItems.ts` から `ItemSortKey` をインポートしていた（ライブラリ層がアプリケーション層に依存）
- → `types/item.ts` からインポートするよう修正

### 3. プレゼンテーション層からのDB呼び出し排除

- `routes/_auth.calendar.tsx` に直接Supabase呼び出し（`handleCheck`, `handleUndo`）があった
- → `hooks/useCalendarConsume.ts` として抽出し、ルートはフックを呼ぶだけに

## 変更後のレイヤー構造

```
ドメイン層:   src/types/          ← エンティティ・値オブジェクト・ドメイン関数
アプリ層:     src/hooks/          ← ユースケース（Supabase呼び出しはここで完結）
インフラ層:   src/lib/supabase.ts ← Supabaseクライアント（単一箇所）
プレゼン層:   src/routes/ + src/components/ ← フックを呼ぶだけ
```

## テスト

- typecheck: ✅ エラーなし
- lint: ✅ エラーなし（既存 warning 2件のみ）
- format: ✅ 差分なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Wr846zAxDd3ouFdv7pdGY