### PR TITLE
fix: EditItemPage のロット更新失敗時に警告トーストで通知 (#222)

### DIFF
--- a/src/components/pages/EditItemPage.tsx
+++ b/src/components/pages/EditItemPage.tsx
@@ -47,16 +47,24 @@ export const EditItemPage = ({ itemId }: EditItemPageProps) => {
       const oldImagePath = item?.image_path ?? null;
       await updateItem.mutateAsync(values);
       if (selectedLot) {
-        await updateLot.mutateAsync({
-          lotId: selectedLot.id,
-          itemId,
-          values: {
-            units: values.units,
-            opened_remaining: values.opened_remaining ?? null,
-            purchase_date: values.purchase_date ?? null,
-            expiry_date: values.expiry_date ?? null,
-          },
-        });
+        try {
+          await updateLot.mutateAsync({
+            lotId: selectedLot.id,
+            itemId,
+            values: {
+              units: values.units,
+              opened_remaining: values.opened_remaining ?? null,
+              purchase_date: values.purchase_date ?? null,
+              expiry_date: values.expiry_date ?? null,
+            },
+          });
+        } catch {
+          // Item was updated but lot update failed — show warning and navigate
+          toast(t("lotUpdateFailed"), "warning");
+          await qc.invalidateQueries({ queryKey: ["items"] });
+          void navigate({ to: "/items/$itemId", params: { itemId } });
+          return;
+        }
       }
       const pendingFile = pendingFileRef.current;
       const pendingImageUrl = pendingImageUrlRef.current;

--- a/src/locales/en/items.json
+++ b/src/locales/en/items.json
@@ -129,5 +129,6 @@
   "consumeAllConfirmLabel": "Use all",
   "cloneItem": "Duplicate Item",
   "cloneSuccess": "Item duplicated and added",
-  "defaultContentUnit": "piece"
+  "defaultContentUnit": "piece",
+  "lotUpdateFailed": "Item was updated, but the lot update failed"
 }

--- a/src/locales/ja/items.json
+++ b/src/locales/ja/items.json
@@ -128,5 +128,6 @@
   "consumeAllConfirmLabel": "全量消費する",
   "cloneItem": "複製して追加",
   "cloneSuccess": "複製して在庫を追加しました",
-  "defaultContentUnit": "個"
+  "defaultContentUnit": "個",
+  "lotUpdateFailed": "在庫情報は更新されましたが、ロット情報の更新に失敗しました"
 }


### PR DESCRIPTION
## 変更概要

### #222: EditItemPage でアイテム更新後にロット更新が失敗した場合データが不整合になる

**問題:** `handleSubmit` でアイテム更新 → ロット更新の順に実行しているが、ロット更新が失敗してもアイテム更新はロールバックできず、エラーも汎用の "エラーが発生しました" トーストのみで何が起きたか分からない。

**修正:** ロット更新のみを `try/catch` で囲み:
- 失敗した場合「在庫情報は更新されましたが、ロット情報の更新に失敗しました」の **warning** トーストを表示
- キャッシュを無効化して詳細ページへ遷移（ユーザーに現状を明示）

> **注:** 本来はDBトランザクションによるアトミックな処理が理想ですが、クライアントサイドのみの構成ではSupabase RPC/Edge Functionが必要です。当面はユーザーへの明示的な通知で対応します。

Closes #222

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ)_