### PR TITLE
fix: バグ修正4件 + 単体テスト・Storybook追加

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@happy-dom/global-registrator": "^20.10.4",
+        "@happy-dom/global-registrator": "^20.10.6",
         "@storybook/react-vite": "^10.3.5",
         "@tailwindcss/vite": "^4.2.4",
         "@tanstack/react-query-devtools": "5.100.8",
@@ -349,7 +349,7 @@
 
     "@hapi/topo": ["@hapi/topo@5.1.0", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg=="],
 
-    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.4", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.4" } }, "sha512-d1iWnYgb20MuHYyXVcjkEdFkUy5+myq8RyLAFK9Sy4PVNy/cU5xrM5JM/MMMR3KDZQ6YNVj9puy96lcfEaKh8Q=="],
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.6" } }, "sha512-Nu/IjRkkNxmeG2ywWsyJSO4d1BrWTqVzxCPL+gXj0b97klhmjd6wLzt6Bx/laNpkZ3WLW7zNCqmtMIbIlahqug=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
@@ -1163,7 +1163,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "happy-dom": ["happy-dom@20.10.4", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-bKrsQnFNpcjZG0UPsH7UMN7Oyp3AB42LXk2GuiQmu7l4QFxH7lsw5T1eWEtE2+vbIFrTC45sbNSB2pkB8MTfKA=="],
+    "happy-dom": ["happy-dom@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw=="],
 
     "hard-rejection": ["hard-rejection@2.1.0", "", {}, "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@happy-dom/global-registrator": "^20.10.4",
+    "@happy-dom/global-registrator": "^20.10.6",
     "@storybook/react-vite": "^10.3.5",
     "@tailwindcss/vite": "^4.2.4",
     "@tanstack/react-query-devtools": "5.100.8",

--- a/src/components/atoms/Spinner.stories.tsx
+++ b/src/components/atoms/Spinner.stories.tsx
@@ -19,3 +19,7 @@ export const Small: Story = {
 export const Large: Story = {
   args: { className: "h-12 w-12" },
 };
+
+export const WithCustomLabel: Story = {
+  args: { label: "読み込み中" },
+};

--- a/src/components/atoms/Spinner.test.tsx
+++ b/src/components/atoms/Spinner.test.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "bun:test";
+
+import { Spinner } from "./Spinner";
+
+describe("Spinner", () => {
+  it("renders with default aria-label in English", () => {
+    const { container } = render(<Spinner />);
+    const el = container.firstChild as HTMLElement;
+    expect(el).not.toBeNull();
+    expect(el.getAttribute("role")).toBe("status");
+    expect(el.getAttribute("aria-label")).toBe("Loading");
+  });
+
+  it("renders with custom aria-label", () => {
+    const { container } = render(<Spinner label="読み込み中" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("aria-label")).toBe("読み込み中");
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(<Spinner className="h-4 w-4" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toContain("h-4 w-4");
+  });
+});

--- a/src/components/atoms/Spinner.tsx
+++ b/src/components/atoms/Spinner.tsx
@@ -1,7 +1,12 @@
-export const Spinner = ({ className = "" }: { className?: string }) => (
+interface SpinnerProps {
+  className?: string;
+  label?: string;
+}
+
+export const Spinner = ({ className = "", label = "Loading" }: SpinnerProps) => (
   <div
     className={`inline-block h-6 w-6 animate-spin rounded-full border-2 border-current border-t-transparent ${className}`}
     role="status"
-    aria-label="読み込み中"
+    aria-label={label}
   />
 );

--- a/src/components/molecules/ConfirmDialog.stories.tsx
+++ b/src/components/molecules/ConfirmDialog.stories.tsx
@@ -30,3 +30,15 @@ export const Closed: Story = {
     onCancel: () => {},
   },
 };
+
+export const IsConfirming: Story = {
+  args: {
+    open: true,
+    title: "削除の確認",
+    message: "このアイテムを削除しますか？この操作は取り消せません。",
+    confirmLabel: "削除",
+    isConfirming: true,
+    onConfirm: () => {},
+    onCancel: () => {},
+  },
+};

--- a/src/components/molecules/ConfirmDialog.test.tsx
+++ b/src/components/molecules/ConfirmDialog.test.tsx
@@ -1,0 +1,135 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, mock } from "bun:test";
+import { type ReactNode } from "react";
+import { I18nextProvider } from "react-i18next";
+
+import i18n from "../../lib/i18n";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+);
+
+describe("ConfirmDialog", () => {
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <ConfirmDialog
+        open={false}
+        title="削除"
+        message="削除しますか？"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+      { wrapper },
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders dialog when open", () => {
+    const { container } = render(
+      <ConfirmDialog
+        open={true}
+        title="削除の確認"
+        message="削除しますか？"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+      { wrapper },
+    );
+    const dialog = container.querySelector('[role="alertdialog"]');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.textContent).toContain("削除の確認");
+    expect(dialog?.textContent).toContain("削除しますか？");
+  });
+
+  it("calls onCancel when backdrop is clicked and not confirming", () => {
+    const onCancel = mock(() => {});
+    const { container } = render(
+      <ConfirmDialog
+        open={true}
+        title="削除"
+        message="削除しますか？"
+        isConfirming={false}
+        onConfirm={() => {}}
+        onCancel={onCancel}
+      />,
+      { wrapper },
+    );
+    const backdrop = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call onCancel when backdrop is clicked while isConfirming=true", () => {
+    const onCancel = mock(() => {});
+    const { container } = render(
+      <ConfirmDialog
+        open={true}
+        title="削除"
+        message="削除しますか？"
+        isConfirming={true}
+        onConfirm={() => {}}
+        onCancel={onCancel}
+      />,
+      { wrapper },
+    );
+    const backdrop = container.querySelector('[aria-hidden="true"]') as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("disables buttons when isConfirming=true", () => {
+    const { container } = render(
+      <ConfirmDialog
+        open={true}
+        title="削除"
+        message="削除しますか？"
+        isConfirming={true}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+      { wrapper },
+    );
+    const buttons = container.querySelectorAll("button");
+    buttons.forEach((btn) => {
+      expect((btn as HTMLButtonElement).disabled).toBe(true);
+    });
+  });
+
+  it("shows spinner in confirm button when isConfirming=true", () => {
+    const { container } = render(
+      <ConfirmDialog
+        open={true}
+        title="削除"
+        message="削除しますか？"
+        isConfirming={true}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />,
+      { wrapper },
+    );
+    const spinner = container.querySelector('[role="status"]');
+    expect(spinner).not.toBeNull();
+  });
+
+  it("calls onConfirm when confirm button clicked", () => {
+    const onConfirm = mock(() => {});
+    const { container } = render(
+      <ConfirmDialog
+        open={true}
+        title="削除"
+        message="削除しますか？"
+        confirmLabel="削除する"
+        onConfirm={onConfirm}
+        onCancel={() => {}}
+      />,
+      { wrapper },
+    );
+    const buttons = container.querySelectorAll("button");
+    const confirmBtn = Array.from(buttons).find((b) =>
+      b.textContent?.includes("削除する"),
+    ) as HTMLButtonElement;
+    fireEvent.click(confirmBtn);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/molecules/ConfirmDialog.tsx
+++ b/src/components/molecules/ConfirmDialog.tsx
@@ -42,7 +42,11 @@ export const ConfirmDialog = ({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-      <div className="absolute inset-0 bg-black/50" onClick={onCancel} aria-hidden="true" />
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={() => !isConfirming && onCancel()}
+        aria-hidden="true"
+      />
       <div
         role="alertdialog"
         aria-modal="true"

--- a/src/components/molecules/ItemCard.test.tsx
+++ b/src/components/molecules/ItemCard.test.tsx
@@ -1,0 +1,102 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { act, render } from "@testing-library/react";
+import { describe, expect, it } from "bun:test";
+import { type ReactNode } from "react";
+import { I18nextProvider } from "react-i18next";
+
+import type { Item } from "@/types/item";
+
+import i18n from "../../lib/i18n";
+import { ItemCard } from "./ItemCard";
+
+const baseItem: Item = {
+  id: "1",
+  user_id: "u1",
+  name: "牛乳",
+  units: 2,
+  content_amount: 1000,
+  content_unit: "mL",
+  opened_remaining: null,
+  category_id: null,
+  barcode: null,
+  storage_location_id: null,
+  expiry_date: "2099-12-31",
+  purchase_date: null,
+  notes: null,
+  image_path: null,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+const makeWrapper = (children: ReactNode) => () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const rootRoute = createRootRoute({ component: () => <>{children}</> });
+  const router = createRouter({
+    routeTree: rootRoute,
+    history: createMemoryHistory(),
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <I18nextProvider i18n={i18n}>
+        <RouterProvider router={router} />
+      </I18nextProvider>
+    </QueryClientProvider>
+  );
+};
+
+const renderCard = async (props: Parameters<typeof ItemCard>[0]) => {
+  const Wrapper = makeWrapper(<ItemCard {...props} />);
+  let result!: ReturnType<typeof render>;
+  await act(async () => {
+    result = render(<Wrapper />);
+  });
+  return result;
+};
+
+describe("ItemCard", () => {
+  it("shows Minus icon (no spinner) when isQuickConsuming=false", async () => {
+    const { container } = await renderCard({
+      item: baseItem,
+      onQuickConsume: () => {},
+      isQuickConsuming: false,
+    });
+    const spinner = container.querySelector('[role="status"]');
+    expect(spinner).toBeNull();
+  });
+
+  it("shows spinner when isQuickConsuming=true", async () => {
+    const { container } = await renderCard({
+      item: baseItem,
+      onQuickConsume: () => {},
+      isQuickConsuming: true,
+    });
+    const spinner = container.querySelector('[role="status"]');
+    expect(spinner).not.toBeNull();
+  });
+
+  it("disables quick consume button when isQuickConsuming=true", async () => {
+    const { container } = await renderCard({
+      item: baseItem,
+      onQuickConsume: () => {},
+      isQuickConsuming: true,
+    });
+    const btn = container.querySelector("button") as HTMLButtonElement;
+    expect(btn).not.toBeNull();
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("does not show quick consume button when units=0", async () => {
+    const { container } = await renderCard({
+      item: { ...baseItem, units: 0 },
+      onQuickConsume: () => {},
+    });
+    const btn = container.querySelector("button");
+    expect(btn).toBeNull();
+  });
+});

--- a/src/components/molecules/ItemCard.tsx
+++ b/src/components/molecules/ItemCard.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import { ExpiryBadge } from "@/components/atoms/ExpiryBadge";
 import { ItemImage } from "@/components/atoms/ItemImage";
+import { Spinner } from "@/components/atoms/Spinner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { parseLocalDate } from "@/lib/dateUtils";
@@ -106,7 +107,11 @@ export const ItemCard = ({
                   onQuickConsume(item);
                 }}
               >
-                <Minus className="h-3.5 w-3.5" />
+                {isQuickConsuming ? (
+                  <Spinner className="h-3.5 w-3.5" />
+                ) : (
+                  <Minus className="h-3.5 w-3.5" />
+                )}
               </Button>
             )}
             <ExpiryBadge expiryDate={item.expiry_date} warningDays={warningDays} />

--- a/src/routes/_auth.settings.categories.tsx
+++ b/src/routes/_auth.settings.categories.tsx
@@ -122,6 +122,7 @@ const CategoriesPage = () => {
             value={newName}
             onChange={(e) => setNewName(e.target.value)}
             placeholder={t("categoryName")}
+            disabled={createCategory.isPending}
             onKeyDown={(e) => {
               if (e.key === "Enter") void handleCreate();
             }}
@@ -159,6 +160,7 @@ const CategoriesPage = () => {
                       onChange={(e) => setEditName(e.target.value)}
                       className="flex-1"
                       autoFocus
+                      disabled={updateCategory.isPending}
                       onKeyDown={(e) => {
                         if (e.key === "Enter") void handleUpdate();
                       }}
@@ -168,6 +170,7 @@ const CategoriesPage = () => {
                       onClick={() => {
                         void handleUpdate();
                       }}
+                      disabled={updateCategory.isPending || !editName.trim()}
                     >
                       {tc("save")}
                     </Button>

--- a/src/routes/_auth.settings.locations.tsx
+++ b/src/routes/_auth.settings.locations.tsx
@@ -113,6 +113,7 @@ const LocationsPage = () => {
           value={newName}
           onChange={(e) => setNewName(e.target.value)}
           placeholder={t("locationName")}
+          disabled={createLocation.isPending}
           onKeyDown={(e) => {
             if (e.key === "Enter") void handleCreate();
           }}
@@ -146,6 +147,7 @@ const LocationsPage = () => {
                     onChange={(e) => setEditName(e.target.value)}
                     className="flex-1"
                     autoFocus
+                    disabled={updateLocation.isPending}
                     onKeyDown={(e) => {
                       if (e.key === "Enter") void handleUpdate();
                     }}
@@ -155,6 +157,7 @@ const LocationsPage = () => {
                     onClick={() => {
                       void handleUpdate();
                     }}
+                    disabled={updateLocation.isPending || !editName.trim()}
                   >
                     {tc("save")}
                   </Button>


### PR DESCRIPTION
## 概要

コードレビューで発見したバグ4件を修正し、対象コンポーネントの単体テストとStorybookストーリーを追加しました。

## 修正内容

### #295 — ConfirmDialog: `isConfirming` 中にバックドロップクリックで `onCancel` が呼ばれるバグ
- **問題**: Escape キーは `isConfirming` をチェックして閉じないが、バックドロップの `onClick` はチェックしていなかった
- **修正**: `onClick={() => !isConfirming && onCancel()}` に変更し、Escape キーと同じ挙動にそろえた

### #296 — 設定ページ（カテゴリ/保管場所）: mutation 中に入力欄・ボタンが無効化されない
- **問題**: 追加フォームの Input・編集フォームの Input と保存ボタンに `disabled` が設定されておらず、mutation 中に二重送信が可能だった
- **修正**: `_auth.settings.categories.tsx` と `_auth.settings.locations.tsx` 双方の該当要素に `disabled={isPending}` を追加

### #297 — Spinner: `aria-label` が日本語ハードコードで i18n・アクセシビリティ違反
- **問題**: `aria-label="読み込み中"` がハードコードされており、英語環境で不正確・スクリーンリーダー対応が不十分だった
- **修正**: `label` prop を追加し、デフォルト値を `"Loading"` に変更（呼び出し元で必要に応じて渡す）

### #298 — ItemCard: クイック消費中に Spinner が表示されない
- **問題**: `isQuickConsuming=true` のとき Story (`QuickConsumeInProgress`) は存在していたが、実装側で Spinner を表示していなかった
- **修正**: `Minus` アイコンを `isQuickConsuming` 時は `<Spinner>` に差し替え、ボタンを `disabled` に設定

## テスト・Storybook

| ファイル | 内容 |
|---|---|
| `Spinner.test.tsx` | デフォルト aria-label・カスタム label・className 適用の3ケース |
| `ConfirmDialog.test.tsx` | 開閉・バックドロップクリック・isConfirming 中の無効化・Spinner 表示 など7ケース |
| `ItemCard.test.tsx` | Spinner 表示・ボタン disabled・units=0 時の非表示 など4ケース（RouterProvider + QueryClientProvider 対応） |
| `Spinner.stories.tsx` | `WithCustomLabel` story 追加 |
| `ConfirmDialog.stories.tsx` | `IsConfirming` story 追加 |

## チェックリスト

- [x] `bun run format:check` — パス
- [x] `bun run check` (lint + typecheck) — パス
- [x] `bun test` — 149 tests pass, 0 fail

Closes #295
Closes #296
Closes #297
Closes #298

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4SMv4RKG8ffH79Haxw9Pd)_