### PR TITLE
fix: Spinner aria-label i18n 対応 & ItemForm units 即時バリデーション (#323, #325)

### DIFF
--- a/src/components/atoms/Spinner.test.tsx
+++ b/src/components/atoms/Spinner.test.tsx
@@ -1,25 +1,33 @@
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "bun:test";
+import { type ReactNode } from "react";
+import { I18nextProvider } from "react-i18next";
 
+import i18n from "../../lib/i18n";
 import { Spinner } from "./Spinner";
 
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+);
+
 describe("Spinner", () => {
-  it("renders with default aria-label in English", () => {
-    const { container } = render(<Spinner />);
+  it("renders with default aria-label from locale", () => {
+    const { container } = render(<Spinner />, { wrapper });
     const el = container.firstChild as HTMLElement;
     expect(el).not.toBeNull();
     expect(el.getAttribute("role")).toBe("status");
-    expect(el.getAttribute("aria-label")).toBe("Loading");
+    // ja fallback: "読み込み中..."
+    expect(el.getAttribute("aria-label")).toBe("読み込み中...");
   });
 
-  it("renders with custom aria-label", () => {
-    const { container } = render(<Spinner label="読み込み中" />);
+  it("renders with custom aria-label override", () => {
+    const { container } = render(<Spinner label="カスタムラベル" />, { wrapper });
     const el = container.firstChild as HTMLElement;
-    expect(el.getAttribute("aria-label")).toBe("読み込み中");
+    expect(el.getAttribute("aria-label")).toBe("カスタムラベル");
   });
 
   it("applies custom className", () => {
-    const { container } = render(<Spinner className="h-4 w-4" />);
+    const { container } = render(<Spinner className="h-4 w-4" />, { wrapper });
     const el = container.firstChild as HTMLElement;
     expect(el.className).toContain("h-4 w-4");
   });

--- a/src/components/atoms/Spinner.tsx
+++ b/src/components/atoms/Spinner.tsx
@@ -1,12 +1,17 @@
+import { useTranslation } from "react-i18next";
+
 interface SpinnerProps {
   className?: string;
   label?: string;
 }
 
-export const Spinner = ({ className = "", label = "Loading" }: SpinnerProps) => (
-  <div
-    className={`inline-block h-6 w-6 animate-spin rounded-full border-2 border-current border-t-transparent ${className}`}
-    role="status"
-    aria-label={label}
-  />
-);
+export const Spinner = ({ className = "", label }: SpinnerProps) => {
+  const { t } = useTranslation("common");
+  return (
+    <div
+      className={`inline-block h-6 w-6 animate-spin rounded-full border-2 border-current border-t-transparent ${className}`}
+      role="status"
+      aria-label={label ?? t("loading")}
+    />
+  );
+};

--- a/src/components/organisms/ItemForm.tsx
+++ b/src/components/organisms/ItemForm.tsx
@@ -347,8 +347,13 @@ export const ItemForm = ({
                 const raw = e.target.value;
                 if (!/^\d*$/.test(raw)) return;
                 setUnitsRaw(raw);
-                setUnitsError("");
-                if (raw !== "") set("units", parseInt(raw, 10));
+                const parsed = parseInt(raw, 10);
+                if (raw !== "" && !isNaN(parsed) && parsed <= 0) {
+                  setUnitsError(t("unitsPositive"));
+                } else {
+                  setUnitsError("");
+                }
+                if (raw !== "") set("units", parsed);
               }}
               className="w-24"
             />


### PR DESCRIPTION
## 概要

バグ #323（Spinner の aria-label がハードコード英語）と #325（ItemForm の units 入力で 0 以下を入力しても即時エラーが出ない）の修正。

## 変更内容

### fix(#323): Spinner aria-label を i18n 対応

- `Spinner.tsx`: デフォルト `label` を `"Loading"` ハードコードから `useTranslation("common")` の `t("loading")` に変更
- ja フォールバック: `"読み込み中..."` / en: `"Loading..."`
- `Spinner.test.tsx`: `I18nextProvider` でラップし、ja フォールバック値 (`"読み込み中..."`) を検証するよう更新

### fix(#325): ItemForm units 入力の即時バリデーション

- `ItemForm.tsx`: units の `onChange` ハンドラで、値が `0` 以下のときに即座に `t("unitsPositive")` エラーを表示するよう修正
- 従来は submit 時のみ検証されており、`0` を入力した状態でエラーがクリアされていた

## テスト

- `bun test`: 154 tests pass
- `bun run check`: lint + typecheck クリア
- `bun run format:check`: フォーマット差分なし

Closes #323
Closes #325

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dw4UBzFnwcZUk5hTLFo2FL)_