### PR TITLE
fix: 購入処理を冪等化しデータ不整合を防止

### DIFF
--- a/src/hooks/useShoppingList.ts
+++ b/src/hooks/useShoppingList.ts
@@ -210,30 +210,59 @@ export const usePurchaseShoppingItem = () => {
         }
       }
 
-      // バーコードなし or 既存アイテムなし → 新規作成
+      // バーコードなし or 既存アイテムなし → 新規作成（冪等化）
+      // created_item_id が既に設定されている場合はリトライ: 同じIDでupsert
+      const { data: shoppingRow } = await supabase
+        .from("shopping_list_items")
+        .select("created_item_id")
+        .eq("id", shoppingItemId)
+        .maybeSingle();
+      const reservedItemId = shoppingRow?.created_item_id ?? null;
+      const newItemId = reservedItemId ?? crypto.randomUUID();
+
+      // アイテム作成前に created_item_id を予約（失敗時のリトライで重複作成を防ぐ）
+      if (!reservedItemId) {
+        await supabase
+          .from("shopping_list_items")
+          .update({ created_item_id: newItemId })
+          .eq("id", shoppingItemId);
+      }
+
       const { data: newItem, error: itemError } = await supabase
         .from("items")
-        .insert({
-          user_id: user.id,
-          name: itemValues.name,
-          barcode: itemValues.barcode ?? null,
-          category_id: itemValues.category_id ?? null,
-          storage_location_id: itemValues.storage_location_id ?? null,
-          units: itemValues.units,
-          content_amount: itemValues.content_amount,
-          content_unit: itemValues.content_unit,
-          opened_remaining: itemValues.opened_remaining ?? null,
-          purchase_date: itemValues.purchase_date ?? null,
-          expiry_date: itemValues.expiry_date ?? null,
-          notes: itemValues.notes ?? null,
-        })
+        .upsert(
+          {
+            id: newItemId,
+            user_id: user.id,
+            name: itemValues.name,
+            barcode: itemValues.barcode ?? null,
+            category_id: itemValues.category_id ?? null,
+            storage_location_id: itemValues.storage_location_id ?? null,
+            units: itemValues.units,
+            content_amount: itemValues.content_amount,
+            content_unit: itemValues.content_unit,
+            opened_remaining: itemValues.opened_remaining ?? null,
+            purchase_date: itemValues.purchase_date ?? null,
+            expiry_date: itemValues.expiry_date ?? null,
+            notes: itemValues.notes ?? null,
+          },
+          { onConflict: "id" },
+        )
         .select()
         .single();
       if (itemError) throw new Error(itemError.message);
 
-      // Fix #211: 新規アイテムのロットを作成
-      await createLot(user.id, newItem.id, lotValuesFromForm(itemValues));
+      // Fix #211: ロットが未作成の場合のみ追加（リトライ時の重複を防ぐ）
+      const { data: existingLots } = await supabase
+        .from("item_lots")
+        .select("id")
+        .eq("item_id", newItemId)
+        .limit(1);
+      if (!existingLots || existingLots.length === 0) {
+        await createLot(user.id, newItem.id, lotValuesFromForm(itemValues));
+      }
 
+      await syncItemAggregate(newItem.id);
       await markShoppingItemPurchased(shoppingItemId, newItem.id);
 
       return newItem as Item;


### PR DESCRIPTION
## Summary

- 新規アイテム作成前に `crypto.randomUUID()` でIDを生成し、`shopping_list_items.created_item_id` に先行保存
- アイテム作成は `insert` → `upsert (onConflict: "id")` に変更（リトライ時に同じIDで更新）
- ロット作成前に既存ロットの存在チェックを追加（リトライ時の重複ロット作成を防止）
- `syncItemAggregate` は冪等なので常に実行（順序は変わらず）

## Test plan

- [ ] 通常の購入処理が正常に動作する
- [ ] ネットワーク障害後のリトライでアイテムが重複しない
- [ ] バーコードマッチング・既存アイテムスタックのパスは変更なし

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ)_