### PR TITLE
feat: 買い物リストのカテゴリ別グループ化・並び替え機能 (#326)

### DIFF
--- a/.github/workflows/_audit.yml
+++ b/.github/workflows/_audit.yml
@@ -1,4 +1,4 @@
-name: Knip Dead Code Detection
+name: Security Audit
 
 on:
   workflow_call:
@@ -7,8 +7,8 @@ permissions:
   contents: read
 
 jobs:
-  knip:
-    name: Dead Code Check
+  audit:
+    name: Dependency Vulnerability Scan
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -18,5 +18,6 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Run knip
-        run: bun run knip
+      - name: Run bun audit
+        run: bun audit
+        continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ jobs:
   test:
     uses: ./.github/workflows/_test.yml
 
+  audit:
+    uses: ./.github/workflows/_audit.yml
+
+  knip:
+    uses: ./.github/workflows/_knip.yml
+
   commitlint:
     uses: ./.github/workflows/_commitlint.yml
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,6 @@ jobs:
   test:
     uses: ./.github/workflows/_test.yml
 
-  audit:
-    uses: ./.github/workflows/_audit.yml
-
-  knip:
-    uses: ./.github/workflows/_knip.yml
-
   commitlint:
     uses: ./.github/workflows/_commitlint.yml
     with:

--- a/src/components/atoms/ErrorBoundary.test.tsx
+++ b/src/components/atoms/ErrorBoundary.test.tsx
@@ -1,7 +1,17 @@
 import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, spyOn } from "bun:test";
+import type { ReactNode } from "react";
+import { I18nextProvider } from "react-i18next";
 
+import i18n from "../../lib/i18n";
 import { ErrorBoundary } from "./ErrorBoundary";
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+);
+
+const UNKNOWN_ERROR_TEXT = /エラーが発生しました|An error occurred/;
+const RETRY_TEXT = /再試行|Retry/;
 
 const ThrowError = () => {
   throw new Error("test error");
@@ -13,6 +23,7 @@ describe("ErrorBoundary", () => {
       <ErrorBoundary>
         <p>正常コンテンツ</p>
       </ErrorBoundary>,
+      { wrapper },
     );
     expect(getByText("正常コンテンツ")).not.toBeNull();
   });
@@ -23,9 +34,10 @@ describe("ErrorBoundary", () => {
       <ErrorBoundary>
         <ThrowError />
       </ErrorBoundary>,
+      { wrapper },
     );
-    expect(getByText("エラーが発生しました")).not.toBeNull();
-    expect(getByText("再試行")).not.toBeNull();
+    expect(getByText(UNKNOWN_ERROR_TEXT)).not.toBeNull();
+    expect(getByText(RETRY_TEXT)).not.toBeNull();
     consoleSpy.mockRestore();
   });
 
@@ -35,6 +47,7 @@ describe("ErrorBoundary", () => {
       <ErrorBoundary fallback={<p>カスタムフォールバック</p>}>
         <ThrowError />
       </ErrorBoundary>,
+      { wrapper },
     );
     expect(getByText("カスタムフォールバック")).not.toBeNull();
     consoleSpy.mockRestore();
@@ -46,10 +59,11 @@ describe("ErrorBoundary", () => {
       <ErrorBoundary>
         <ThrowError />
       </ErrorBoundary>,
+      { wrapper },
     );
-    fireEvent.click(getByText("再試行"));
+    fireEvent.click(getByText(RETRY_TEXT));
     // After reset the child throws again, so fallback is shown again
-    expect(getByText("再試行")).not.toBeNull();
+    expect(getByText(RETRY_TEXT)).not.toBeNull();
     consoleSpy.mockRestore();
   });
 });

