### PR TITLE
fix: エラートーストの二重表示バグを修正

### DIFF
--- a/src/components/pages/EditItemPage.tsx
+++ b/src/components/pages/EditItemPage.tsx
@@ -88,7 +88,7 @@ export const EditItemPage = ({ itemId }: EditItemPageProps) => {
       await qc.invalidateQueries({ queryKey: ["items"] });
       void navigate({ to: "/items/$itemId", params: { itemId } });
     } catch {
-      toast(t("common:unknownError"), "error");
+      // error is handled by the mutation's onError
     } finally {
       setIsSubmitting(false);
     }

--- a/src/components/pages/NewItemPage.tsx
+++ b/src/components/pages/NewItemPage.tsx
@@ -73,7 +73,7 @@ export const NewItemPage = ({ cloneFrom }: NewItemPageProps) => {
         void navigate({ to: "/" });
       }
     } catch {
-      toast(t("common:unknownError"), "error");
+      // error is handled by the mutation's onError
     } finally {
       setIsSubmitting(false);
     }

--- a/src/hooks/useItems.ts
+++ b/src/hooks/useItems.ts
@@ -322,6 +322,7 @@ export const useCreateItem = () => {
     },
     onError: (error) => {
       if (error instanceof OfflineError) toast(t("common:offlineError"), "error");
+      else toast(t("common:unknownError"), "error");
     },
   });
 };
@@ -370,6 +371,7 @@ export const useUpdateItem = (id: string) => {
     },
     onError: (error) => {
       if (error instanceof OfflineError) toast(t("offlineError"), "error");
+      else toast(t("unknownError"), "error");
     },
   });
 };

--- a/src/hooks/useMasterData.ts
+++ b/src/hooks/useMasterData.ts
@@ -101,6 +101,7 @@ export const useCreateCategory = () => {
     },
     onError: (error) => {
       if (error instanceof OfflineError) toast(t("offlineError"), "error");
+      else toast(t("unknownError"), "error");
     },
   });
 };
@@ -117,6 +118,7 @@ export const useUpdateCategory = () => {
     },
     onError: (error) => {
       if (error instanceof OfflineError) toast(t("offlineError"), "error");
+      else toast(t("unknownError"), "error");
     },
   });
 };
@@ -135,6 +137,7 @@ export const useDeleteCategory = () => {
     },
     onError: (error) => {
       if (error instanceof OfflineError) toast(t("offlineError"), "error");
+      else toast(t("unknownError"), "error");
     },
   });
 };
@@ -226,6 +229,7 @@ export const useCreateStorageLocation = () => {
     },
     onError: (error) => {
       if (error instanceof OfflineError) toast(t("offlineError"), "error");
+      else toast(t("unknownError"), "error");
     },
   });
 };
@@ -241,6 +245,7 @@ export const useUpdateStorageLocation = () => {
     },
     onError: (error) => {
       if (error instanceof OfflineError) toast(t("offlineError"), "error");
+      else toast(t("unknownError"), "error");
     },
   });
 };
@@ -259,6 +264,7 @@ export const useDeleteStorageLocation = () => {
     },
     onError: (error) => {
       if (error instanceof OfflineError) toast(t("offlineError"), "error");
+      else toast(t("unknownError"), "error");
     },
   });
 };

--- a/src/routes/_auth.items.$itemId.tsx
+++ b/src/routes/_auth.items.$itemId.tsx
@@ -72,7 +72,7 @@ const ItemDetailPage = () => {
       await upsertShopping.mutateAsync({ name: item.name, linked_item_id: item.id });
       toast(t("restockSuccess"), "success");
     } catch {
-      toast(t("common:unknownError"), "error");
+      // error is handled by useUpsertShoppingItem.onError
     }
   };
 

--- a/src/routes/_auth.settings.categories.tsx
+++ b/src/routes/_auth.settings.categories.tsx
@@ -46,7 +46,7 @@ const CategoriesPage = () => {
       setNewColor(null);
       toast(t("common:saveSuccess"), "success");
     } catch {
-      toast(t("common:unknownError"), "error");
+      // error is handled by the mutation's onError
     }
   };
 
