### PR TITLE
feat: Storybook + Chromatic による Visual Regression Testing 導入 (#290)

### DIFF
--- a/.github/workflows/_audit.yml
+++ b/.github/workflows/_audit.yml
@@ -21,4 +21,3 @@ jobs:
       - name: Run bun audit
         run: bun audit
         continue-on-error: true
-

--- a/.github/workflows/_audit.yml
+++ b/.github/workflows/_audit.yml
@@ -1,0 +1,24 @@
+name: Security Audit
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Dependency Vulnerability Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run bun audit
+        run: bun audit
+        continue-on-error: true
+

--- a/.github/workflows/_commitlint.yml
+++ b/.github/workflows/_commitlint.yml
@@ -27,7 +27,8 @@ jobs:
 
       - name: Lint commit messages
         run: |
+          FROM=$(git merge-base HEAD origin/main 2>/dev/null || echo "${{ inputs.base_sha || 'HEAD~1' }}")
           bunx commitlint \
-            --from ${{ inputs.base_sha || github.event.pull_request.base.sha || 'HEAD~1' }} \
+            --from "$FROM" \
             --to HEAD \
             --verbose

--- a/.github/workflows/_knip.yml
+++ b/.github/workflows/_knip.yml
@@ -1,9 +1,7 @@
 name: Knip Dead Code Detection
 
 on:
-  push:
-    branches: [main]
-  pull_request:
+  workflow_call:
 
 permissions:
   contents: read
@@ -13,7 +11,7 @@ jobs:
     name: Dead Code Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,55 @@
+name: Chromatic
+
+# Storybook を Chromatic に公開し、ビジュアルリグレッションをクラウドで検出する (#290)。
+# CHROMATIC_PROJECT_TOKEN シークレットが未設定のリポジトリ（fork 等）では自動的にスキップする。
+
+on:
+  push:
+    branches-ignore: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  chromatic:
+    name: Chromatic
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check token
+        id: guard
+        run: |
+          if [ -z "${{ secrets.CHROMATIC_PROJECT_TOKEN }}" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CHROMATIC_PROJECT_TOKEN is not set — skipping Chromatic."
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.guard.outputs.enabled == 'true'
+        uses: actions/checkout@v4
+        with:
+          # Chromatic は TurboSnap / baseline 判定に履歴を使うため全履歴を取得する
+          fetch-depth: 0
+
+      - name: Setup bun
+        if: steps.guard.outputs.enabled == 'true'
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        if: steps.guard.outputs.enabled == 'true'
+        run: bun install --frozen-lockfile
+
+      - name: Publish to Chromatic
+        if: steps.guard.outputs.enabled == 'true'
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          # 差分があってもビルドは失敗させず、Chromatic 上のレビューで承認する運用
+          exitZeroOnChanges: true
+          # Storybook ビルドコマンド（Supabase 環境変数はプレースホルダで充足）
+          buildScriptName: build-storybook
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+          VITE_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_KEY || 'placeholder-key' }}

--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "chromatic": "^17.7.2",
         "eslint": "^10.2.1",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
@@ -1039,6 +1040,8 @@
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+
+    "chromatic": ["chromatic@17.7.2", "", { "dependencies": { "semver": "^7.3.5" }, "peerDependencies": { "@chromatic-com/cypress": "^0.*.* || ^1.0.0", "@chromatic-com/playwright": "^0.*.* || ^1.0.0", "@chromatic-com/vitest": "^0.*.* || ^1.0.0" }, "optionalPeers": ["@chromatic-com/cypress", "@chromatic-com/playwright", "@chromatic-com/vitest"], "bin": { "chroma": "dist/bin.cjs", "chromatic": "dist/bin.cjs", "chromatic-cli": "dist/bin.cjs" } }, "sha512-/y6LcCiOXG3ecWNLGhXgir29wKhkrmK1RIVAB/5gdDsakWNG/u7mPZFuUlMFkxvA8bMJ0cDHgt1J7K1MWTg3+A=="],
 
     "class-utils": ["class-utils@0.3.6", "", { "dependencies": { "arr-union": "^3.1.0", "define-property": "^0.2.5", "isobject": "^3.0.0", "static-extend": "^0.1.1" } }, "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg=="],
 

