### PR TITLE
feat: add PWA Shortcuts API for quick home-screen actions (#215)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,6 +41,22 @@ export default defineConfig({
                   purpose: "any",
                 },
               ],
+              shortcuts: [
+                {
+                  name: "在庫を追加",
+                  short_name: "追加",
+                  description: "新しい在庫アイテムを登録する",
+                  url: "/items/new",
+                  icons: [{ src: "/favicon.svg", sizes: "any", type: "image/svg+xml" }],
+                },
+                {
+                  name: "買い物リスト",
+                  short_name: "リスト",
+                  description: "買い物リストを開く",
+                  url: "/shopping",
+                  icons: [{ src: "/favicon.svg", sizes: "any", type: "image/svg+xml" }],
+                },
+              ],
             },
             devOptions: {
               enabled: false,


### PR DESCRIPTION
## Summary

- Adds `shortcuts` to the web app manifest via VitePWA plugin config
- "在庫を追加" shortcut → `/items/new` (add item)
- "買い物リスト" shortcut → `/shopping` (shopping list)
- Long-pressing the installed app icon on Android Chrome / iOS Safari 17+ now reveals these quick-action shortcuts

## Test plan

- [ ] Build the app (`bun run build`) and install as PWA on Android
- [ ] Long-press the home-screen icon — verify two shortcuts appear
- [ ] Tap each shortcut and confirm correct navigation
- [ ] Verify manifest JSON contains the `shortcuts` array in the built output

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ)_