### PR TITLE
fix: タブ状態のURL永続化・consumeLotログ失敗の追跡 (#235 #236)

### DIFF
--- a/src/hooks/useItemLots.ts
+++ b/src/hooks/useItemLots.ts
@@ -133,8 +133,7 @@ export const consumeLot = async ({
     .single();
   if (error) throw error;
 
-  // Log failure is non-fatal: stock is already updated above
-  await supabase.from("consumption_logs").insert({
+  const { error: logError } = await supabase.from("consumption_logs").insert({
     user_id: userData.user.id,
     item_id: lot.item_id,
     delta_amount: deltaAmount,
@@ -144,6 +143,11 @@ export const consumeLot = async ({
     opened_remaining_before: lot.opened_remaining ?? null,
     opened_remaining_after: result.opened_remaining_after,
   });
+  if (logError) {
+    // Non-fatal: stock is already updated. Log for debugging.
+    // oxlint-disable-next-line no-console
+    console.warn("consumeLot: consumption_logs insert failed", logError);
+  }
 
   await syncItemAggregate(lot.item_id);
 

--- a/src/routes/_auth.items.$itemId.tsx
+++ b/src/routes/_auth.items.$itemId.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { z } from "zod";
 
 import { ExpiryBadge } from "@/components/atoms/ExpiryBadge";
 import { ItemImage } from "@/components/atoms/ItemImage";
@@ -44,10 +45,15 @@ const DetailRow = ({ icon, label, value }: { icon: ReactNode; label: string; val
   </div>
 );
 
+const tabSchema = z.object({
+  tab: z.enum(["info", "lots", "history"]).optional().default("info"),
+});
+
 const ItemDetailPage = () => {
   const { t, i18n } = useTranslation("items");
   const { t: tc } = useTranslation("common");
   const { itemId } = Route.useParams();
+  const { tab: detailTab } = Route.useSearch();
   const navigate = useNavigate();
   const matches = useRouterState({ select: (s) => s.matches });
   const isChildActive = matches.some(
@@ -64,7 +70,10 @@ const ItemDetailPage = () => {
   const { data: logs = [] } = useConsumptionLogs(itemId);
   const { toast } = useToast();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [detailTab, setDetailTab] = useState<"info" | "lots" | "history">("info");
+
+  const setDetailTab = (tab: "info" | "lots" | "history") => {
+    void navigate({ to: "/items/$itemId", params: { itemId }, search: { tab } });
+  };
 
   const handleRestock = async () => {
     if (!item) return;
@@ -441,5 +450,6 @@ const ItemDetailPage = () => {
 };
 
 export const Route = createFileRoute("/_auth/items/$itemId")({
+  validateSearch: tabSchema,
   component: ItemDetailPage,
 });


### PR DESCRIPTION
## 変更概要

### #235: アイテム詳細ページのタブ選択状態がURLに永続化されない

**問題:** `detailTab` が `useState` で管理されており、ブラウザバック後や再訪問時にタブ選択が "info" にリセットされていた。

**修正:** TanStack Router の `validateSearch` を使って `tab` パラメータをURLに持たせた。`?tab=lots` のようなURLでタブ状態が保持され、ブックマークやリロードでも復元される。

```
/items/abc123?tab=lots
/items/abc123?tab=history
```

### #236: consumeLot の消費ログ記録失敗が無音で無視される

**問題:** `consumeLot` で `consumption_logs` への INSERT が失敗しても、在庫数更新は完了するが消費履歴が欠損する。エラーは完全に無視されていた。

**修正:** INSERT の返却値を確認し、失敗した場合は `console.warn` で記録するようにした（非致命的エラーのため例外にはせず、デバッグ追跡を可能に）。

Closes #235
Closes #236

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ)_