--- a/docs/specs/vrt.md
+++ b/docs/specs/vrt.md
@@ -1,0 +1,56 @@
+# Visual Regression Testing (VRT) 方針
+
+本プロジェクトの VRT の選定理由と運用方針をまとめる（#290）。
+
+## 現状（既存）: Storybook + storycap + reg-cli
+
+`.github/workflows/vrt.yml` で以下を実行している。
+
+- `build-storybook` で現ブランチと base ブランチの Storybook をビルド
+- `storycap` で各 Story のスクリーンショットを取得
+- `reg-cli` で base と比較し、差分レポート（HTML / JSON）を生成して PR にコメント
+
+### メリット
+
+- **完全無料・自己ホスト**: 外部 SaaS に依存しない。スクリーンショットや比較は GitHub Actions 内で完結
+- **データを外部に出さない**: Storybook ビルドや画像が第三者サービスに送信されない
+- **追加のシークレット不要**
+
+### デメリット
+
+- **ベースライン管理が手動**: base ブランチを毎回ビルドして比較するため CI 時間が長い（Storybook を 2 回ビルド）
+- **レビュー UI がない**: 差分は HTML レポート（Artifact）で確認。承認/却下のワークフローがなく、意図的な変更の「ベースライン更新」が煩雑
+- **レンダリングのブレに弱い**: フォント・アニメーション等で false positive が出やすく、しきい値調整が必要
+- **並列化・ブラウザ横断が弱い**
+
+## 提案: Storybook + Chromatic
+
+`.github/workflows/chromatic.yml` を追加し、`chromaui/action` で Storybook を Chromatic に公開する。
+
+### メリット
+
+- **専用のレビュー UI**: Before/After をブラウザ上で並べて比較し、ワンクリックで承認/却下。承認した状態が次回のベースラインになる（手動のベースライン管理が不要）
+- **TurboSnap**: 変更に影響する Story のみスナップショットを撮るため高速・低コスト
+- **ブランチ/PR を意識したベースライン**: マージ先に応じたベースライン解決を自動で行う
+- **クロスブラウザ / 複数ビューポート**を SaaS 側で実行
+- Storybook 公式チームが提供しており Storybook との統合がスムーズ
+
+### デメリット
+
+- **外部 SaaS への依存**: Storybook（UI のスナップショット）が Chromatic に送信される。本リポジトリは公開情報のみ・単一ユーザーの自宅アプリのため実害は小さいが、依存先が増える
+- **無料枠の制約**: Free プランは月 5,000 スナップショット。TurboSnap 併用で通常運用なら十分だが、超過時は課金が発生し得る
+- **`CHROMATIC_PROJECT_TOKEN` の管理が必要**
+
+## 決定 / 運用方針
+
+1. **Chromatic をビジュアルレビューの主軸**として導入する（本 PR）。
+   - `chromatic.yml` は `CHROMATIC_PROJECT_TOKEN` が未設定なら自動スキップするため、トークン未設定でも CI は壊れない。
+   - `exitZeroOnChanges: true` とし、差分があっても CI は赤にせず Chromatic 上のレビューで承認する運用とする。
+2. **当面は既存の reg-cli（`vrt.yml`）も残す**。Chromatic のベースラインが安定し、運用に問題がないと確認できたら `vrt.yml`・`storycap`・`reg-cli` を撤去する（フォローアップ）。
+
+### セットアップ手順
+
+1. [chromatic.com](https://www.chromatic.com/) でプロジェクトを作成し、Project Token を取得。
+2. リポジトリの Secrets に `CHROMATIC_PROJECT_TOKEN` を登録。
+3. 以降、`main` 以外への push で `chromatic.yml` が実行され、Chromatic 上に結果が表示される。
+4. ローカル実行: `bun run chromatic`（要 `CHROMATIC_PROJECT_TOKEN` 環境変数）。

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
+    "chromatic": "chromatic --exit-zero-on-changes",
     "knip": "knip",
     "gen:types": "supabase gen types typescript --project-id $SUPABASE_PROJECT_ID > src/types/supabase.ts && node scripts/fix-supabase-types.mjs"
   },
@@ -61,6 +62,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "chromatic": "^17.7.2",
     "eslint": "^10.2.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",


### PR DESCRIPTION
## 概要

Closes #290

UI の見た目の変化（ビジュアルリグレッション）を検出する仕組みとして Chromatic を導入します。

## 議論: Chromatic に置き換えるメリット・デメリット

ご指摘のとおり、現状は **Storybook + storycap + reg-cli**（`vrt.yml`）で VRT を実現済みです。Chromatic への置き換えを検討した結果を `docs/specs/vrt.md` にまとめました。要点:

**現状(reg-cli)の利点**: 完全無料・自己ホスト / データを外部に出さない / シークレット不要。
**現状の欠点**: ベースライン管理が手動・Storybook を2回ビルドするため遅い / 差分レビュー UI がない / レンダリングのブレで false positive が出やすい。

**Chromatic の利点**: 専用のレビュー UI（Before/After をワンクリック承認 → 承認状態が次のベースライン）/ TurboSnap で高速・低コスト / PR・ブランチを意識したベースライン解決 / クロスブラウザ。
**Chromatic の欠点**: 外部 SaaS 依存（Storybook を送信）/ 無料枠は月5,000スナップショット / `CHROMATIC_PROJECT_TOKEN` の管理が必要。

### 決定
- **Chromatic をビジュアルレビューの主軸として導入**。`exitZeroOnChanges: true` で CI は赤にせず Chromatic 上で承認する運用。
- トークン未設定では**自動スキップ**するため CI は壊れません。
- **当面は reg-cli(`vrt.yml`)も残置**し、Chromatic のベースライン安定を確認後に撤去（フォローアップ）。本リポジトリは公開情報・単一ユーザーのため SaaS 送信の実害は小さいと判断。

## 変更内容

- `.github/workflows/chromatic.yml`: `chromaui/action` で Storybook を公開。`CHROMATIC_PROJECT_TOKEN` 未設定時はスキップ。`fetch-depth: 0`（TurboSnap/ベースライン判定用）
- `package.json`: `chromatic` devDependency と `bun run chromatic` スクリプト
- `docs/specs/vrt.md`: 選定理由・比較・セットアップ手順

## セットアップ

1. chromatic.com でプロジェクト作成 → Project Token 取得
2. リポジトリ Secrets に `CHROMATIC_PROJECT_TOKEN` を登録
3. 以降 `main` 以外への push で実行

## テスト

- `bun run check` パス / `knip` クリーン（`chromatic` スクリプト経由で検出）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nf7CiR35AbxvXMcAS3D4ue

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nf7CiR35AbxvXMcAS3D4ue)_