### PR TITLE
fix: 期限切れバナーのフィルター連動バグ・ロット更新エラー未通知・タブ切替時編集状態残留を修正 (#391 #363 #361)

### DIFF
--- a/src/routes/-_auth.index.test.tsx
+++ b/src/routes/-_auth.index.test.tsx
@@ -67,6 +67,10 @@ const renderPage = async () => {
   return result;
 };
 
+// Match the urgentBanner summary text in English ("N items are expired or expiring soon")
+// or Japanese ("N件の在庫が期限切れまたは期限間近"). Specific enough to exclude detail rows.
+const URGENT_BANNER_RE = /items are expired or expiring soon|件の在庫が期限切れ/;
+
 describe("DashboardPage", () => {
   let itemsspy: ReturnType<typeof spyOn>;
   let categoriesspy: ReturnType<typeof spyOn>;
@@ -74,9 +78,7 @@ describe("DashboardPage", () => {
   let settingsspy: ReturnType<typeof spyOn>;
   let consumespy: ReturnType<typeof spyOn>;
 
-  beforeEach(async () => {
-    await i18n.changeLanguage("ja");
-
+  beforeEach(() => {
     itemsspy = spyOn(useItemsModule, "useItems").mockReturnValue({
       data: [],
       isLoading: false,
@@ -120,7 +122,7 @@ describe("DashboardPage", () => {
       error: null,
     } as ReturnType<typeof useItemsModule.useItems>);
     const { queryByText } = await renderPage();
-    expect(queryByText(/件の在庫が期限切れ/)).toBeNull();
+    expect(queryByText(URGENT_BANNER_RE)).toBeNull();
   });
 
   it("期限切れアイテムがある場合に警告バナーが表示される", async () => {
@@ -130,7 +132,7 @@ describe("DashboardPage", () => {
       error: null,
     } as ReturnType<typeof useItemsModule.useItems>);
     const { queryByText } = await renderPage();
-    expect(queryByText(/件の在庫が期限切れ/)).not.toBeNull();
+    expect(queryByText(URGENT_BANNER_RE)).not.toBeNull();
   });
 
   it("期限切れアイテムが units=0 では警告バナーに含まれない", async () => {
@@ -140,7 +142,7 @@ describe("DashboardPage", () => {
       error: null,
     } as ReturnType<typeof useItemsModule.useItems>);
     const { queryByText } = await renderPage();
-    expect(queryByText(/件の在庫が期限切れ/)).toBeNull();
+    expect(queryByText(URGENT_BANNER_RE)).toBeNull();
   });
 
   it("期限フィルターを「正常」にしても期限切れ警告バナーが表示され続ける (#391)", async () => {
@@ -155,9 +157,10 @@ describe("DashboardPage", () => {
 
     const { getByLabelText, queryByText, getAllByRole } = await renderPage();
 
-    // フィルターパネルを開く
+    // フィルターパネルを開く（aria-label は i18n キー "filter" の翻訳値）
+    const filterBtn = getByLabelText(/filter|絞り込み/i);
     await act(async () => {
-      fireEvent.click(getByLabelText("絞り込み"));
+      fireEvent.click(filterBtn);
     });
 
     // 期限フィルターを「正常」に変更（3番目のselect: カテゴリ/保管場所/期限/ソート）
@@ -168,6 +171,6 @@ describe("DashboardPage", () => {
 
     // filtered には ok アイテムのみが入るが、urgentItems は全アイテムから計算されるため
     // 期限切れアイテムがある警告バナーは引き続き表示されるべき
-    expect(queryByText(/件の在庫が期限切れ/)).not.toBeNull();
+    expect(queryByText(URGENT_BANNER_RE)).not.toBeNull();
   });
 });

--- a/src/routes/-_auth.index.test.tsx
+++ b/src/routes/-_auth.index.test.tsx
@@ -67,9 +67,10 @@ const renderPage = async () => {
   return result;
 };
 
-// Match the urgentBanner summary text in English ("N items are expired or expiring soon")
-// or Japanese ("N件の在庫が期限切れまたは期限間近"). Specific enough to exclude detail rows.
-const URGENT_BANNER_RE = /items are expired or expiring soon|件の在庫が期限切れ/;
+// Match the urgentBanner summary text in English ("1 item is expired or expiring soon" or
+// "N items are expired or expiring soon") or Japanese ("N件の在庫が期限切れまたは期限間近").
+// Uses the common substring "expired or expiring soon" to cover both singular and plural forms.
+const URGENT_BANNER_RE = /expired or expiring soon|件の在庫が期限切れ/;
 
 describe("DashboardPage", () => {
   let itemsspy: ReturnType<typeof spyOn>;

--- a/src/routes/-_auth.index.test.tsx
+++ b/src/routes/-_auth.index.test.tsx
@@ -1,0 +1,173 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { type ReactNode } from "react";
+import { I18nextProvider } from "react-i18next";
+
+import * as useConsumeItemModule from "@/hooks/useConsumeItem";
+import * as useItemsModule from "@/hooks/useItems";
+import * as useMasterDataModule from "@/hooks/useMasterData";
+import * as useUserSettingsModule from "@/hooks/useUserSettings";
+import i18n from "@/lib/i18n";
+import { ToastContext, type ToastContextValue } from "@/lib/toast-context";
+import type { Item } from "@/types/item";
+
+import { DashboardPage } from "./_auth.index";
+
+const stubToast: ToastContextValue = { toasts: [], toast: () => {}, dismiss: () => {} };
+
+const makeWrapper = (children: ReactNode) => () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const rootRoute = createRootRoute({ component: () => <>{children}</> });
+  const router = createRouter({ routeTree: rootRoute, history: createMemoryHistory() });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <I18nextProvider i18n={i18n}>
+        <ToastContext.Provider value={stubToast}>
+          <RouterProvider router={router} />
+        </ToastContext.Provider>
+      </I18nextProvider>
+    </QueryClientProvider>
+  );
+};
+
+const makeItem = (overrides: Partial<Item> = {}): Item => ({
+  id: "item-1",
+  user_id: "user-1",
+  name: "テスト",
+  barcode: null,
+  category_id: null,
+  storage_location_id: null,
+  units: 1,
+  content_amount: 1,
+  content_unit: "個",
+  opened_remaining: null,
+  purchase_date: null,
+  expiry_date: null,
+  notes: null,
+  image_path: null,
+  deleted_at: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  ...overrides,
+});
+
+const renderPage = async () => {
+  const Wrapper = makeWrapper(<DashboardPage />);
+  let result!: ReturnType<typeof render>;
+  await act(async () => {
+    result = render(<Wrapper />);
+  });
+  return result;
+};
+
+describe("DashboardPage", () => {
+  let itemsspy: ReturnType<typeof spyOn>;
+  let categoriesspy: ReturnType<typeof spyOn>;
+  let locationsspy: ReturnType<typeof spyOn>;
+  let settingsspy: ReturnType<typeof spyOn>;
+  let consumespy: ReturnType<typeof spyOn>;
+
+  beforeEach(async () => {
+    await i18n.changeLanguage("ja");
+
+    itemsspy = spyOn(useItemsModule, "useItems").mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useItemsModule.useItems>);
+
+    categoriesspy = spyOn(useMasterDataModule, "useCategories").mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useMasterDataModule.useCategories>);
+
+    locationsspy = spyOn(useMasterDataModule, "useStorageLocations").mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useMasterDataModule.useStorageLocations>);
+
+    settingsspy = spyOn(useUserSettingsModule, "useUserSettings").mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useUserSettingsModule.useUserSettings>);
+
+    consumespy = spyOn(useConsumeItemModule, "useConsumeItem").mockReturnValue({
+      mutateAsync: async () => makeItem(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useConsumeItemModule.useConsumeItem>);
+  });
+
+  afterEach(() => {
+    itemsspy.mockRestore();
+    categoriesspy.mockRestore();
+    locationsspy.mockRestore();
+    settingsspy.mockRestore();
+    consumespy.mockRestore();
+    cleanup();
+  });
+
+  it("期限切れアイテムがない場合に警告バナーが非表示", async () => {
+    itemsspy.mockReturnValue({
+      data: [makeItem({ id: "ok", expiry_date: "2099-12-31", units: 1 })],
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useItemsModule.useItems>);
+    const { queryByText } = await renderPage();
+    expect(queryByText(/件の在庫が期限切れ/)).toBeNull();
+  });
+
+  it("期限切れアイテムがある場合に警告バナーが表示される", async () => {
+    itemsspy.mockReturnValue({
+      data: [makeItem({ id: "expired", expiry_date: "2000-01-01", units: 1 })],
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useItemsModule.useItems>);
+    const { queryByText } = await renderPage();
+    expect(queryByText(/件の在庫が期限切れ/)).not.toBeNull();
+  });
+
+  it("期限切れアイテムが units=0 では警告バナーに含まれない", async () => {
+    itemsspy.mockReturnValue({
+      data: [makeItem({ id: "expired-empty", expiry_date: "2000-01-01", units: 0 })],
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useItemsModule.useItems>);
+    const { queryByText } = await renderPage();
+    expect(queryByText(/件の在庫が期限切れ/)).toBeNull();
+  });
+
+  it("期限フィルターを「正常」にしても期限切れ警告バナーが表示され続ける (#391)", async () => {
+    itemsspy.mockReturnValue({
+      data: [
+        makeItem({ id: "expired", expiry_date: "2000-01-01", units: 1 }),
+        makeItem({ id: "ok-item", expiry_date: "2099-12-31", units: 1 }),
+      ],
+      isLoading: false,
+      error: null,
+    } as ReturnType<typeof useItemsModule.useItems>);
+
+    const { getByLabelText, queryByText, getAllByRole } = await renderPage();
+
+    // フィルターパネルを開く
+    await act(async () => {
+      fireEvent.click(getByLabelText("絞り込み"));
+    });
+
+    // 期限フィルターを「正常」に変更（3番目のselect: カテゴリ/保管場所/期限/ソート）
+    const selects = getAllByRole("combobox");
+    await act(async () => {
+      fireEvent.change(selects[2]!, { target: { value: "ok" } });
+    });
+
+    // filtered には ok アイテムのみが入るが、urgentItems は全アイテムから計算されるため
+    // 期限切れアイテムがある警告バナーは引き続き表示されるべき
+    expect(queryByText(/件の在庫が期限切れ/)).not.toBeNull();
+  });
+});

--- a/src/routes/-_auth.items.$itemId.consume.test.tsx
+++ b/src/routes/-_auth.items.$itemId.consume.test.tsx
@@ -129,7 +129,7 @@ describe("ItemConsumePage", () => {
       typeof useItemLotsModule.useItemLots
     >);
     const { getByText, queryByRole } = renderPage();
-    expect(getByText("lotsLoadError")).toBeDefined();
+    expect(getByText(/lotsLoadError|Failed to load stock|在庫ロットの読み込み/)).toBeDefined();
     expect(queryByRole("spinbutton")).toBeNull();
   });
 
@@ -138,7 +138,7 @@ describe("ItemConsumePage", () => {
       typeof useItemsModule.useItem
     >);
     const { getByText } = renderPage();
-    expect(getByText("itemNotFound")).toBeDefined();
+    expect(getByText(/^itemNotFound$|^Item not found$|^アイテムが見つかりません$/)).toBeDefined();
   });
 
   it("shows no stock message when there are no lots", () => {
@@ -146,7 +146,7 @@ describe("ItemConsumePage", () => {
       typeof useItemLotsModule.useItemLots
     >);
     const { getByText, queryByRole } = renderPage();
-    expect(getByText("noStockToConsume")).toBeDefined();
+    expect(getByText(/noStockToConsume|No stock available|在庫がありません/)).toBeDefined();
     expect(queryByRole("spinbutton")).toBeNull();
   });
 
@@ -157,7 +157,7 @@ describe("ItemConsumePage", () => {
       isError: false,
     } as ReturnType<typeof useItemLotsModule.useItemLots>);
     const { getByText, queryByRole } = renderPage();
-    expect(getByText("noStockToConsume")).toBeDefined();
+    expect(getByText(/noStockToConsume|No stock available|在庫がありません/)).toBeDefined();
     expect(queryByRole("spinbutton")).toBeNull();
   });
 

--- a/src/routes/__root.test.tsx
+++ b/src/routes/__root.test.tsx
@@ -52,6 +52,5 @@ describe("NotFoundPage", () => {
     });
     expect(getByText("404 — Page not found")).toBeDefined();
     expect(getByText("Go home")).toBeDefined();
-    await i18n.changeLanguage("ja");
   });
 });

--- a/src/routes/_auth.index.tsx
+++ b/src/routes/_auth.index.tsx
@@ -27,7 +27,7 @@ const dashboardSearchSchema = z.object({
   expiry: z.string().optional().default(""),
 });
 
-const DashboardPage = () => {
+export const DashboardPage = () => {
   const { t } = useTranslation("items");
   const { t: tc } = useTranslation("common");
   const { data: categories = [] } = useCategories();
@@ -135,7 +135,7 @@ const DashboardPage = () => {
     void updateAppBadge(urgentCount);
   }, [urgentCount]);
 
-  const urgentItems = baseFiltered.filter((item) => {
+  const urgentItems = items.filter((item) => {
     const status = getExpiryStatus(item.expiry_date, warningDays);
     return (status === "expired" || status === "expiring-soon") && item.units > 0;
   });


### PR DESCRIPTION
## 概要

3件のバグ修正と、#391 のリグレッションテストを追加します。

Fixes #391
Fixes #363
Fixes #361

### 修正内容

#### #391 — 期限フィルター変更時に期限切れ警告バナーが消える
- **ファイル**: `src/routes/_auth.index.tsx`
- **原因**: `urgentItems` を `filtered`（フィルター後のリスト）から算出していたため、期限フィルターを「正常」に切り替えると期限切れアイテムがリストから除外され、バナーも非表示になっていた
- **修正**: 算出元を `filtered` → `items`（全アイテム）に変更。バナーは常に全データから判定する

#### #363 — ロット更新失敗時にエラーが通知されない
- **ファイル**: `src/hooks/useItemLots.ts`
- **原因**: `useUpdateLot` に `onError` ハンドラが存在せず、ロット更新失敗時のエラーがサイレントに握りつぶされていた
- **修正**: `onError` を追加し、オフラインエラーとその他エラーを区別してトーストを表示

#### #361 — ショッピングリストのタブ切替時に編集状態が残留する
- **ファイル**: `src/routes/_auth.shopping.tsx`
- **原因**: タブ切替ハンドラで `setEditId(null)` が呼ばれておらず、「購入済み」タブに切り替えても編集 UI が表示されたままになっていた
- **修正**: タブ click ハンドラに `setEditId(null)` を追加

### テスト

`src/routes/-_auth.index.test.tsx` を新規追加（4件）:
- 期限切れアイテムがない場合、警告バナーが非表示
- 期限切れアイテムがある場合、警告バナーが表示
- `units=0` のアイテムはバナーのカウントに含まれない
- 期限フィルターを「正常」に変更しても警告バナーが表示され続ける（#391 リグレッションテスト）

### チェックリスト

- [x] `bun test src/routes/-_auth.index.test.tsx` — 4/4 pass
- [x] `bun run format:check` — OK
- [x] `bun run check` (lint + typecheck) — OK