### PR TITLE
feat: Spinner をスケルトンローディングに置き換えてローディング UX を改善

### DIFF
--- a/src/components/atoms/Skeleton.stories.tsx
+++ b/src/components/atoms/Skeleton.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Skeleton } from "./Skeleton";
+
+const meta: Meta<typeof Skeleton> = {
+  component: Skeleton,
+  title: "Atoms/Skeleton",
+};
+export default meta;
+
+type Story = StoryObj<typeof Skeleton>;
+
+export const Default: Story = {
+  args: { className: "h-4 w-48" },
+};
+
+export const Circle: Story = {
+  args: { className: "h-12 w-12 rounded-full" },
+};
+
+export const Card: Story = {
+  render: () => (
+    <div className="w-48 space-y-2 rounded-lg border p-3">
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-4 w-3/4" />
+      <Skeleton className="h-3 w-1/2" />
+    </div>
+  ),
+};

--- a/src/components/atoms/Skeleton.tsx
+++ b/src/components/atoms/Skeleton.tsx
@@ -1,0 +1,9 @@
+import { cn } from "@/lib/utils";
+
+interface SkeletonProps {
+  className?: string;
+}
+
+export const Skeleton = ({ className }: SkeletonProps) => (
+  <div className={cn("animate-pulse rounded-md bg-muted", className)} />
+);

--- a/src/routes/_auth.index.tsx
+++ b/src/routes/_auth.index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { z } from "zod";
 
-import { Spinner } from "@/components/atoms/Spinner";
+import { Skeleton } from "@/components/atoms/Skeleton";
 import { ItemCard } from "@/components/molecules/ItemCard";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -357,8 +357,14 @@ const DashboardPage = () => {
 
       {/* Loading / Error / Content */}
       {isLoading ? (
-        <div className="flex min-h-[200px] items-center justify-center">
-          <Spinner />
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="space-y-2 rounded-lg border p-3">
+              <Skeleton className="aspect-square w-full rounded-md" />
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-3 w-1/2" />
+            </div>
+          ))}
         </div>
       ) : error ? (
         <div className="rounded-lg border border-destructive p-4 text-sm text-destructive">

--- a/src/routes/_auth.items.$itemId.tsx
+++ b/src/routes/_auth.items.$itemId.tsx
@@ -20,7 +20,7 @@ import { z } from "zod";
 
 import { ExpiryBadge } from "@/components/atoms/ExpiryBadge";
 import { ItemImage } from "@/components/atoms/ItemImage";
-import { Spinner } from "@/components/atoms/Spinner";
+import { Skeleton } from "@/components/atoms/Skeleton";
 import { ConfirmDialog } from "@/components/molecules/ConfirmDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -104,8 +104,25 @@ const ItemDetailPage = () => {
 
   if (isLoading) {
     return (
-      <div className="flex min-h-[200px] items-center justify-center">
-        <Spinner />
+      <div className="space-y-4">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-9 w-9 rounded-md" />
+          <Skeleton className="h-6 w-48" />
+        </div>
+        <Skeleton className="aspect-video w-full rounded-lg" />
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="flex justify-between py-1">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-32" />
+            </div>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-9 w-20 rounded-md" />
+          ))}
+        </div>
       </div>
     );
   }

--- a/src/routes/_auth.settings.tsx
+++ b/src/routes/_auth.settings.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { LanguageToggle } from "@/components/atoms/LanguageToggle";
-import { Spinner } from "@/components/atoms/Spinner";
+import { Skeleton } from "@/components/atoms/Skeleton";
 import { NotificationSettings } from "@/components/organisms/NotificationSettings";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -85,8 +85,13 @@ const SettingsPage = () => {
       </div>
 
       {isLoading ? (
-        <div className="flex justify-center py-8">
-          <Spinner />
+        <div className="space-y-6">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="space-y-2">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-10 w-full rounded-md" />
+            </div>
+          ))}
         </div>
       ) : (
         <div className="space-y-6">

--- a/src/routes/_auth.shopping.tsx
+++ b/src/routes/_auth.shopping.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { ShareButton } from "@/components/atoms/ShareButton";
-import { Spinner } from "@/components/atoms/Spinner";
+import { Skeleton } from "@/components/atoms/Skeleton";
 import { ConfirmDialog } from "@/components/molecules/ConfirmDialog";
 import { ShoppingRow } from "@/components/molecules/ShoppingRow";
 import { Button } from "@/components/ui/button";
@@ -260,8 +260,14 @@ const ShoppingPage = () => {
 
       {/* List */}
       {isLoading ? (
-        <div className="flex justify-center py-8">
-          <Spinner />
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3 rounded-lg border p-3">
+              <Skeleton className="h-5 w-5 rounded" />
+              <Skeleton className="h-4 flex-1" />
+              <Skeleton className="h-8 w-16 rounded-md" />
+            </div>
+          ))}
         </div>
       ) : items.length === 0 ? (
         <p className="py-8 text-center text-muted-foreground">

--- a/src/routes/_auth.stats.tsx
+++ b/src/routes/_auth.stats.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 
-import { Spinner } from "@/components/atoms/Spinner";
+import { Skeleton } from "@/components/atoms/Skeleton";
 import { CategoryChart } from "@/components/organisms/CategoryChart";
 import { ConsumptionChart } from "@/components/organisms/ConsumptionChart";
 import { ExpiryChart } from "@/components/organisms/ExpiryChart";
@@ -31,8 +31,13 @@ const ChartCard = ({
       </CardHeader>
       <CardContent>
         {isLoading ? (
-          <div className="flex min-h-[160px] items-center justify-center">
-            <Spinner />
+          <div className="space-y-2 py-2">
+            <Skeleton className="h-[120px] w-full rounded-md" />
+            <div className="flex justify-center gap-4">
+              <Skeleton className="h-3 w-16" />
+              <Skeleton className="h-3 w-16" />
+              <Skeleton className="h-3 w-16" />
+            </div>
           </div>
         ) : isError ? (
           <div className="flex min-h-[160px] items-center justify-center rounded-lg border border-destructive p-4 text-center text-destructive">


### PR DESCRIPTION
## Summary

- `Skeleton` atom コンポーネントを作成（`animate-pulse` + Tailwind `bg-muted`）
- ダッシュボード: ItemCard グリッドの形を模したスケルトン（8枚）
- アイテム詳細: 画像エリア + 行ペア × 4 + タブボタン × 3
- ショッピングリスト: チェックボックス + テキスト + ボタンの行スケルトン × 5
- 統計ページ: チャートエリアのグレーブロック + 凡例行
- 設定ページ: ラベル + フィールドのセクションスケルトン × 3
- `Skeleton.stories.tsx` を追加

## Test plan

- [ ] 各ページでローディング時にスケルトンが表示される
- [ ] データ取得後にスケルトンが消えてコンテンツが表示される
- [ ] Storybook で Skeleton コンポーネントが確認できる

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ)_