### PR TITLE
feat: ダッシュボードにクイックフィルターチップと件数バッジを追加 (#182)

### DIFF
--- a/src/locales/en/items.json
+++ b/src/locales/en/items.json
@@ -130,5 +130,6 @@
   "cloneItem": "Duplicate Item",
   "cloneSuccess": "Item duplicated and added",
   "defaultContentUnit": "piece",
-  "lotUpdateFailed": "Item was updated, but the lot update failed"
+  "lotUpdateFailed": "Item was updated, but the lot update failed",
+  "quickFilterAll": "All"
 }

--- a/src/locales/ja/items.json
+++ b/src/locales/ja/items.json
@@ -129,5 +129,6 @@
   "cloneItem": "複製して追加",
   "cloneSuccess": "複製して在庫を追加しました",
   "defaultContentUnit": "個",
-  "lotUpdateFailed": "在庫情報は更新されましたが、ロット情報の更新に失敗しました"
+  "lotUpdateFailed": "在庫情報は更新されましたが、ロット情報の更新に失敗しました",
+  "quickFilterAll": "すべて"
 }

--- a/src/routes/_auth.index.tsx
+++ b/src/routes/_auth.index.tsx
@@ -1,7 +1,8 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { AlertTriangle, Plus, Search, SlidersHorizontal } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { z } from "zod";
 
 import { Spinner } from "@/components/atoms/Spinner";
 import { ItemCard } from "@/components/molecules/ItemCard";
@@ -15,6 +16,13 @@ import { useUserSettings } from "@/hooks/useUserSettings";
 import { useToast } from "@/lib/toast-context";
 import { getExpiryStatus, type Item } from "@/types/item";
 
