### PR TITLE
feat: ダッシュボードのフィルター状態をURLクエリパラメータに反映 (#258)

### DIFF
--- a/src/components/molecules/ItemCard.stories.tsx
+++ b/src/components/molecules/ItemCard.stories.tsx
@@ -193,9 +193,7 @@ export const WithQuickConsume: Story = {
     },
     categoryName: "食品",
     locationName: "冷蔵庫",
-    onQuickConsume: (item) => {
-      console.log("Quick consume:", item.name);
-    },
+    onQuickConsume: () => {},
   },
 };
 
@@ -218,8 +216,6 @@ export const QuickConsumeInProgress: Story = {
     categoryName: "食品",
     locationName: "冷蔵庫",
     isQuickConsuming: true,
-    onQuickConsume: (item) => {
-      console.log("Quick consume:", item.name);
-    },
+    onQuickConsume: () => {},
   },
 };

--- a/src/routes/_auth.index.tsx
+++ b/src/routes/_auth.index.tsx
@@ -1,7 +1,8 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { AlertTriangle, Plus, Search, SlidersHorizontal } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { z } from "zod";
 
 import { Spinner } from "@/components/atoms/Spinner";
 import { ItemCard } from "@/components/molecules/ItemCard";
@@ -15,6 +16,13 @@ import { useUserSettings } from "@/hooks/useUserSettings";
 import { useToast } from "@/lib/toast-context";
 import { getExpiryStatus, type Item } from "@/types/item";
 
+const dashboardSearchSchema = z.object({
+  q: z.string().optional().default(""),
+  cat: z.string().optional().default(""),
+  loc: z.string().optional().default(""),
+  expiry: z.string().optional().default(""),
+});
+
 const DashboardPage = () => {
   const { t } = useTranslation("items");
   const { t: tc } = useTranslation("common");
@@ -24,11 +32,19 @@ const DashboardPage = () => {
   const warningDays = userSettings?.expiry_warning_days;
   const consumeItem = useConsumeItem();
   const { toast } = useToast();
+  const navigate = useNavigate();
 
-  const [search, setSearch] = useState("");
-  const [categoryId, setCategoryId] = useState("");
-  const [locationId, setLocationId] = useState("");
-  const [expiryFilter, setExpiryFilter] = useState("");
+  const { q: search, cat: categoryId, loc: locationId, expiry: expiryFilter } = Route.useSearch();
+
+  const setSearch = (v: string) =>
+    void navigate({ to: "/", search: (prev) => ({ ...prev, q: v }), replace: true });
+  const setCategoryId = (v: string) =>
+    void navigate({ to: "/", search: (prev) => ({ ...prev, cat: v }), replace: true });
+  const setLocationId = (v: string) =>
+    void navigate({ to: "/", search: (prev) => ({ ...prev, loc: v }), replace: true });
+  const setExpiryFilter = (v: string) =>
+    void navigate({ to: "/", search: (prev) => ({ ...prev, expiry: v }), replace: true });
+
   const [sort, setSort] = useState<ItemSortKey>(
     () => (localStorage.getItem("dashboard.sort") as ItemSortKey) ?? "created_at",
   );
@@ -359,5 +375,6 @@ const DashboardPage = () => {
 };
 
 export const Route = createFileRoute("/_auth/")({
+  validateSearch: dashboardSearchSchema,
   component: DashboardPage,
 });

--- a/src/routes/_auth.settings.tsx
+++ b/src/routes/_auth.settings.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 import { ArrowLeft, Bell, ChevronRight, Globe, MapPin, Tag } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { LanguageToggle } from "@/components/atoms/LanguageToggle";
@@ -22,13 +22,10 @@ const SettingsPage = () => {
   const { data: settings, isLoading } = useUserSettings();
   const updateSettings = useUpdateUserSettings();
   const { toast } = useToast();
-  const [warningDays, setWarningDays] = useState<string>("");
-
-  useEffect(() => {
-    if (settings?.expiry_warning_days !== undefined) {
-      setWarningDays(String(settings.expiry_warning_days));
-    }
-  }, [settings?.expiry_warning_days]);
+  const [warningDays, setWarningDays] = useState<string | null>(null);
+  const warningDaysValue =
+    warningDays ??
+    (settings?.expiry_warning_days !== undefined ? String(settings.expiry_warning_days) : "");
 
   const handleLanguageChange = async (lang: "ja" | "en") => {
     try {
@@ -43,6 +40,7 @@ const SettingsPage = () => {
     if (isNaN(days) || days < 0) return;
     try {
       await updateSettings.mutateAsync({ expiry_warning_days: days });
+      setWarningDays(null);
       toast(t("saveSuccess"), "success");
     } catch {
       toast(t("common:unknownError"), "error");
@@ -98,11 +96,11 @@ const SettingsPage = () => {
                 type="number"
                 min={0}
                 max={30}
-                value={warningDays}
+                value={warningDaysValue}
                 className="w-24"
                 onChange={(e) => setWarningDays(e.target.value)}
                 onBlur={() => {
-                  void handleWarningDaysChange(parseInt(warningDays, 10));
+                  void handleWarningDaysChange(parseInt(warningDaysValue, 10));
                 }}
               />
               <Label>{t("daysBefore")}</Label>


### PR DESCRIPTION
## 変更概要

### #258: 検索・フィルター状態を URL クエリパラメータに反映

**問題:** ダッシュボードの検索・フィルター状態が `useState` で管理されており、ページリロード後にリセットされる。フィルター済み状態のブックマーク・共有ができない。

**修正:** TanStack Router の `validateSearch` を使い、フィルター状態を URL search params に移行した。

| パラメータ | 内容 |
|-----------|------|
| `?q=...` | 検索文字列 |
| `?cat=...` | カテゴリ ID |
| `?loc=...` | 保管場所 ID |
| `?expiry=expired\|expiring-soon\|ok\|unknown` | 期限ステータスフィルター |

**例:** `/?q=牛乳&expiry=expiring-soon` → 「牛乳」かつ「期限間近」でフィルター済みのURLをブックマーク・共有可能。

`navigate({ replace: true })` を使用しているため、フィルター変更でブラウザ履歴は蓄積されない。
`sort` / `hideEmpty` は引き続き localStorage で永続化。

Closes #258

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ)_