--- a/src/components/molecules/ShoppingGroupHeader.stories.tsx
+++ b/src/components/molecules/ShoppingGroupHeader.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ShoppingGroupHeader } from "./ShoppingGroupHeader";
+
+const meta = {
+  component: ShoppingGroupHeader,
+  tags: ["autodocs"],
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof ShoppingGroupHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    name: "食品",
+    color: "#22c55e",
+    count: 3,
+    otherLabel: "その他",
+  },
+};
+
+export const NoColor: Story = {
+  args: {
+    name: "日用品",
+    color: null,
+    count: 1,
+    otherLabel: "その他",
+  },
+};
+
+export const Uncategorized: Story = {
+  args: {
+    name: null,
+    count: 2,
+    otherLabel: "その他",
+  },
+};

--- a/src/components/molecules/ShoppingGroupHeader.tsx
+++ b/src/components/molecules/ShoppingGroupHeader.tsx
@@ -1,0 +1,23 @@
+import { ColorDot } from "@/components/atoms/ColorDot";
+
+interface ShoppingGroupHeaderProps {
+  /** カテゴリ名。未分類グループのときは null */
+  name: string | null;
+  color?: string | null;
+  count: number;
+  /** 未分類グループに表示するラベル（例: 「その他」） */
+  otherLabel: string;
+}
+
+export const ShoppingGroupHeader = ({
+  name,
+  color,
+  count,
+  otherLabel,
+}: ShoppingGroupHeaderProps) => (
+  <div className="flex items-center gap-2 pt-2 pb-1">
+    <ColorDot color={name === null ? "#9ca3af" : color} className="h-3 w-3" />
+    <h3 className="text-sm font-semibold text-foreground">{name ?? otherLabel}</h3>
+    <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">{count}</span>
+  </div>
+);

--- a/src/lib/shoppingView.test.ts
+++ b/src/lib/shoppingView.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  type CategoryResolver,
+  groupShoppingItemsByCategory,
+  isShoppingSortKey,
+  type ResolvedCategory,
+  sortShoppingItems,
+} from "@/lib/shoppingView";
+import type { ShoppingItem } from "@/types/shopping";
+
+const makeItem = (overrides: Partial<ShoppingItem> = {}): ShoppingItem => ({
+  id: "s-1",
+  user_id: "u-1",
+  name: "アイテム",
+  desired_units: 1,
+  note: null,
+  linked_item_id: null,
+  status: "planned",
+  purchased_at: null,
+  created_item_id: null,
+  created_at: "2026-06-01T00:00:00Z",
+  updated_at: "2026-06-01T00:00:00Z",
+  ...overrides,
+});
+
+const categories: Record<string, ResolvedCategory> = {
+  food: { id: "food", name: "食品", color: "#22c55e" },
+  daily: { id: "daily", name: "日用品", color: "#3b82f6" },
+};
+
+const resolver: CategoryResolver = (item) =>
+  item.linked_item_id ? (categories[item.linked_item_id] ?? null) : null;
+
+describe("isShoppingSortKey", () => {
+  test("有効なキーを判定する", () => {
+    expect(isShoppingSortKey("category")).toBe(true);
+    expect(isShoppingSortKey("invalid")).toBe(false);
+  });
+});
+
+describe("sortShoppingItems", () => {
+  test("name: 五十音順に並ぶ", () => {
+    const items = [makeItem({ id: "a", name: "りんご" }), makeItem({ id: "b", name: "あんず" })];
+    const sorted = sortShoppingItems(items, "name", resolver);
+    expect(sorted.map((i) => i.name)).toEqual(["あんず", "りんご"]);
+  });
+
+  test("priority: desired_units が多い順に並ぶ", () => {
+    const items = [
+      makeItem({ id: "a", desired_units: 1 }),
+      makeItem({ id: "b", desired_units: 5 }),
+    ];
+    const sorted = sortShoppingItems(items, "priority", resolver);
+    expect(sorted.map((i) => i.id)).toEqual(["b", "a"]);
+  });
+
+  test("added: 元の順序を維持する", () => {
+    const items = [makeItem({ id: "a" }), makeItem({ id: "b" })];
+    const sorted = sortShoppingItems(items, "added", resolver);
+    expect(sorted.map((i) => i.id)).toEqual(["a", "b"]);
+  });
+
+  test("category: カテゴリ名順、未分類は末尾", () => {
+    const items = [
+      makeItem({ id: "x", linked_item_id: null }),
+      makeItem({ id: "d", linked_item_id: "daily" }),
+      makeItem({ id: "f", linked_item_id: "food" }),
+    ];
+    const sorted = sortShoppingItems(items, "category", resolver);
+    // 食品 < 日用品 < 未分類
+    expect(sorted.map((i) => i.id)).toEqual(["f", "d", "x"]);
+  });
+});
+
+describe("groupShoppingItemsByCategory", () => {
+  test("カテゴリ別にグループ化し、未分類を末尾にする", () => {
+    const items = [
+      makeItem({ id: "x", name: "メモ", linked_item_id: null }),
+      makeItem({ id: "f1", name: "牛乳", linked_item_id: "food" }),
+      makeItem({ id: "d1", name: "洗剤", linked_item_id: "daily" }),
+      makeItem({ id: "f2", name: "卵", linked_item_id: "food" }),
+    ];
+    const groups = groupShoppingItemsByCategory(items, resolver);
+    expect(groups.map((g) => g.categoryName)).toEqual(["食品", "日用品", null]);
+    const food = groups[0];
+    expect(food?.items.map((i) => i.name)).toEqual(["牛乳", "卵"]); // グループ内も名前順
+    expect(food?.color).toBe("#22c55e");
+    expect(groups[2]?.items.map((i) => i.id)).toEqual(["x"]);
+  });
+});