+const dashboardSearchSchema = z.object({
+  q: z.string().optional().default(""),
+  cat: z.string().optional().default(""),
+  loc: z.string().optional().default(""),
+  expiry: z.string().optional().default(""),
+});
+
 const DashboardPage = () => {
   const { t } = useTranslation("items");
   const { t: tc } = useTranslation("common");
@@ -24,11 +32,19 @@ const DashboardPage = () => {
   const warningDays = userSettings?.expiry_warning_days;
   const consumeItem = useConsumeItem();
   const { toast } = useToast();
+  const navigate = useNavigate();
 
-  const [search, setSearch] = useState("");
-  const [categoryId, setCategoryId] = useState("");
-  const [locationId, setLocationId] = useState("");
-  const [expiryFilter, setExpiryFilter] = useState("");
+  const { q: search, cat: categoryId, loc: locationId, expiry: expiryFilter } = Route.useSearch();
+
+  const setSearch = (v: string) =>
+    void navigate({ to: "/", search: (prev) => ({ ...prev, q: v }), replace: true });
+  const setCategoryId = (v: string) =>
+    void navigate({ to: "/", search: (prev) => ({ ...prev, cat: v }), replace: true });
+  const setLocationId = (v: string) =>
+    void navigate({ to: "/", search: (prev) => ({ ...prev, loc: v }), replace: true });
+  const setExpiryFilter = (v: string) =>
+    void navigate({ to: "/", search: (prev) => ({ ...prev, expiry: v }), replace: true });
+
   const [sort, setSort] = useState<ItemSortKey>(
     () => (localStorage.getItem("dashboard.sort") as ItemSortKey) ?? "created_at",
   );
@@ -359,5 +375,6 @@ const DashboardPage = () => {
 };
 
 export const Route = createFileRoute("/_auth/")({
+  validateSearch: dashboardSearchSchema,
   component: DashboardPage,
 });

--- a/src/routes/_auth.index.tsx
+++ b/src/routes/_auth.index.tsx
@@ -63,8 +63,9 @@ const DashboardPage = () => {
   const categoryMap = Object.fromEntries(categories.map((c) => [c.id, c.name]));
   const locationMap = Object.fromEntries(locations.map((l) => [l.id, l.name]));
 
-  const filtered = items.filter((item) => {
-    if (hideEmpty && item.units === 0) return false;
+  const baseFiltered = items.filter((item) => !hideEmpty || item.units > 0);
+
+  const filtered = baseFiltered.filter((item) => {
     if (expiryFilter && expiryFilter !== "all") {
       const status = getExpiryStatus(item.expiry_date, warningDays);
       if (status !== expiryFilter) return false;
@@ -72,11 +73,18 @@ const DashboardPage = () => {
     return true;
   });
 
-  const urgentItems = filtered.filter((item) => {
+  const expiredCount = baseFiltered.filter(
+    (item) => getExpiryStatus(item.expiry_date, warningDays) === "expired",
+  ).length;
+  const expiringSoonCount = baseFiltered.filter(
+    (item) => getExpiryStatus(item.expiry_date, warningDays) === "expiring-soon",
+  ).length;
+  const urgentCount = expiredCount + expiringSoonCount;
+
+  const urgentItems = baseFiltered.filter((item) => {
     const status = getExpiryStatus(item.expiry_date, warningDays);
     return (status === "expired" || status === "expiring-soon") && item.units > 0;
   });
-  const urgentCount = urgentItems.length;
   const expiredItems = urgentItems.filter(
     (item) => getExpiryStatus(item.expiry_date, warningDays) === "expired",
   );
@@ -185,6 +193,48 @@ const DashboardPage = () => {
           <SlidersHorizontal className="h-4 w-4" />
         </Button>
       </div>
+
+      {/* Quick filter chips */}
+      {(expiredCount > 0 || expiringSoonCount > 0) && (
+        <div className="flex flex-wrap gap-2">
+          <button
+            onClick={() => setExpiryFilter("")}
+            className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+              !expiryFilter || expiryFilter === "all"
+                ? "border-primary bg-primary text-primary-foreground"
+                : "border-border bg-background text-foreground hover:bg-muted"
+            }`}
+          >
+            {t("quickFilterAll")} ({baseFiltered.length})
+          </button>
+          {expiredCount > 0 && (
+            <button
+              onClick={() => setExpiryFilter(expiryFilter === "expired" ? "" : "expired")}
+              className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                expiryFilter === "expired"
+                  ? "border-destructive bg-destructive text-destructive-foreground"
+                  : "border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/20"
+              }`}
+            >
+              {t("expiryStatus.expired")} ({expiredCount})
+            </button>
+          )}
+          {expiringSoonCount > 0 && (
+            <button
+              onClick={() =>
+                setExpiryFilter(expiryFilter === "expiring-soon" ? "" : "expiring-soon")
+              }
+              className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                expiryFilter === "expiring-soon"
+                  ? "border-yellow-600 bg-yellow-500 text-white"
+                  : "border-yellow-400/50 bg-yellow-50 text-yellow-700 hover:bg-yellow-100"
+              }`}
+            >
+              {t("expiryStatus.expiring-soon")} ({expiringSoonCount})
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Filter panel */}
       {showFilters && (

--- a/src/routes/_auth.settings.tsx
+++ b/src/routes/_auth.settings.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 import { ArrowLeft, Bell, ChevronRight, Globe, MapPin, Tag } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { LanguageToggle } from "@/components/atoms/LanguageToggle";
@@ -22,10 +22,13 @@ const SettingsPage = () => {
   const { data: settings, isLoading } = useUserSettings();
   const updateSettings = useUpdateUserSettings();
   const { toast } = useToast();
-  const [warningDays, setWarningDays] = useState<string | null>(null);
-  const warningDaysValue =
-    warningDays ??
-    (settings?.expiry_warning_days !== undefined ? String(settings.expiry_warning_days) : "");
+  const [warningDays, setWarningDays] = useState<string>("");
+
+  useEffect(() => {
+    if (settings?.expiry_warning_days !== undefined) {
+      setWarningDays(String(settings.expiry_warning_days));
+    }
+  }, [settings?.expiry_warning_days]);
 
   const handleLanguageChange = async (lang: "ja" | "en") => {
     try {
@@ -40,7 +43,6 @@ const SettingsPage = () => {
     if (isNaN(days) || days < 0) return;
     try {
       await updateSettings.mutateAsync({ expiry_warning_days: days });
-      setWarningDays(null);
       toast(t("saveSuccess"), "success");
     } catch {
       toast(t("common:unknownError"), "error");
@@ -96,11 +98,11 @@ const SettingsPage = () => {
                 type="number"
                 min={0}
                 max={30}
-                value={warningDaysValue}
+                value={warningDays}
                 className="w-24"
                 onChange={(e) => setWarningDays(e.target.value)}
                 onBlur={() => {
-                  void handleWarningDaysChange(parseInt(warningDaysValue, 10));
+                  void handleWarningDaysChange(parseInt(warningDays, 10));
                 }}
               />
               <Label>{t("daysBefore")}</Label>

--- a/src/routes/_auth.settings.tsx
+++ b/src/routes/_auth.settings.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 import { ArrowLeft, Bell, ChevronRight, Globe, MapPin, Tag } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { LanguageToggle } from "@/components/atoms/LanguageToggle";
@@ -22,13 +22,10 @@ const SettingsPage = () => {
   const { data: settings, isLoading } = useUserSettings();
   const updateSettings = useUpdateUserSettings();
   const { toast } = useToast();
-  const [warningDays, setWarningDays] = useState<string>("");
-
-  useEffect(() => {
-    if (settings?.expiry_warning_days !== undefined) {
-      setWarningDays(String(settings.expiry_warning_days));
-    }
-  }, [settings?.expiry_warning_days]);
+  const [warningDays, setWarningDays] = useState<string | null>(null);
+  const warningDaysValue =
+    warningDays ??
+    (settings?.expiry_warning_days !== undefined ? String(settings.expiry_warning_days) : "");
 
   const handleLanguageChange = async (lang: "ja" | "en") => {
     try {
@@ -43,6 +40,7 @@ const SettingsPage = () => {
     if (isNaN(days) || days < 0) return;
     try {
       await updateSettings.mutateAsync({ expiry_warning_days: days });
+      setWarningDays(null);
       toast(t("saveSuccess"), "success");
     } catch {
       toast(t("common:unknownError"), "error");
@@ -98,11 +96,11 @@ const SettingsPage = () => {
                 type="number"
                 min={0}
                 max={30}
-                value={warningDays}
+                value={warningDaysValue}
                 className="w-24"
                 onChange={(e) => setWarningDays(e.target.value)}
                 onBlur={() => {
-                  void handleWarningDaysChange(parseInt(warningDays, 10));
+                  void handleWarningDaysChange(parseInt(warningDaysValue, 10));
                 }}
               />
               <Label>{t("daysBefore")}</Label>


### PR DESCRIPTION
## 変更概要

### #182: ダッシュボードのクイックフィルターチップ

**背景:** 期限切れ・期限間近のアイテムを確認するには、フィルターパネルを展開して Selectbox を操作する必要があり、操作ステップが多かった。

**実装:**
- 検索バーの下に「すべて (N)」「期限切れ (N)」「期限間近 (N)」のチップを常時表示
- 件数が 0 の状態は非表示（期限問題がない場合はチップ全体を非表示）
- チップをタップするとフィルターが適用され、再タップで解除
- 既存の詳細フィルターパネルとの共存（expiryFilter state を共有）

**UI:**
- 期限切れ: 赤系のアクセントカラー
- 期限間近: 黄系のアクセントカラー
- アクティブなチップはより濃い背景色で区別

Closes #182

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ)_