### PR TITLE
ci: add test coverage report as PR comment (#202)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,30 @@
+name: Coverage Report
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  coverage:
+    name: Test Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests with coverage
+        run: bun test --coverage --coverage-reporter=lcov --coverage-dir=coverage
+
+      - name: Post coverage comment
+        uses: romeovs/lcov-reporter-action@v0.4.0
+        with:
+          lcov-file: coverage/lcov.info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          delete-old-comments: true


### PR DESCRIPTION
## Summary

- New `coverage.yml` workflow (triggers on `pull_request`, has `pull-requests: write` permission)
- Runs `bun test --coverage --coverage-reporter=lcov` to generate `coverage/lcov.info`
- Uses `romeovs/lcov-reporter-action` to post an inline coverage table as a PR comment
- Old coverage comments are automatically replaced on re-runs (`delete-old-comments: true`)

## Test plan

- [ ] Open a PR and confirm "Test Coverage" job appears in CI
- [ ] Check the PR for a coverage comment showing file-level percentages
- [ ] Push another commit and confirm the old comment is replaced, not duplicated

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rqa7rEC86ai17rD9n6zhAQ)_