### PR TITLE
ci: バンドルサイズ追跡と Supabase 型の鮮度チェックを追加

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,45 @@
+name: Bundle Size
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  bundle:
+    name: Bundle Size Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+        env:
+          VITE_SUPABASE_URL: https://placeholder.supabase.co
+          VITE_SUPABASE_PUBLISHABLE_KEY: placeholder-anon-key
+
+      - name: Report compressed sizes
+        uses: preactjs/compressed-size-action@v2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          pattern: "./dist/**/*.{js,css}"
+
+      - name: Analyze bundle
+        run: bunx vite-bundle-visualizer --outFile dist/stats.html
+        env:
+          VITE_SUPABASE_URL: https://placeholder.supabase.co
+          VITE_SUPABASE_PUBLISHABLE_KEY: placeholder-anon-key
+
+      - name: Upload bundle stats
+        uses: actions/upload-artifact@v4
+        with:
+          name: bundle-stats-${{ github.run_id }}
+          path: dist/stats.html
+          retention-days: 14

--- a/.github/workflows/db-types.yml
+++ b/.github/workflows/db-types.yml
@@ -1,0 +1,38 @@
+name: Supabase Type Check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  type-check:
+    name: DB Type Freshness
+    runs-on: ubuntu-latest
+    # Skip if Supabase credentials are not configured
+    if: vars.SUPABASE_PROJECT_ID != ''
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Generate Supabase types
+        run: bun run gen:types
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_ID: ${{ vars.SUPABASE_PROJECT_ID }}
+
+      - name: Check for type drift
+        run: |
+          if ! git diff --quiet src/types/supabase.ts; then
+            echo "Supabase TypeScript types are out of sync with the DB schema."
+            echo "Run 'bun run gen:types' and commit the result."
+            git diff src/types/supabase.ts
+            exit 1
+          fi

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
         "storycap": "^5.0.1",
         "stylelint": "^17.11.0",
         "stylelint-config-standard": "^40.0.0",
+        "supabase": "^2.107.0",
         "tailwindcss": "^4.2.4",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.59.1",
