### PR TITLE
ci: bun audit による依存パッケージ脆弱性スキャンを追加 (#261)

### DIFF
--- a/.github/workflows/_audit.yml
+++ b/.github/workflows/_audit.yml
@@ -1,0 +1,23 @@
+name: Security Audit
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Dependency Vulnerability Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run bun audit
+        run: bun audit
+        continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,6 @@ jobs:
 
   test:
     uses: ./.github/workflows/_test.yml
+
+  audit:
+    uses: ./.github/workflows/_audit.yml


### PR DESCRIPTION
## 変更概要

### #261: GitHub Actions で bun audit を実行

**問題:** CI では lint / format / typecheck / build のみで、依存パッケージのセキュリティ脆弱性チェックがなかった。

**実装:**
- `.github/workflows/_audit.yml` を新規作成
- `ci.yml` から `audit` ジョブとして呼び出す
- `bun audit` を実行し、既知の CVE を検出
- `continue-on-error: true` で既存の脆弱性がある場合も CI をブロックしない（まず可視化を優先）

Closes #261

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ)_