### PR TITLE
fix: ダッシュボード件数表示バグ・user_idフィルタ欠如・i18nバリデーション修正

### DIFF
--- a/src/hooks/useBarcodeLookup.ts
+++ b/src/hooks/useBarcodeLookup.ts
@@ -38,10 +38,14 @@ export const useBarcodeLookup = () => {
     setIsLoading(true);
     setError(null);
     try {
+      const { data: userData, error: userError } = await supabase.auth.getUser();
+      if (userError || !userData.user) throw new Error("Not authenticated");
+
       const { data: localData, error: localError } = await supabase
         .from("items")
         .select("name, image_path")
         .eq("barcode", barcode)
+        .eq("user_id", userData.user.id)
         .is("deleted_at", null)
         .order("updated_at", { ascending: false })
         .limit(1)

--- a/src/hooks/useNotificationPreferences.ts
+++ b/src/hooks/useNotificationPreferences.ts
@@ -9,7 +9,14 @@ import type { NotificationPreferences, UpdatePrefs } from "@/types/user";
 const PREFS_KEY = ["notification-preferences"] as const;
 
 const fetchPreferences = async (): Promise<NotificationPreferences | null> => {
-  const { data, error } = await supabase.from("notification_preferences").select("*").maybeSingle();
+  const { data: userData, error: userError } = await supabase.auth.getUser();
+  if (userError || !userData.user) throw new Error("Not authenticated");
+
+  const { data, error } = await supabase
+    .from("notification_preferences")
+    .select("*")
+    .eq("user_id", userData.user.id)
+    .maybeSingle();
   if (error) throw error;
   return data as NotificationPreferences | null;
 };

--- a/src/routes/_auth.index.tsx
+++ b/src/routes/_auth.index.tsx
@@ -182,9 +182,12 @@ const DashboardPage = () => {
         <div>
           <h1 className="text-2xl font-bold">{t("title")}</h1>
           <p className="text-sm text-muted-foreground">
-            {filtered.length === items.length
-              ? t("itemCountLabel", { count: items.length })
-              : t("itemCountLabelFiltered", { filtered: filtered.length, total: items.length })}
+            {filtered.length === baseFiltered.length
+              ? t("itemCountLabel", { count: baseFiltered.length })
+              : t("itemCountLabelFiltered", {
+                  filtered: filtered.length,
+                  total: baseFiltered.length,
+                })}
           </p>
         </div>
         <div className="flex items-center gap-2">

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -41,7 +41,7 @@ export interface Item {
 }
 
 export const itemFormSchema = z.object({
-  name: z.string().min(1, "名前は必須です"),
+  name: z.string().min(1),
   barcode: z.string().optional(),
   category_id: z.string().uuid().nullable().optional(),
   storage_location_id: z.string().uuid().nullable().optional(),


### PR DESCRIPTION
## 概要

コードレビューで発見された3件のバグを修正します。

Closes #414
Closes #415
Closes #416

## 修正内容

### #415: ダッシュボード件数表示の誤り

`hideEmpty=true` (空アイテムを非表示) の状態でフィルターを適用していない場合でも、件数が `X/Y 件` の「フィルタ中」表示になってしまうバグを修正。

**原因**: `filtered.length === items.length` の比較で `items` は `hideEmpty` を考慮していないため、hideEmpty で除外されたアイテムが存在すると常に filtered 表示になっていた。

**修正**: `items.length` を `baseFiltered.length`（hideEmpty 適用後）に変更。

```diff
- filtered.length === items.length
-   ? t("itemCountLabel", { count: items.length })
-   : t("itemCountLabelFiltered", { filtered: filtered.length, total: items.length })
+ filtered.length === baseFiltered.length
+   ? t("itemCountLabel", { count: baseFiltered.length })
+   : t("itemCountLabelFiltered", { filtered: filtered.length, total: baseFiltered.length })
```

### #416: user_id フィルタ欠如（セキュリティバグ）

2箇所で `user_id` によるフィルタが欠如していたため、他ユーザーのデータを誤って参照するリスクがあった。

- `useNotificationPreferences.ts`: `fetchPreferences()` で `notification_preferences` テーブルを取得する際に `user_id` フィルタなし
- `useBarcodeLookup.ts`: ローカル DB でバーコード検索する際に `user_id` フィルタなし

**修正**: 両箇所に `.eq("user_id", userData.user.id)` を追加。

### #414: itemFormSchema name バリデーションエラーが日本語ハードコード

```diff
- name: z.string().min(1, "名前は必須です"),
+ name: z.string().min(1),
```

i18next によるエラーメッセージ表示が前提のため、Zod スキーマ内の日本語ハードコードは不適切。Zod デフォルトメッセージに変更することで i18n 対応の余地を残す。

## テスト

- `bun run check` (oxlint + eslint + tsc) → エラーなし
- フォーマット (`npx oxfmt .`) → 差分なし