### PR TITLE
test(skeleton): add unit tests for Skeleton atom

### DIFF
--- a/src/components/atoms/Skeleton.test.tsx
+++ b/src/components/atoms/Skeleton.test.tsx
@@ -1,0 +1,19 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "bun:test";
+
+import { Skeleton } from "./Skeleton";
+
+describe("Skeleton", () => {
+  it("renders a div with animate-pulse class", () => {
+    const { container } = render(<Skeleton />);
+    const el = container.firstChild as HTMLElement;
+    expect(el).not.toBeNull();
+    expect(el.className).toContain("animate-pulse");
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(<Skeleton className="h-4 w-full" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toContain("h-4 w-full");
+  });
+});


### PR DESCRIPTION
## Summary

- `Skeleton.tsx`（新規 atom）に対する unit test が未追加だったため追加
- `animate-pulse` クラスの付与と `className` の結合を検証する2ケース

## Test plan

- [x] `bun test src/components/atoms/Skeleton.test.tsx` — 2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)