--- a/src/lib/shoppingView.ts
+++ b/src/lib/shoppingView.ts
@@ -1,0 +1,100 @@
+import type { ShoppingItem } from "@/types/shopping";
+
+/** 買い物リストの並び順。`category` のときはカテゴリ別グループ表示になる。 */
+export type ShoppingSortKey = "added" | "category" | "name" | "priority";
+
+export const SHOPPING_SORT_KEYS = ["added", "category", "name", "priority"] as const;
+
+export const isShoppingSortKey = (value: string): value is ShoppingSortKey =>
+  (SHOPPING_SORT_KEYS as readonly string[]).includes(value);
+
+export interface ResolvedCategory {
+  id: string;
+  name: string;
+  color: string | null;
+}
+
+/** 買い物アイテム（`linked_item_id` 経由）からカテゴリを解決する。未分類は null。 */
+export type CategoryResolver = (item: ShoppingItem) => ResolvedCategory | null;
+
+const collator = new Intl.Collator("ja");
+
+/**
+ * 並び順に応じて買い物アイテムを並べ替える。
+ * `added` は元の追加順（呼び出し側が created_at desc で渡す）を維持する。
+ */
+export const sortShoppingItems = (
+  items: ShoppingItem[],
+  sortKey: ShoppingSortKey,
+  resolveCategory: CategoryResolver,
+): ShoppingItem[] => {
+  const sorted = [...items];
+  switch (sortKey) {
+    case "name":
+      sorted.sort((a, b) => collator.compare(a.name, b.name));
+      break;
+    case "priority":
+      sorted.sort((a, b) => b.desired_units - a.desired_units || collator.compare(a.name, b.name));
+      break;
+    case "category":
+      sorted.sort((a, b) => {
+        const ca = resolveCategory(a)?.name ?? null;
+        const cb = resolveCategory(b)?.name ?? null;
+        if (ca === cb) return collator.compare(a.name, b.name);
+        if (ca === null) return 1; // 未分類は末尾
+        if (cb === null) return -1;
+        return collator.compare(ca, cb);
+      });
+      break;
+    case "added":
+      break;
+  }
+  return sorted;
+};
+
+export interface ShoppingGroup {
+  /** 未分類グループは null */
+  categoryId: string | null;
+  categoryName: string | null;
+  color: string | null;
+  items: ShoppingItem[];
+}
+
+const OTHER_KEY = "__other__";
+
+/**
+ * 買い物アイテムをカテゴリ別にグループ化する。
+ * グループはカテゴリ名昇順、未分類（その他）は末尾。各グループ内は名前順。
+ */
+export const groupShoppingItemsByCategory = (
+  items: ShoppingItem[],
+  resolveCategory: CategoryResolver,
+): ShoppingGroup[] => {
+  const groups = new Map<string, ShoppingGroup>();
+  for (const item of items) {
+    const cat = resolveCategory(item);
+    const key = cat?.id ?? OTHER_KEY;
+    let group = groups.get(key);
+    if (!group) {
+      group = {
+        categoryId: cat?.id ?? null,
+        categoryName: cat?.name ?? null,
+        color: cat?.color ?? null,
+        items: [],
+      };
+      groups.set(key, group);
+    }
+    group.items.push(item);
+  }
+
+  for (const group of groups.values()) {
+    group.items.sort((a, b) => collator.compare(a.name, b.name));
+  }
+
+  return [...groups.values()].sort((a, b) => {
+    if (a.categoryName === b.categoryName) return 0;
+    if (a.categoryName === null) return 1;
+    if (b.categoryName === null) return -1;
+    return collator.compare(a.categoryName, b.categoryName);
+  });
+};

