### PR TITLE
ci: add Lighthouse CI for performance and accessibility auditing (#190)

### DIFF
--- a/.github/workflows/_lighthouse.yml
+++ b/.github/workflows/_lighthouse.yml
@@ -1,0 +1,41 @@
+name: Lighthouse CI
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  lighthouse:
+    name: Lighthouse Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build
+        env:
+          VITE_SUPABASE_URL: https://placeholder.supabase.co
+          VITE_SUPABASE_PUBLISHABLE_KEY: placeholder-anon-key
+
+      - name: Start preview server
+        run: bunx vite preview --port 4173 &
+        shell: bash
+
+      - name: Wait for server
+        run: npx wait-on http://localhost:4173 --timeout 30000
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          configPath: .lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}

--- a/.github/workflows/_lighthouse.yml
+++ b/.github/workflows/_lighthouse.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
 
       - name: Wait for server
-        run: npx wait-on http://localhost:4173 --timeout 30000
+        run: bunx wait-on http://localhost:4173 --timeout 30000
 
       - name: Run Lighthouse CI
         uses: treosh/lighthouse-ci-action@v12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,6 @@ jobs:
     uses: ./.github/workflows/_commitlint.yml
     with:
       base_sha: ${{ github.event.pull_request.base.sha }}
+
+  lighthouse:
+    uses: ./.github/workflows/_lighthouse.yml

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,23 @@
+{
+  "ci": {
+    "collect": {
+      "url": ["http://localhost:4173/login"],
+      "numberOfRuns": 1,
+      "settings": {
+        "preset": "desktop",
+        "chromeFlags": "--no-sandbox --disable-dev-shm-usage"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.7 }],
+        "categories:accessibility": ["error", { "minScore": 0.9 }],
+        "categories:best-practices": ["warn", { "minScore": 0.8 }],
+        "categories:seo": ["warn", { "minScore": 0.8 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/knip.json
+++ b/knip.json
@@ -9,5 +9,6 @@
     "src/**/*.stories.tsx"
   ],
   "project": ["src/**/*.{ts,tsx}"],
-  "ignoreDependencies": ["tailwindcss", "i18next-parser"]
+  "ignoreDependencies": ["tailwindcss", "i18next-parser"],
+  "ignoreBinaries": ["wait-on"]
 }


### PR DESCRIPTION
## Summary

- `.lighthouserc.json` — configures Lighthouse CI against `/login` (desktop preset); accessibility ≥ 0.9 (error), performance/best-practices/SEO ≥ 0.7–0.8 (warn); results uploaded to temporary public storage
- `.github/workflows/_lighthouse.yml` — reusable workflow: build → start `vite preview` → wait for port 4173 → run `treosh/lighthouse-ci-action@v12`
- `ci.yml` — adds the `lighthouse` job calling the reusable workflow

## Notes

- `LHCI_GITHUB_APP_TOKEN` secret is optional; without it, results still upload to temporary public storage but won't post a PR status check from the Lighthouse GitHub App
- The login page is used as the audit target because it's the only page accessible without Supabase authentication

## Test plan

- [ ] Open a PR and confirm "Lighthouse Audit" job appears in CI
- [ ] Check the job output for Lighthouse scores
- [ ] Verify report URL appears in the job summary

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ)_