@@ -679,6 +680,22 @@
     "@storybook/react-vite": ["@storybook/react-vite@10.3.5", "", { "dependencies": { "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0", "@rollup/pluginutils": "^5.0.2", "@storybook/builder-vite": "10.3.5", "@storybook/react": "10.3.5", "empathic": "^2.0.0", "magic-string": "^0.30.0", "react-docgen": "^8.0.0", "resolve": "^1.22.8", "tsconfig-paths": "^4.2.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.3.5", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-UB5sJHeh26bfd8sNMx2YPGYRYmErIdTRaLOT28m4bykQIa1l9IgVktsYg/geW7KsJU0lXd3oTbnUjLD+enpi3w=="],
 
     "@supabase/auth-js": ["@supabase/auth-js@2.105.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-zc4s8Xg4truwE1Q4Q8M8oUVDARMd05pKh73NyQsMbYU1HDdDN2iiKzena/yu+yJze3WrD4c092FdckPiK1rLQw=="],
+
+    "@supabase/cli-darwin-arm64": ["@supabase/cli-darwin-arm64@2.107.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-930MojHei14+PrGNF0QzlPJAjOYilCofgO9aTtKiQ6x36ZUI7dc4ujl5VzccC/19ex/f4ird0lH1d2U92MwDqQ=="],
+
+    "@supabase/cli-darwin-x64": ["@supabase/cli-darwin-x64@2.107.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-qcnichkHiCCNybtCqoeqYO6q8WuTxilaah18QilZskEM+zCSdV5rOXXfeF1BPexRxsvGYbghZ+fEQfWp7+lOUQ=="],
+
+    "@supabase/cli-linux-arm64": ["@supabase/cli-linux-arm64@2.107.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-an0dsOhPcLQXZ0sFEBm6NU1HFUjXCStHxetfJvgt4u7SiH/EyDMLfDvV7W9ef56bgG+3hoWHtih2Kplj3cecQA=="],
+
+    "@supabase/cli-linux-arm64-musl": ["@supabase/cli-linux-arm64-musl@2.107.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-5se1bYRIzivL+ehImnwFjBpzKZ+AwLS6/cBg6lvJOJdWatuaK9Edu6wOZAmPjVMy4vZRJ27tdL+3F7N+Vk64AA=="],
+
+    "@supabase/cli-linux-x64": ["@supabase/cli-linux-x64@2.107.0", "", { "os": "linux", "cpu": "x64" }, "sha512-8ttnpfBFEXk0JFmH6gw8ZCVcMa/UNH1sD6iG9PQLbK2eXdZ6kDIzGs5g+CEvxZ3j6HxEIYn9h9rfxoqGoBUgwA=="],
+
+    "@supabase/cli-linux-x64-musl": ["@supabase/cli-linux-x64-musl@2.107.0", "", { "os": "linux", "cpu": "x64" }, "sha512-gXDzvDsmmJw9HbeVRFD6xboGwbu/cpBp84ZESEcXKyB8Onvs3igWKwoXMofx+ppFM1EaZb/flTwJ77b19EMD1A=="],
+
+    "@supabase/cli-windows-arm64": ["@supabase/cli-windows-arm64@2.107.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-V/4q5dbDgBQXhDAJaHamTm9u/kY2UJ4nNibVKOYMaLh9q7H74b8unteJ+rYHSwWZy0EIT8DTDryGP6xatKQicw=="],
+
+    "@supabase/cli-windows-x64": ["@supabase/cli-windows-x64@2.107.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ciDDFUGHt6bFjtVD00cojFhB5oscZAyjPo2vg94RGUeKHXx1zo/UzfMvUlCA32y5b5KONZ4TKStCHhlFK7Clrw=="],
 
     "@supabase/functions-js": ["@supabase/functions-js@2.105.1", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-dTk1e7oE51VGc1lS2S0J0NLo0Wp4JYChj74ArJKbIWgoWuFwO0wcJYjeyOV3AAEpKst8/LQWUZOUKO1tRXBrpA=="],
 
@@ -2063,6 +2080,8 @@
     "stylelint-config-recommended": ["stylelint-config-recommended@18.0.0", "", { "peerDependencies": { "stylelint": "^17.0.0" } }, "sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg=="],
 
     "stylelint-config-standard": ["stylelint-config-standard@40.0.0", "", { "dependencies": { "stylelint-config-recommended": "^18.0.0" }, "peerDependencies": { "stylelint": "^17.0.0" } }, "sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw=="],
+
+    "supabase": ["supabase@2.107.0", "", { "optionalDependencies": { "@supabase/cli-darwin-arm64": "2.107.0", "@supabase/cli-darwin-x64": "2.107.0", "@supabase/cli-linux-arm64": "2.107.0", "@supabase/cli-linux-arm64-musl": "2.107.0", "@supabase/cli-linux-x64": "2.107.0", "@supabase/cli-linux-x64-musl": "2.107.0", "@supabase/cli-windows-arm64": "2.107.0", "@supabase/cli-windows-x64": "2.107.0" }, "bin": { "supabase": "dist/supabase.js" } }, "sha512-qYAbm3D//buhnY5v4L//IrBQhowN2Jd2kx16hNyOfu0+TVuWVIR1L5WsS/YOk+UJh3Ch5ABmqKebWpwn1p0ysg=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "knip": "knip",
-    "gen:types": "supabase gen types typescript --project-id $SUPABASE_PROJECT_ID > src/types/supabase.ts"
+    "gen:types": "supabase gen types typescript --project-id $SUPABASE_PROJECT_ID > src/types/supabase.ts && node scripts/fix-supabase-types.mjs"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.105.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "knip": "knip"
+    "knip": "knip",
+    "gen:types": "supabase gen types typescript --project-id $SUPABASE_PROJECT_ID > src/types/supabase.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.105.1",
@@ -71,6 +72,7 @@
     "storycap": "^5.0.1",
     "stylelint": "^17.11.0",
     "stylelint-config-standard": "^40.0.0",
+    "supabase": "^2.107.0",
     "tailwindcss": "^4.2.4",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.59.1",

--- a/scripts/fix-supabase-types.mjs
+++ b/scripts/fix-supabase-types.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// Supabase CLI generates `export type Foo = { ... }` for object types, but our
+// lint rule (consistent-type-definitions) requires `interface` for those.
+// This script converts only top-level object type aliases to interfaces.
+import { readFileSync, writeFileSync } from "node:fs";
+
+const filePath = new URL("../src/types/supabase.ts", import.meta.url).pathname;
+const original = readFileSync(filePath, "utf8");
+
+// Match `export type Foo = {` at the start of a line (object type alias only).
+const result = original.replace(
+  /^export type ([A-Za-z_]\w*) = \{$/gm,
+  "export interface $1 {",
+);
+
+if (result === original) {
+  console.log("fix-supabase-types: nothing to change");
+} else {
+  writeFileSync(filePath, result, "utf8");
+  console.log("fix-supabase-types: converted type aliases to interfaces");
+}

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,0 +1,543 @@
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
+
+export interface Database {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.5";
+  };
+  public: {
+    Tables: {
+      categories: {
+        Row: {
+          color: string | null;
+          created_at: string;
+          icon: string | null;
+          id: string;
+          name: string;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          color?: string | null;
+          created_at?: string;
+          icon?: string | null;
+          id?: string;
+          name: string;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          color?: string | null;
+          created_at?: string;
+          icon?: string | null;
+          id?: string;
+          name?: string;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
+      consumption_logs: {
+        Row: {
+          delta_amount: number;
+          delta_unit: string;
+          id: string;
+          item_id: string;
+          occurred_at: string;
+          opened_remaining_after: number | null;
+          opened_remaining_before: number | null;
+          units_after: number;
+          units_before: number;
+          user_id: string;
+        };
+        Insert: {
+          delta_amount: number;
+          delta_unit: string;
+          id?: string;
+          item_id: string;
+          occurred_at?: string;
+          opened_remaining_after?: number | null;
+          opened_remaining_before?: number | null;
+          units_after: number;
+          units_before: number;
+          user_id: string;
+        };
+        Update: {
+          delta_amount?: number;
+          delta_unit?: string;
+          id?: string;
+          item_id?: string;
+          occurred_at?: string;
+          opened_remaining_after?: number | null;
+          opened_remaining_before?: number | null;
+          units_after?: number;
+          units_before?: number;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "consumption_logs_item_id_fkey";
+            columns: ["item_id"];
+            isOneToOne: false;
+            referencedRelation: "items";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      item_lots: {
+        Row: {
+          created_at: string;
+          expiry_date: string | null;
+          id: string;
+          item_id: string;
+          opened_remaining: number | null;
+          purchase_date: string | null;
+          units: number;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          expiry_date?: string | null;
+          id?: string;
+          item_id: string;
+          opened_remaining?: number | null;
+          purchase_date?: string | null;
+          units?: number;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          expiry_date?: string | null;
+          id?: string;
+          item_id?: string;
+          opened_remaining?: number | null;
+          purchase_date?: string | null;
+          units?: number;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "item_lots_item_id_fkey";
+            columns: ["item_id"];
+            isOneToOne: false;
+            referencedRelation: "items";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      items: {
+        Row: {
+          barcode: string | null;
+          category_id: string | null;
+          content_amount: number;
+          content_unit: string;
+          created_at: string | null;
+          deleted_at: string | null;
+          expiry_date: string | null;
+          id: string;
+          image_path: string | null;
+          name: string;
+          notes: string | null;
+          opened_remaining: number | null;
+          purchase_date: string | null;
+          storage_location_id: string | null;
+          units: number;
+          updated_at: string | null;
+          user_id: string;
+        };
+        Insert: {
+          barcode?: string | null;
+          category_id?: string | null;
+          content_amount?: number;
+          content_unit?: string;
+          created_at?: string | null;
+          deleted_at?: string | null;
+          expiry_date?: string | null;
+          id?: string;
+          image_path?: string | null;
+          name: string;
+          notes?: string | null;
+          opened_remaining?: number | null;
+          purchase_date?: string | null;
+          storage_location_id?: string | null;
+          units?: number;
+          updated_at?: string | null;
+          user_id: string;
+        };
+        Update: {
+          barcode?: string | null;
+          category_id?: string | null;
+          content_amount?: number;
+          content_unit?: string;
+          created_at?: string | null;
+          deleted_at?: string | null;
+          expiry_date?: string | null;
+          id?: string;
+          image_path?: string | null;
+          name?: string;
+          notes?: string | null;
+          opened_remaining?: number | null;
+          purchase_date?: string | null;
+          storage_location_id?: string | null;
+          units?: number;
+          updated_at?: string | null;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "items_category_id_fkey";
+            columns: ["category_id"];
+            isOneToOne: false;
+            referencedRelation: "categories";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "items_storage_location_id_fkey";
+            columns: ["storage_location_id"];
+            isOneToOne: false;
+            referencedRelation: "storage_locations";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      notification_preferences: {
+        Row: {
+          email_address: string | null;
+          email_enabled: boolean;
+          notify_at: string;
+          push_enabled: boolean;
+          threshold_days: number;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          email_address?: string | null;
+          email_enabled?: boolean;
+          notify_at?: string;
+          push_enabled?: boolean;
+          threshold_days?: number;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          email_address?: string | null;
+          email_enabled?: boolean;
+          notify_at?: string;
+          push_enabled?: boolean;
+          threshold_days?: number;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
+      push_subscriptions: {
+        Row: {
+          auth: string;
+          created_at: string;
+          endpoint: string;
+          id: string;
+          p256dh: string;
+          user_agent: string | null;
+          user_id: string;
+        };
+        Insert: {
+          auth: string;
+          created_at?: string;
+          endpoint: string;
+          id?: string;
+          p256dh: string;
+          user_agent?: string | null;
+          user_id: string;
+        };
+        Update: {
+          auth?: string;
+          created_at?: string;
+          endpoint?: string;
+          id?: string;
+          p256dh?: string;
+          user_agent?: string | null;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
+      shopping_list_items: {
+        Row: {
+          created_at: string;
+          created_item_id: string | null;
+          desired_units: number;
+          id: string;
+          linked_item_id: string | null;
+          name: string;
+          note: string | null;
+          purchased_at: string | null;
+          status: string;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          created_item_id?: string | null;
+          desired_units?: number;
+          id?: string;
+          linked_item_id?: string | null;
+          name: string;
+          note?: string | null;
+          purchased_at?: string | null;
+          status?: string;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          created_item_id?: string | null;
+          desired_units?: number;
+          id?: string;
+          linked_item_id?: string | null;
+          name?: string;
+          note?: string | null;
+          purchased_at?: string | null;
+          status?: string;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "shopping_list_items_created_item_id_fkey";
+            columns: ["created_item_id"];
+            isOneToOne: false;
+            referencedRelation: "items";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "shopping_list_items_linked_item_id_fkey";
+            columns: ["linked_item_id"];
+            isOneToOne: false;
+            referencedRelation: "items";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      storage_locations: {
+        Row: {
+          created_at: string;
+          icon: string | null;
+          id: string;
+          name: string;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          icon?: string | null;
+          id?: string;
+          name: string;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          icon?: string | null;
+          id?: string;
+          name?: string;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
+      user_security_questions: {
+        Row: {
+          answer_hash: string;
+          created_at: string;
+          email: string;
+          question: string;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          answer_hash: string;
+          created_at?: string;
+          email: string;
+          question: string;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          answer_hash?: string;
+          created_at?: string;
+          email?: string;
+          question?: string;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
+      user_settings: {
+        Row: {
+          created_at: string;
+          default_unit: string;
+          expiry_warning_days: number;
+          language: string;
+          notify_at: string;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: {
+          created_at?: string;
+          default_unit?: string;
+          expiry_warning_days?: number;
+          language?: string;
+          notify_at?: string;
+          updated_at?: string;
+          user_id: string;
+        };
+        Update: {
+          created_at?: string;
+          default_unit?: string;
+          expiry_warning_days?: number;
+          language?: string;
+          notify_at?: string;
+          updated_at?: string;
+          user_id?: string;
+        };
+        Relationships: [];
+      };
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      [_ in never]: never;
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
+};
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">];
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R;
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] & DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R;
+      }
+      ? R
+      : never
+    : never;
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I;
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I;
+      }
+      ? I
+      : never
+    : never;
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U;
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U;
+      }
+      ? U
+      : never
+    : never;
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never;
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals;
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals;
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never;
+
+export const Constants = {
+  public: {
+    Enums: {},
+  },
+} as const;


### PR DESCRIPTION
## Summary

### バンドルサイズ追跡 (#239)
- `bundle-size.yml` を追加
- `preactjs/compressed-size-action` で PR に before/after サイズ差分をコメント
- `vite-bundle-visualizer` で詳細分析 HTML を 14日間アーティファクト保存

### Supabase 型鮮度チェック (#278)
- `supabase` CLI をインストールし `gen:types` スクリプトを追加
- `db-types.yml` を追加: `src/types/supabase.ts` を再生成し差分があれば CI 失敗
- `SUPABASE_PROJECT_ID` (vars) と `SUPABASE_ACCESS_TOKEN` (secrets) が未設定の場合はスキップ

## 注意事項

- `db-types.yml` を有効にするには `SUPABASE_PROJECT_ID` リポジトリ変数と `SUPABASE_ACCESS_TOKEN` シークレットを GitHub で設定する必要があります
- 初回実行前に `bun run gen:types` を実行して `src/types/supabase.ts` を生成し、コミットしてください

## Test plan

- [ ] PRを作成するとバンドルサイズコメントが投稿される
- [ ] バンドル stats HTML がアーティファクトにアップロードされる
- [ ] Supabase 認証情報設定後、`bun run gen:types` が正常動作する

Closes #239
Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ)_