### PR TITLE
fix: アイテム削除をソフトデリートに変更・ItemFormメモリリーク修正 (#253 #229)

### DIFF
--- a/src/components/organisms/ItemForm.tsx
+++ b/src/components/organisms/ItemForm.tsx
@@ -1,5 +1,5 @@
 import { Barcode, Loader2, Search } from "lucide-react";
-import { type FormEvent, useState } from "react";
+import { type FormEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { ImageUploader } from "@/components/molecules/ImageUploader";
@@ -83,6 +83,12 @@ export const ItemForm = ({
   const [barcodeImageUrl, setBarcodeImageUrl] = useState<string | null>(null);
   const [lookupResult, setLookupResult] = useState<ProductInfo | null | undefined>(undefined);
   const [lookupSource, setLookupSource] = useState<"db" | "api" | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (localPreviewUrl) URL.revokeObjectURL(localPreviewUrl);
+    };
+  }, [localPreviewUrl]);
 
   const { data: existingImageUrl } = useSignedItemImage(
     localPreviewUrl ? null : values.image_path || null,

--- a/src/routes/_auth.items.$itemId.tsx
+++ b/src/routes/_auth.items.$itemId.tsx
@@ -26,7 +26,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { useConsumptionLogs } from "@/hooks/useConsumptionLogs";
 import { useItemLots } from "@/hooks/useItemLots";
-import { useDeleteItem, useItem } from "@/hooks/useItems";
+import { useItem, useSoftDeleteItem } from "@/hooks/useItems";
 import { useCategories, useStorageLocations } from "@/hooks/useMasterData";
 import { useUpsertShoppingItem } from "@/hooks/useShoppingList";
 import { useUserSettings } from "@/hooks/useUserSettings";
@@ -59,7 +59,7 @@ const ItemDetailPage = () => {
   const { data: categories = [] } = useCategories();
   const { data: locations = [] } = useStorageLocations();
   const { data: userSettings } = useUserSettings();
-  const deleteItem = useDeleteItem();
+  const deleteItem = useSoftDeleteItem();
   const upsertShopping = useUpsertShoppingItem();
   const { data: logs = [] } = useConsumptionLogs(itemId);
   const { toast } = useToast();
@@ -83,10 +83,9 @@ const ItemDetailPage = () => {
     try {
       await deleteItem.mutateAsync(itemId);
       setShowDeleteConfirm(false);
-      toast(t("deleteSuccess"), "success");
       void navigate({ to: "/" });
     } catch {
-      toast(t("common:unknownError"), "error");
+      setShowDeleteConfirm(false);
     }
   };
 


### PR DESCRIPTION
## 変更概要

### #253: アイテム詳細ページの削除をソフトデリートに変更

**問題:** `_auth.items.$itemId.tsx` の削除ボタンが `useDeleteItem`（ハードデリート）を使用しており、バーコードスキャンによる `tryReviveItem`（`deleted_at IS NOT NULL` のアイテムを復活）との整合性がなかった。

**修正:** `useDeleteItem` → `useSoftDeleteItem` に変更し、削除済みアイテムをバーコードで復活できるようにした。

### #229: ItemForm の Object URL メモリリーク修正

**問題:** `ItemForm.tsx` で `URL.createObjectURL()` で生成した Blob URL が、コンポーネントの unmount 時に `URL.revokeObjectURL()` されなかった。

**修正:** `useEffect` のクリーンアップ関数で `localPreviewUrl` を revoke するようにした（unmount 時・URL 変更時の両方でクリーンアップ）。

## 変更ファイル

- `src/routes/_auth.items.$itemId.tsx` — `useSoftDeleteItem` に切り替え、重複トーストを除去
- `src/components/organisms/ItemForm.tsx` — useEffect で Object URL をクリーンアップ

Closes #253
Closes #229

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ)_