### PR TITLE
feat: 買い物リストからバーコードスキャンで直接アイテム追加 (#344)

### DIFF
--- a/src/components/molecules/ScanToShoppingDialog.stories.tsx
+++ b/src/components/molecules/ScanToShoppingDialog.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ScanToShoppingDialog } from "./ScanToShoppingDialog";
+
+const meta = {
+  component: ScanToShoppingDialog,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof ScanToShoppingDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const LookingUp: Story = {
+  args: {
+    open: true,
+    isLooking: true,
+    defaultName: "",
+    matchedExisting: false,
+    onConfirm: () => {},
+    onClose: () => {},
+  },
+};
+
+export const MatchedExisting: Story = {
+  args: {
+    open: true,
+    isLooking: false,
+    defaultName: "牛乳",
+    matchedExisting: true,
+    onConfirm: () => {},
+    onClose: () => {},
+  },
+};
+
+export const NewProduct: Story = {
+  args: {
+    open: true,
+    isLooking: false,
+    defaultName: "オーガニックグリーンティー",
+    matchedExisting: false,
+    onConfirm: () => {},
+    onClose: () => {},
+  },
+};
+
+export const NotFound: Story = {
+  args: {
+    open: true,
+    isLooking: false,
+    defaultName: "",
+    matchedExisting: false,
+    onConfirm: () => {},
+    onClose: () => {},
+  },
+};

--- a/src/components/molecules/ScanToShoppingDialog.tsx
+++ b/src/components/molecules/ScanToShoppingDialog.tsx
@@ -1,0 +1,109 @@
+import { PackageCheck, PackageSearch, X } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { Spinner } from "@/components/atoms/Spinner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface ScanToShoppingDialogProps {
+  open: boolean;
+  /** バーコード照合中（在庫検索 / API 問い合わせ）かどうか */
+  isLooking: boolean;
+  /** 解決された商品名（在庫一致名 or API 取得名、未取得なら空文字） */
+  defaultName: string;
+  /** 既存の在庫アイテムに一致したか */
+  matchedExisting: boolean;
+  isSubmitting?: boolean;
+  onConfirm: (name: string) => void;
+  onClose: () => void;
+}
+
+export const ScanToShoppingDialog = ({
+  open,
+  isLooking,
+  defaultName,
+  matchedExisting,
+  isSubmitting,
+  onConfirm,
+  onClose,
+}: ScanToShoppingDialogProps) => {
+  const { t } = useTranslation("shopping");
+  const [name, setName] = useState(defaultName);
+  const [prevDefaultName, setPrevDefaultName] = useState(defaultName);
+
+  // 照合完了後に解決済みの商品名を入力欄へ反映する（prop 変化時の state 調整）
+  if (defaultName !== prevDefaultName) {
+    setPrevDefaultName(defaultName);
+    setName(defaultName);
+  }
+
+  if (!open) return null;
+
+  const handleConfirm = () => {
+    const trimmed = name.trim();
+    if (trimmed) onConfirm(trimmed);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end bg-black/50 sm:items-center sm:justify-center">
+      <div className="w-full rounded-t-2xl bg-background p-4 shadow-xl sm:max-w-md sm:rounded-2xl">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-bold">{t("scanDialogTitle")}</h2>
+          <Button variant="ghost" size="icon" onClick={onClose} disabled={isSubmitting}>
+            <X className="h-5 w-5" />
+          </Button>
+        </div>
+
+        {isLooking ? (
+          <div className="flex items-center justify-center gap-2 py-8 text-muted-foreground">
+            <Spinner />
+            <span className="text-sm">{t("scanLookingUp")}</span>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="flex items-center gap-2 rounded-md bg-muted/60 p-3 text-sm">
+              {matchedExisting ? (
+                <>
+                  <PackageCheck className="h-5 w-5 shrink-0 text-primary" />
+                  <span>{t("scanMatchedExisting")}</span>
+                </>
+              ) : (
+                <>
+                  <PackageSearch className="h-5 w-5 shrink-0 text-muted-foreground" />
+                  <span>{t("scanNewProduct")}</span>
+                </>
+              )}
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="scan-name">{t("itemName")}</Label>
+              <Input
+                id="scan-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder={t("itemNamePlaceholder")}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleConfirm();
+                }}
+                autoFocus
+              />
+            </div>
+            <div className="flex gap-2">
+              <Button
+                className="flex-1"
+                onClick={handleConfirm}
+                disabled={!name.trim() || isSubmitting}
+              >
+                {t("scanAddConfirm")}
+              </Button>
+              <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
+                {t("common:cancel")}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/locales/en/shopping.json
+++ b/src/locales/en/shopping.json
@@ -25,6 +25,12 @@
   "purchaseDialog": "Mark Purchased — Add to Inventory",
   "purchaseSuccess": "Added to inventory",
   "restock": "Restock",
+  "scanAdd": "Scan to add",
+  "scanAddConfirm": "Add to list",
+  "scanDialogTitle": "Scan to add to list",
+  "scanLookingUp": "Looking up product…",
+  "scanMatchedExisting": "Found a matching item in your inventory",
+  "scanNewProduct": "Not in your inventory. Check the name and add it",
   "share": "Share",
   "shareShoppingList": "Share Shopping List",
   "title": "Shopping List"

--- a/src/locales/ja/shopping.json
+++ b/src/locales/ja/shopping.json
@@ -25,6 +25,12 @@
   "purchaseDialog": "購入完了 — 在庫に追加",
   "purchaseSuccess": "在庫に追加しました",
   "restock": "再購入",
+  "scanAdd": "スキャン追加",
+  "scanAddConfirm": "リストに追加",
+  "scanDialogTitle": "スキャンしてリストに追加",
+  "scanLookingUp": "商品を照合中…",
+  "scanMatchedExisting": "在庫に一致する商品が見つかりました",
+  "scanNewProduct": "在庫にない商品です。名前を確認して追加できます",
   "share": "共有",
   "shareShoppingList": "買い物リストを共有",
   "title": "買い物リスト"

--- a/src/routes/_auth.shopping.tsx
+++ b/src/routes/_auth.shopping.tsx
@@ -1,15 +1,19 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { Plus, ShoppingCart } from "lucide-react";
+import { Plus, ScanLine, ShoppingCart } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { ShareButton } from "@/components/atoms/ShareButton";
 import { Skeleton } from "@/components/atoms/Skeleton";
 import { ConfirmDialog } from "@/components/molecules/ConfirmDialog";
+import { ScanToShoppingDialog } from "@/components/molecules/ScanToShoppingDialog";
 import { ShoppingRow } from "@/components/molecules/ShoppingRow";
+import { BarcodeScanner } from "@/components/organisms/BarcodeScanner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useBarcodeLookup } from "@/hooks/useBarcodeLookup";
+import { findActiveItemByBarcode } from "@/hooks/useItems";
 import {
   useDeleteAllPurchasedItems,
   useDeleteShoppingItem,
@@ -21,6 +25,13 @@ import { useToast } from "@/lib/toast-context";
 import type { ItemFormValues } from "@/types/item";
 
 import { PurchaseDialog } from "../components/molecules/PurchaseDialog";
+
+interface ScanDraft {
+  barcode: string;
+  defaultName: string;
+  matchedExisting: boolean;
+  linkedItemId: string | null;
+}
 
 type ShoppingTab = "planned" | "purchased";
 
@@ -41,6 +52,9 @@ const ShoppingPage = () => {
   const [savingId, setSavingId] = useState<string | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [showClearPurchased, setShowClearPurchased] = useState(false);
+  const [showScanner, setShowScanner] = useState(false);
+  const [scanDraft, setScanDraft] = useState<ScanDraft | null>(null);
+  const [isLooking, setIsLooking] = useState(false);
 
   const { data: items = [], isLoading } = useShoppingList(tab);
   const { data: plannedItems = [] } = useShoppingList("planned");
@@ -48,6 +62,7 @@ const ShoppingPage = () => {
   const deleteItem = useDeleteShoppingItem();
   const purchase = usePurchaseShoppingItem();
   const clearPurchased = useDeleteAllPurchasedItems();
+  const { lookup } = useBarcodeLookup();
 
   const handleAdd = async () => {
     if (!addName.trim()) return;
@@ -115,6 +130,47 @@ const ShoppingPage = () => {
     }
   };
 
+  // バーコードスキャン → 在庫一致 or バーコードAPIで商品名を解決し、確認ダイアログを開く
+  const handleScan = async (barcode: string) => {
+    setShowScanner(false);
+    setIsLooking(true);
+    setScanDraft({ barcode, defaultName: "", matchedExisting: false, linkedItemId: null });
+    try {
+      const existing = await findActiveItemByBarcode(barcode);
+      if (existing) {
+        setScanDraft({
+          barcode,
+          defaultName: existing.name,
+          matchedExisting: true,
+          linkedItemId: existing.id,
+        });
+        return;
+      }
+      const result = await lookup(barcode);
+      setScanDraft({
+        barcode,
+        defaultName: result.product?.name ?? "",
+        matchedExisting: false,
+        linkedItemId: null,
+      });
+    } catch {
+      setScanDraft({ barcode, defaultName: "", matchedExisting: false, linkedItemId: null });
+    } finally {
+      setIsLooking(false);
+    }
+  };
+
+  const handleScanConfirm = async (name: string) => {
+    if (!scanDraft) return;
+    try {
+      await upsert.mutateAsync({ name, linked_item_id: scanDraft.linkedItemId });
+      setScanDraft(null);
+      toast(t("addSuccess"), "success");
+    } catch {
+      // Error toast is handled by useUpsertShoppingItem.onError
+    }
+  };
+
   return (
     <div className="space-y-4">
       <ConfirmDialog
@@ -176,12 +232,42 @@ const ShoppingPage = () => {
               label={t("share")}
             />
           )}
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setShowScanner(true)}
+            aria-label={t("scanAdd")}
+          >
+            <ScanLine className="mr-1 h-4 w-4" />
+            {t("scanAdd")}
+          </Button>
           <Button size="sm" onClick={() => setShowAdd((v) => !v)}>
             <Plus className="mr-1 h-4 w-4" />
             {t("addItem")}
           </Button>
         </div>
       </div>
+
+      {showScanner && (
+        <BarcodeScanner
+          onScan={(barcode) => {
+            void handleScan(barcode);
+          }}
+          onClose={() => setShowScanner(false)}
+        />
+      )}
+
+      <ScanToShoppingDialog
+        open={scanDraft !== null}
+        isLooking={isLooking}
+        defaultName={scanDraft?.defaultName ?? ""}
+        matchedExisting={scanDraft?.matchedExisting ?? false}
+        isSubmitting={upsert.isPending}
+        onConfirm={(name) => {
+          void handleScanConfirm(name);
+        }}
+        onClose={() => setScanDraft(null)}
+      />
 
       {/* Add form */}
       {showAdd && (


### PR DESCRIPTION
## 概要

Closes #344

スーパーで「これを買おう」と思ったときに、その場でバーコードをスキャンして買い物リストへ即追加できるようにします。

## 変更内容

- `src/routes/_auth.shopping.tsx` に「スキャン追加」ボタンを追加
  - 既存の `BarcodeScanner` organism を再利用
  - スキャン後のフロー:
    1. `findActiveItemByBarcode` で在庫に一致するアクティブアイテムを検索 → 見つかれば商品名と `linked_item_id` をセット（カテゴリ別グループ表示や購入時の在庫連携にも繋がる）
    2. 見つからなければ既存の `useBarcodeLookup`（ローカルDB → バーコードAPI Edge Function）で商品名を取得
    3. 確認ダイアログで商品名（編集可）を確認して買い物リストへ追加（在庫アイテムとしては未登録のまま）
- `src/components/molecules/ScanToShoppingDialog.tsx`（+ Story）を追加
  - 照合中はスピナー、完了後は在庫一致/新規商品の別を示すバッジと商品名入力を表示
  - prop 変化時の state 調整パターンで解決済み商品名を入力欄へ反映
- i18n キー（ja / en）追加

## テスト

- `bun test` 全 179 件パス / `bun run check` パス / `knip` クリーン

## 関連

- #241 バーコードスキャン時の確認ダイアログ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nf7CiR35AbxvXMcAS3D4ue

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nf7CiR35AbxvXMcAS3D4ue)_