--- a/src/locales/en/shopping.json
+++ b/src/locales/en/shopping.json
@@ -15,6 +15,7 @@
   "editItem": "Edit",
   "editSave": "Save",
   "editSuccess": "Updated",
+  "groupOther": "Other",
   "itemName": "Item name",
   "itemNamePlaceholder": "Enter item name",
   "markPurchased": "Add to Inventory",
@@ -27,5 +28,10 @@
   "restock": "Restock",
   "share": "Share",
   "shareShoppingList": "Share Shopping List",
+  "sortAdded": "Added order",
+  "sortCategory": "By category",
+  "sortLabel": "Sort",
+  "sortName": "By name",
+  "sortPriority": "By quantity",
   "title": "Shopping List"
 }

--- a/src/locales/ja/shopping.json
+++ b/src/locales/ja/shopping.json
@@ -15,6 +15,7 @@
   "editItem": "編集",
   "editSave": "保存",
   "editSuccess": "更新しました",
+  "groupOther": "その他",
   "itemName": "商品名",
   "itemNamePlaceholder": "商品名を入力",
   "markPurchased": "在庫に追加",
@@ -27,5 +28,10 @@
   "restock": "再購入",
   "share": "共有",
   "shareShoppingList": "買い物リストを共有",
+  "sortAdded": "追加順",
+  "sortCategory": "カテゴリ順",
+  "sortLabel": "並び替え",
+  "sortName": "名前順",
+  "sortPriority": "数量が多い順",
   "title": "買い物リスト"
 }

--- a/src/routes/_auth.shopping.tsx
+++ b/src/routes/_auth.shopping.tsx
@@ -6,10 +6,14 @@ import { useTranslation } from "react-i18next";
 import { ShareButton } from "@/components/atoms/ShareButton";
 import { Skeleton } from "@/components/atoms/Skeleton";
 import { ConfirmDialog } from "@/components/molecules/ConfirmDialog";
+import { ShoppingGroupHeader } from "@/components/molecules/ShoppingGroupHeader";
 import { ShoppingRow } from "@/components/molecules/ShoppingRow";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