@@ -57,7 +57,7 @@ const CategoriesPage = () => {
       setEditId(null);
       toast(t("common:saveSuccess"), "success");
     } catch {
-      toast(t("common:unknownError"), "error");
+      // error is handled by the mutation's onError
     }
   };
 
@@ -84,7 +84,7 @@ const CategoriesPage = () => {
       setDeleteId(null);
       toast(t("common:deleteSuccess"), "success");
     } catch {
-      toast(t("common:unknownError"), "error");
+      // error is handled by the mutation's onError
     }
   };
 

--- a/src/routes/_auth.settings.locations.tsx
+++ b/src/routes/_auth.settings.locations.tsx
@@ -39,7 +39,7 @@ const LocationsPage = () => {
       setNewName("");
       toast(t("common:saveSuccess"), "success");
     } catch {
-      toast(t("common:unknownError"), "error");
+      // error is handled by the mutation's onError
     }
   };
 
@@ -50,7 +50,7 @@ const LocationsPage = () => {
       setEditId(null);
       toast(t("common:saveSuccess"), "success");
     } catch {
-      toast(t("common:unknownError"), "error");
+      // error is handled by the mutation's onError
     }
   };
 
@@ -77,7 +77,7 @@ const LocationsPage = () => {
       setDeleteId(null);
       toast(t("common:deleteSuccess"), "success");
     } catch {
-      toast(t("common:unknownError"), "error");
+      // error is handled by the mutation's onError
     }
   };
 


### PR DESCRIPTION
## 概要

ミューテーション失敗時にエラートーストが2回表示されるバグを3件修正する。

Closes #377
Closes #378
Closes #379

## 背景

このコードベースでは、TanStack Query の `mutateAsync` を使う場合、エラーハンドリングが**2か所**で走る：
1. フック側の `onError` コールバック
2. コンポーネント側の `catch` ブロック

`useUpsertShoppingItem`・`useSoftDeleteItem` など一部のフックは `onError` で全エラーを処理済みだが、コンポーネント側の `catch` でも `toast()` を呼んでいたため、オフラインエラー等で重複してトーストが表示されていた。

## 変更内容

### Bug A (#377) — `handleRestock` の二重トースト
- `src/routes/_auth.items.$itemId.tsx`
  - `handleRestock` の `catch` ブロックから `toast(...)` を削除（`useUpsertShoppingItem.onError` に一本化）

### Bug B (#378) — 新規・編集ページのオフラインエラー時に誤メッセージ＋二重トースト
- `src/hooks/useItems.ts`
  - `useCreateItem.onError` / `useUpdateItem.onError` に `else toast(t("unknownError"), "error")` を追加し、OfflineError以外のエラーもカバー
- `src/components/pages/NewItemPage.tsx`
- `src/components/pages/EditItemPage.tsx`
  - 外側 `catch` ブロックの `toast(...)` を削除（エラーハンドリングをフックに一本化）

### Bug C (#379) — 設定ページの二重トースト
- `src/hooks/useMasterData.ts`
  - 全6ミューテーション（`useCreateCategory` / `useUpdateCategory` / `useDeleteCategory` / `useCreateStorageLocation` / `useUpdateStorageLocation` / `useDeleteStorageLocation`）の `onError` に `else toast(...)` を追加
- `src/routes/_auth.settings.categories.tsx`
- `src/routes/_auth.settings.locations.tsx`
  - `handleCreate` / `handleUpdate` / `handleDelete` の `catch` ブロックから `toast(...)` を削除

## テスト方法

- [ ] オフライン状態で補充リスト追加 → エラートーストが1回だけ表示される
- [ ] オフライン状態で新規アイテム作成 → 「オフラインエラー」トーストが1回だけ表示される
- [ ] オフライン状態でアイテム編集 → 「オフラインエラー」トーストが1回だけ表示される
- [ ] オフライン状態でカテゴリ追加・編集・削除 → エラートーストが1回だけ表示される
- [ ] オフライン状態で保管場所追加・編集・削除 → エラートーストが1回だけ表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErtXUv36qrKuhtxPyFu9qa

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErtXUv36qrKuhtxPyFu9qa)_