### PR TITLE
feat: Supabase Realtime による複数デバイス間リアルタイム在庫同期 (#231)

### DIFF
--- a/src/hooks/useRealtimeItems.test.tsx
+++ b/src/hooks/useRealtimeItems.test.tsx
@@ -1,0 +1,56 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactNode } from "react";
+
+type ChangeHandler = () => void;
+
+const handlers: ChangeHandler[] = [];
+const subscribeMock = mock(() => undefined);
+const removeChannelMock = mock(() => Promise.resolve("ok"));
+
+const channelObj = {
+  on: mock((_event: string, _filter: unknown, cb: ChangeHandler) => {
+    handlers.push(cb);
+    return channelObj;
+  }),
+  subscribe: subscribeMock,
+};
+
+const channelMock = mock(() => channelObj);
+
+mock.module("@/lib/supabase", () => ({
+  supabase: {
+    channel: channelMock,
+    removeChannel: removeChannelMock,
+  },
+}));
+
+const { useRealtimeItems } = await import("@/hooks/useRealtimeItems");
+
+const makeWrapper = (qc: QueryClient) => {
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
+};
+
+describe("useRealtimeItems", () => {
+  test("3 テーブルを購読し、変更イベントで該当クエリを無効化する", () => {
+    const qc = new QueryClient();
+    const invalidateSpy = mock(() => Promise.resolve());
+    qc.invalidateQueries = invalidateSpy as unknown as typeof qc.invalidateQueries;
+
+    const { unmount } = renderHook(() => useRealtimeItems(), { wrapper: makeWrapper(qc) });
+
+    // items / item_lots / shopping_list_items の 3 テーブルを購読
+    expect(channelMock).toHaveBeenCalled();
+    expect(handlers.length).toBe(3);
+
+    // postgres_changes イベント発火 → invalidateQueries が呼ばれる
+    handlers.forEach((cb) => cb());
+    expect(invalidateSpy).toHaveBeenCalledTimes(3);
+
+    // アンマウントで購読解除
+    unmount();
+    expect(removeChannelMock).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useRealtimeItems.ts
+++ b/src/hooks/useRealtimeItems.ts
@@ -1,0 +1,64 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
+
+import { supabase } from "@/lib/supabase";
+
+/** Realtime で購読するテーブルと、変更時に無効化する TanStack Query のキー。 */
+const REALTIME_TABLES = [
+  { table: "items", queryKey: ["items"] },
+  { table: "item_lots", queryKey: ["item-lots"] },
+  { table: "shopping_list_items", queryKey: ["shopping"] },
+] as const;
+
+const CHANNEL_NAME = "housekeeper-realtime";
+
+/**
+ * Supabase Realtime (`postgres_changes`) を購読し、`items` / `item_lots` /
+ * `shopping_list_items` の変更を検知して TanStack Query キャッシュを無効化する。
+ *
+ * 複数デバイス間で在庫情報をリアルタイム同期するためのフック。
+ * オフライン時は購読を張らず、オンライン復帰時に再接続する。
+ */
+export const useRealtimeItems = () => {
+  const qc = useQueryClient();
+
+  useEffect(() => {
+    let channel: ReturnType<typeof supabase.channel> | null = null;
+
+    const subscribe = () => {
+      if (channel) return;
+      const ch = supabase.channel(CHANNEL_NAME);
+      for (const { table, queryKey } of REALTIME_TABLES) {
+        ch.on("postgres_changes", { event: "*", schema: "public", table }, () => {
+          void qc.invalidateQueries({ queryKey });
+        });
+      }
+      ch.subscribe();
+      channel = ch;
+    };
+
+    const unsubscribe = () => {
+      if (!channel) return;
+      void supabase.removeChannel(channel);
+      channel = null;
+    };
+
+    const handleOnline = () => {
+      subscribe();
+      // 再接続時はオフライン中に発生した変更を取り込むため一度だけ再取得する
+      for (const { queryKey } of REALTIME_TABLES) {
+        void qc.invalidateQueries({ queryKey });
+      }
+    };
+
+    if (navigator.onLine) subscribe();
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", unsubscribe);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", unsubscribe);
+      unsubscribe();
+    };
+  }, [qc]);
+};

--- a/src/routes/_auth.tsx
+++ b/src/routes/_auth.tsx
@@ -12,6 +12,7 @@ import {
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
+import { useRealtimeItems } from "@/hooks/useRealtimeItems";
 import { supabase } from "@/lib/supabase";
 
 const NAV_ROUTES = [
@@ -26,6 +27,9 @@ const NAV_ROUTES = [
 const AuthLayout = () => {
   const router = useRouter();
   const { t } = useTranslation("common");
+
+  // 複数デバイス間の在庫・買い物リストをリアルタイム同期する
+  useRealtimeItems();
 
   const handleSignOut = async () => {
     await supabase.auth.signOut();


### PR DESCRIPTION
## 概要

Closes #231

複数デバイス（スマホ／タブレット）併用時に、一方で在庫を更新してももう一方では古い情報が表示されたままになる UX 問題を解消します。Supabase Realtime の `postgres_changes` チャネルを購読し、変更を検知して TanStack Query のキャッシュを無効化します。

## 変更内容

- `src/hooks/useRealtimeItems.ts` を追加
  - `items` / `item_lots` / `shopping_list_items` の 3 テーブルを `postgres_changes`（`event: "*"`）で購読
  - 変更検知時に該当するクエリキー（`["items"]` / `["item-lots"]` / `["shopping"]`）を `invalidateQueries`
  - **オフライン対応**: `navigator.onLine` を見て購読の張り直しを制御し、`online` / `offline` イベントで再接続・購読停止。オンライン復帰時はオフライン中の変更を取り込むため一度だけ再取得
  - アンマウント時に `removeChannel` で確実に購読解除
- `src/routes/_auth.tsx`（認証済みレイアウト）で `useRealtimeItems()` を呼び出し、全認証ページで有効化
- `src/hooks/useRealtimeItems.test.tsx` を追加（チャネル購読・イベント時の無効化・アンマウント時の解除を検証）

## テスト

- `bun test` 全 180 件パス
- `bun run check`（lint + typecheck）パス
- `knip` クリーン

## 補足

シングルユーザー自宅アプリのため Supabase Free プランの同時接続数制限（500接続/プロジェクト）は問題になりません。将来の多人数共有（#64）の技術的基盤にもなります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nf7CiR35AbxvXMcAS3D4ue

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nf7CiR35AbxvXMcAS3D4ue)_