+import { useItems } from "@/hooks/useItems";
+import { useCategories } from "@/hooks/useMasterData";
 import {
   useDeleteAllPurchasedItems,
   useDeleteShoppingItem,
@@ -17,10 +21,28 @@ import {
   useShoppingList,
   useUpsertShoppingItem,
 } from "@/hooks/useShoppingList";
+import {
+  type CategoryResolver,
+  groupShoppingItemsByCategory,
+  isShoppingSortKey,
+  SHOPPING_SORT_KEYS,
+  type ShoppingSortKey,
+  sortShoppingItems,
+} from "@/lib/shoppingView";
 import { useToast } from "@/lib/toast-context";
 import type { ItemFormValues } from "@/types/item";
+import type { ShoppingItem } from "@/types/shopping";
 
 import { PurchaseDialog } from "../components/molecules/PurchaseDialog";
+
+const SORT_STORAGE_KEY = "shopping.sort";
+
+const sortLabelKey = {
+  added: "sortAdded",
+  category: "sortCategory",
+  name: "sortName",
+  priority: "sortPriority",
+} as const satisfies Record<ShoppingSortKey, string>;
 
 type ShoppingTab = "planned" | "purchased";
 
@@ -41,9 +63,15 @@ const ShoppingPage = () => {
   const [savingId, setSavingId] = useState<string | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [showClearPurchased, setShowClearPurchased] = useState(false);
+  const [sort, setSort] = useState<ShoppingSortKey>(() => {
+    const saved = localStorage.getItem(SORT_STORAGE_KEY);
+    return saved && isShoppingSortKey(saved) ? saved : "added";
+  });
 
   const { data: items = [], isLoading } = useShoppingList(tab);
   const { data: plannedItems = [] } = useShoppingList("planned");
+  const { data: inventoryItems = [] } = useItems();
+  const { data: categories = [] } = useCategories();
   const upsert = useUpsertShoppingItem();
   const deleteItem = useDeleteShoppingItem();
   const purchase = usePurchaseShoppingItem();
@@ -114,6 +142,46 @@ const ShoppingPage = () => {
       // Error toast is handled by usePurchaseShoppingItem.onError
     }
   };
+
+  const handleSortChange = (value: ShoppingSortKey) => {
+    setSort(value);
+    localStorage.setItem(SORT_STORAGE_KEY, value);
+  };
+
+  // linked_item_id → カテゴリを解決するためのマップを構築する
+  const itemCategoryIdMap = new Map(inventoryItems.map((i) => [i.id, i.category_id ?? null]));
+  const categoryMap = new Map(categories.map((c) => [c.id, c]));
+  const resolveCategory: CategoryResolver = (shoppingItem) => {
+    if (!shoppingItem.linked_item_id) return null;
+    const categoryId = itemCategoryIdMap.get(shoppingItem.linked_item_id);
+    if (!categoryId) return null;
+    const category = categoryMap.get(categoryId);
+    if (!category) return null;
+    return { id: category.id, name: category.name, color: category.color ?? null };
+  };
+
+  const sortedItems = sortShoppingItems(items, sort, resolveCategory);
+  const groups = sort === "category" ? groupShoppingItemsByCategory(items, resolveCategory) : null;
+
+  const renderRow = (item: ShoppingItem) => (
+    <ShoppingRow
+      key={item.id}
+      id={item.id}
+      name={item.name}
+      desiredUnits={item.desired_units}
+      note={item.note}
+      isPurchased={item.status === "purchased"}
+      isEditing={editId === item.id}
+      isSaving={savingId === item.id}
+      onPurchase={tab === "planned" ? (id) => setPendingPurchaseId(id) : undefined}
+      onDelete={(id) => setDeleteId(id)}
+      onEdit={tab === "planned" ? (id) => setEditId(id) : undefined}
+      onEditSave={(id, data) => {
+        void handleEdit(id, data);
+      }}
+      onEditCancel={() => setEditId(null)}
+    />
+  );
 
   return (
     <div className="space-y-4">
@@ -254,6 +322,29 @@ const ShoppingPage = () => {
         ))}
       </div>
 
