### PR TITLE
feat: dark mode with system/light/dark theme toggle (#299)

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,15 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="housekeeper" />
     <title>housekeeper</title>
+    <script>
+      (function () {
+        var t = localStorage.getItem("theme");
+        var prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        if (t === "dark" || (!t && prefersDark) || (t === "system" && prefersDark)) {
+          document.documentElement.classList.add("dark");
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/atoms/ThemeToggle.stories.tsx
+++ b/src/components/atoms/ThemeToggle.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ThemeToggle } from "./ThemeToggle";
+
+const meta = {
+  component: ThemeToggle,
+  tags: ["autodocs"],
+} satisfies Meta<typeof ThemeToggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/atoms/ThemeToggle.tsx
+++ b/src/components/atoms/ThemeToggle.tsx
@@ -1,0 +1,16 @@
+import { useTranslation } from "react-i18next";
+
+import { Select } from "@/components/ui/select";
+import { type Theme, useTheme } from "@/hooks/useTheme";
+
+export const ThemeToggle = () => {
+  const { t } = useTranslation("settings");
+  const { theme, setTheme } = useTheme();
+  return (
+    <Select value={theme} onChange={(e) => setTheme(e.target.value as Theme)}>
+      <option value="system">{t("themeSystem")}</option>
+      <option value="light">{t("themeLight")}</option>
+      <option value="dark">{t("themeDark")}</option>
+    </Select>
+  );
+};

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useState } from "react";
+
+export type Theme = "light" | "dark" | "system";
+
+const STORAGE_KEY = "theme";
+
+const applyTheme = (theme: Theme) => {
+  const root = document.documentElement;
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  const isDark = theme === "dark" || (theme === "system" && prefersDark);
+  root.classList.toggle("dark", isDark);
+};
+
+export const useTheme = () => {
+  const [theme, setThemeState] = useState<Theme>(
+    () => (localStorage.getItem(STORAGE_KEY) as Theme | null) ?? "system",
+  );
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (theme !== "system") return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => applyTheme("system");
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [theme]);
+
+  const setTheme = useCallback((next: Theme) => {
+    localStorage.setItem(STORAGE_KEY, next);
+    setThemeState(next);
+  }, []);
+
+  return { theme, setTheme };
+};

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -20,5 +20,9 @@
   "notifications": "Notification Settings",
   "saveSuccess": "Settings saved",
   "storageLocations": "Storage Location Management",
+  "theme": "Theme",
+  "themeDark": "Dark",
+  "themeLight": "Light",
+  "themeSystem": "System",
   "title": "Settings"
 }

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -20,5 +20,9 @@
   "notifications": "通知設定",
   "saveSuccess": "設定を保存しました",
   "storageLocations": "保管場所管理",
+  "theme": "テーマ",
+  "themeDark": "ダーク",
+  "themeLight": "ライト",
+  "themeSystem": "システム設定に合わせる",
   "title": "設定"
 }

--- a/src/routes/_auth.settings.tsx
+++ b/src/routes/_auth.settings.tsx
@@ -1,10 +1,11 @@
 import { createFileRoute, Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
-import { ArrowLeft, Bell, ChevronRight, Globe, MapPin, Tag } from "lucide-react";
+import { ArrowLeft, Bell, ChevronRight, Globe, MapPin, Moon, Tag } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { LanguageToggle } from "@/components/atoms/LanguageToggle";
 import { Skeleton } from "@/components/atoms/Skeleton";
+import { ThemeToggle } from "@/components/atoms/ThemeToggle";
 import { NotificationSettings } from "@/components/organisms/NotificationSettings";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -107,6 +108,15 @@ const SettingsPage = () => {
                 void handleLanguageChange(lang as "ja" | "en");
               }}
             />
+          </section>
+
+          {/* Theme */}
+          <section>
+            <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold text-muted-foreground">
+              <Moon className="h-4 w-4" />
+              {t("theme")}
+            </h2>
+            <ThemeToggle />
           </section>
 
           {/* Expiry warning days */}


### PR DESCRIPTION
## Summary

- Inline script in `index.html` applies the `dark` class before React mounts, eliminating flash of unstyled content
- `useTheme` hook manages theme state (system / light / dark), persists to `localStorage`, and listens to the `prefers-color-scheme` media query so system mode updates in real time
- `ThemeToggle` atom (Select dropdown) + Storybook story
- Theme section added to Settings page (below Language), using a Moon icon
- i18n keys added for both `ja` and `en` locales

## Test plan

- [ ] Open Settings → confirm "テーマ / Theme" section appears
- [ ] Switch to Dark → UI switches to dark palette immediately
- [ ] Switch to Light → UI switches to light palette immediately
- [ ] Switch to System → follows OS dark/light preference
- [ ] Reload page after selecting Dark → theme is preserved (no flash)
- [ ] Verify dark mode colours look correct across dashboard, shopping list, item detail, and stats pages

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ)_