### PR TITLE
fix: 設定・通知設定ページのオフライン時トースト二重表示を修正

### DIFF
--- a/src/components/organisms/NotificationSettings.tsx
+++ b/src/components/organisms/NotificationSettings.tsx
@@ -33,22 +33,36 @@ export const NotificationSettings = () => {
     try {
       if (prefs?.push_enabled) {
         await unsubscribePush();
-        await updatePrefs.mutateAsync({ push_enabled: false });
       } else {
         const permission = await Notification.requestPermission();
         if (permission !== "granted") {
           toast(t("pushPermissionDenied"), "error");
+          setIsPushLoading(false);
           return;
         }
         await subscribePush();
-        await updatePrefs.mutateAsync({ push_enabled: true });
-        toast(t("pushEnabled"), "success");
       }
     } catch (err) {
+      // subscribePush/unsubscribePush errors are not covered by hook onError
       toast(
         err instanceof OfflineError ? t("common:offlineError") : t("common:unknownError"),
         "error",
       );
+      setIsPushLoading(false);
+      return;
+    }
+    try {
+      if (prefs?.push_enabled) {
+        await updatePrefs.mutateAsync({ push_enabled: false });
+      } else {
+        await updatePrefs.mutateAsync({ push_enabled: true });
+        toast(t("pushEnabled"), "success");
+      }
+    } catch (err) {
+      if (!(err instanceof OfflineError)) {
+        toast(t("common:unknownError"), "error");
+      }
+      // OfflineError is handled by useUpdateNotificationPreferences onError
     } finally {
       setIsPushLoading(false);
     }
@@ -57,8 +71,10 @@ export const NotificationSettings = () => {
   const handleEmailToggle = async () => {
     try {
       await updatePrefs.mutateAsync({ email_enabled: !prefs?.email_enabled });
-    } catch {
-      toast(t("common:unknownError"), "error");
+    } catch (error) {
+      if (!(error instanceof OfflineError)) {
+        toast(t("common:unknownError"), "error");
+      }
     }
   };
 
@@ -70,18 +86,22 @@ export const NotificationSettings = () => {
     }
     try {
       await updatePrefs.mutateAsync({ email_address: trimmed || null });
-    } catch {
-      toast(t("common:unknownError"), "error");
+    } catch (error) {
+      if (!(error instanceof OfflineError)) {
+        toast(t("common:unknownError"), "error");
+      }
     }
   };
 
   const handleThresholdBlur = async (val: string) => {
     const days = parseInt(val, 10);
-    if (isNaN(days) || days < 0) return;
+    if (isNaN(days) || days < 0 || days > 30) return;
     try {
       await updatePrefs.mutateAsync({ threshold_days: days });
-    } catch {
-      toast(t("common:unknownError"), "error");
+    } catch (error) {
+      if (!(error instanceof OfflineError)) {
+        toast(t("common:unknownError"), "error");
+      }
     }
   };
 
@@ -89,8 +109,10 @@ export const NotificationSettings = () => {
     if (!val) return;
     try {
       await updatePrefs.mutateAsync({ notify_at: val });
-    } catch {
-      toast(t("common:unknownError"), "error");
+    } catch (error) {
+      if (!(error instanceof OfflineError)) {
+        toast(t("common:unknownError"), "error");
+      }
     }
   };
 

--- a/src/routes/_auth.settings.tsx
+++ b/src/routes/_auth.settings.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useUpdateUserSettings, useUserSettings } from "@/hooks/useUserSettings";
+import { OfflineError } from "@/lib/requireOnline";
 import { useToast } from "@/lib/toast-context";
 
 const SettingsPage = () => {
@@ -31,8 +32,10 @@ const SettingsPage = () => {
     try {
       await updateSettings.mutateAsync({ language: lang });
       toast(t("saveSuccess"), "success");
-    } catch {
-      toast(t("common:unknownError"), "error");
+    } catch (error) {
+      if (!(error instanceof OfflineError)) {
+        toast(t("common:unknownError"), "error");
+      }
     }
   };
 
@@ -42,8 +45,10 @@ const SettingsPage = () => {
       await updateSettings.mutateAsync({ expiry_warning_days: days });
       setWarningDays(null);
       toast(t("saveSuccess"), "success");
-    } catch {
-      toast(t("common:unknownError"), "error");
+    } catch (error) {
+      if (!(error instanceof OfflineError)) {
+        toast(t("common:unknownError"), "error");
+      }
     }
   };
 


### PR DESCRIPTION
## 概要

設定ページ（`_auth.settings.tsx`）および通知設定コンポーネント（`NotificationSettings.tsx`）で、オフライン時にエラートーストが2回表示されるバグ3件を修正します。また、通知設定の `threshold_days` 上限バリデーション不備も合わせて修正します。

## 修正内容

### バグの根本原因（共通パターン）

各ミューテーションフックの `onError` が `OfflineError` 発生時にトーストを表示する一方、コンポーネント側の `catch` ブロックも **全エラーに対して** `unknownError` トーストを表示していたため、オフライン時に2つのトーストが重複して表示されていた。

```ts
// フック側 (onError)
if (error instanceof OfflineError) toast(offlineError)  // 発火

// コンポーネント側 (catch) — 修正前
} catch {
  toast(unknownError)  // OfflineError でも必ず発火 → 二重表示
}

// コンポーネント側 (catch) — 修正後
} catch (error) {
  if (!(error instanceof OfflineError)) {
    toast(unknownError)  // OfflineError はフック側に委譲
  }
}
```

### 変更ファイル

#### `src/routes/_auth.settings.tsx` (Closes #384)

- `handleLanguageChange`: `OfflineError` を catch でスキップ
- `handleWarningDaysChange`: 同上
- `OfflineError` の import を追加

#### `src/components/organisms/NotificationSettings.tsx` (Closes #385, #386)

- `handleEmailToggle` / `handleEmailAddressBlur` / `handleThresholdBlur` / `handleNotifyAtBlur`: `OfflineError` を catch でスキップ
- `handlePushToggle`: `subscribePush`/`unsubscribePush`（フックで処理されない）と `mutateAsync`（フックで処理される）の try ブロックを分割し、それぞれのエラー源を正確にハンドリング
- `handleThresholdBlur`: `days > 30` の上限バリデーションを追加（`<Input max={30}>` はスピナー操作時のみ有効で手入力では未検証だったため）

## 関連 Issue

- Closes #384 — 設定ページ：言語切替・期限警告日数変更でオフライン時に二重トースト
- Closes #385 — NotificationSettings：全ハンドラーがオフライン時に二重トースト
- Closes #386 — 通知設定 `threshold_days` のJS側上限バリデーション未実装

## 既存の同パターン修正との関係

同様のバグが他ページで既に修正済み:
- PR #303 — ショッピングリスト
- PR #383 — アイテム詳細・マスタデータ設定ページ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrssMTd3eytB6mHtAQ9UFg)_