+      {/* Sort / group control */}
+      {items.length > 0 && (
+        <div className="flex items-center justify-end gap-2">
+          <label htmlFor="shopping-sort" className="text-xs text-muted-foreground">
+            {t("sortLabel")}
+          </label>
+          <Select
+            id="shopping-sort"
+            className="h-8 w-auto"
+            value={sort}
+            onChange={(e) => {
+              if (isShoppingSortKey(e.target.value)) handleSortChange(e.target.value);
+            }}
+          >
+            {SHOPPING_SORT_KEYS.map((key) => (
+              <option key={key} value={key}>
+                {t(sortLabelKey[key])}
+              </option>
+            ))}
+          </Select>
+        </div>
+      )}
+
       {/* Clear purchased button */}
       {tab === "purchased" && items.length > 0 && (
         <div className="flex justify-end">
@@ -283,28 +374,22 @@ const ShoppingPage = () => {
         <p className="py-8 text-center text-muted-foreground">
           {tab === "planned" ? t("noItems") : t("noPurchased")}
         </p>
-      ) : (
-        <div className="space-y-2">
-          {items.map((item) => (
-            <ShoppingRow
-              key={item.id}
-              id={item.id}
-              name={item.name}
-              desiredUnits={item.desired_units}
-              note={item.note}
-              isPurchased={item.status === "purchased"}
-              isEditing={editId === item.id}
-              isSaving={savingId === item.id}
-              onPurchase={tab === "planned" ? (id) => setPendingPurchaseId(id) : undefined}
-              onDelete={(id) => setDeleteId(id)}
-              onEdit={tab === "planned" ? (id) => setEditId(id) : undefined}
-              onEditSave={(id, data) => {
-                void handleEdit(id, data);
-              }}
-              onEditCancel={() => setEditId(null)}
-            />
+      ) : groups ? (
+        <div className="space-y-3">
+          {groups.map((group) => (
+            <div key={group.categoryId ?? "__other__"} className="space-y-2">
+              <ShoppingGroupHeader
+                name={group.categoryName}
+                color={group.color}
+                count={group.items.length}
+                otherLabel={t("groupOther")}
+              />
+              {group.items.map(renderRow)}
+            </div>
           ))}
         </div>
+      ) : (
+        <div className="space-y-2">{sortedItems.map(renderRow)}</div>
       )}
     </div>
   );


### PR DESCRIPTION
## 概要

Closes #326

買い物リストに並び替え機能とカテゴリ別グループ表示を追加し、スーパーの売り場単位でまとめて買い物できるようにします。

## 変更内容

- `src/lib/shoppingView.ts` を追加
  - `ShoppingSortKey`（`added` / `category` / `name` / `priority`）と並び替え・グループ化の純粋関数
  - `sortShoppingItems`: 追加順（既定）/ カテゴリ順 / 名前順 / 数量が多い順（`desired_units`）
  - `groupShoppingItemsByCategory`: `linked_item_id` → 在庫アイテム → カテゴリを解決してグループ化。未分類は「その他」として末尾にまとめる
- `src/components/molecules/ShoppingGroupHeader.tsx`（+ Story）を追加：カラードット・カテゴリ名・件数バッジを表示するグループヘッダー
- `src/routes/_auth.shopping.tsx` に並び替えセレクタを追加
  - 選択値は `localStorage`（`shopping.sort`）に永続化
  - 「カテゴリ順」を選ぶと `ShoppingGroupHeader` 付きのグループ表示、それ以外はフラットなソート済みリスト
- i18n キー（ja / en）追加
- `src/lib/shoppingView.test.ts` で並び替え・グループ化ロジックを単体テスト

## 設計メモ

機能1（グループ表示）と機能2（並び替え）を 1 つの「並び替え」セレクタに統合しました。`category` を選んだときだけグループヘッダー付き表示になり、UI がシンプルになります。カテゴリ名の並びは `Intl.Collator("ja")`（ICU の日本語照合 = 読み順ベース）を使用します。

## テスト

- `bun test` 全 185 件パス / `bun run check` パス / `knip` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nf7CiR35AbxvXMcAS3D4ue

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nf7CiR35AbxvXMcAS3D4ue)_