### PR TITLE
fix: デフォルト単位設定の反映と消費画面の浮動小数点誤差を修正 (#417 #339)

### DIFF
--- a/src/components/pages/NewItemPage.test.tsx
+++ b/src/components/pages/NewItemPage.test.tsx
@@ -86,4 +86,15 @@ describe("NewItemPage - default content unit", () => {
 
     expect(getByTestId("content-unit").textContent).toBe("");
   });
+
+  it("does not render the form until user settings finish loading, to avoid missing default_unit", () => {
+    settingsSpy = spyOn(useUserSettingsModule, "useUserSettings").mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as ReturnType<typeof useUserSettingsModule.useUserSettings>);
+
+    const { queryByTestId } = render(<NewItemPage />, { wrapper: Wrapper });
+
+    expect(queryByTestId("content-unit")).toBeNull();
+  });
 });

--- a/src/components/pages/NewItemPage.test.tsx
+++ b/src/components/pages/NewItemPage.test.tsx
@@ -1,0 +1,89 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import React from "react";
+
+import * as useItemsModule from "@/hooks/useItems";
+import * as useUserSettingsModule from "@/hooks/useUserSettings";
+import { ToastContext, type ToastContextValue } from "@/lib/toast-context";
+import type { Item } from "@/types/item";
+
+// ItemForm pulls in barcode scanning, image upload and master-data hooks that
+// are irrelevant to the default-unit wiring under test, so it is replaced with
+// a lightweight stub that surfaces the received `defaultValues.content_unit`.
+mock.module("@/components/organisms/ItemForm", () => ({
+  ItemForm: ({ defaultValues }: { defaultValues?: { content_unit?: string } }) => (
+    <div data-testid="content-unit">{defaultValues?.content_unit ?? ""}</div>
+  ),
+}));
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import { routerContext } from "../../../node_modules/@tanstack/react-router/dist/esm/routerContext.js";
+import { NewItemPage } from "./NewItemPage";
+
+const stubRouter = {
+  navigate: () => Promise.resolve(),
+  buildLocation: () => ({ href: "/" }),
+  isServer: false,
+  options: {},
+  state: { location: { href: "/", pathname: "/" }, matches: [], pendingMatches: [] },
+} as unknown as Parameters<typeof routerContext.Provider>[0]["value"];
+
+const stubToast: ToastContextValue = { toasts: [], toast: () => {}, dismiss: () => {} };
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => {
+  const [client] = React.useState(() => new QueryClient());
+  return (
+    <QueryClientProvider client={client}>
+      <routerContext.Provider value={stubRouter}>
+        <ToastContext.Provider value={stubToast}>{children}</ToastContext.Provider>
+      </routerContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+describe("NewItemPage - default content unit", () => {
+  let itemSpy: ReturnType<typeof spyOn>;
+  let settingsSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    itemSpy = spyOn(useItemsModule, "useItem").mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as ReturnType<typeof useItemsModule.useItem>);
+
+    spyOn(useItemsModule, "useCreateItem").mockReturnValue({
+      mutateAsync: async () => ({}) as Item,
+      isPending: false,
+    } as unknown as ReturnType<typeof useItemsModule.useCreateItem>);
+  });
+
+  afterEach(() => {
+    itemSpy.mockRestore();
+    settingsSpy.mockRestore();
+    cleanup();
+  });
+
+  it("passes the user's default_unit as the initial content unit", () => {
+    settingsSpy = spyOn(useUserSettingsModule, "useUserSettings").mockReturnValue({
+      data: { default_unit: "kg" },
+      isLoading: false,
+    } as ReturnType<typeof useUserSettingsModule.useUserSettings>);
+
+    const { getByTestId } = render(<NewItemPage />, { wrapper: Wrapper });
+
+    expect(getByTestId("content-unit").textContent).toBe("kg");
+  });
+
+  it("leaves content unit unset when the user has no default_unit configured", () => {
+    settingsSpy = spyOn(useUserSettingsModule, "useUserSettings").mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    } as ReturnType<typeof useUserSettingsModule.useUserSettings>);
+
+    const { getByTestId } = render(<NewItemPage />, { wrapper: Wrapper });
+
+    expect(getByTestId("content-unit").textContent).toBe("");
+  });
+});

--- a/src/components/pages/NewItemPage.tsx
+++ b/src/components/pages/NewItemPage.tsx
@@ -32,7 +32,7 @@ export const NewItemPage = ({ cloneFrom }: NewItemPageProps) => {
   const [showStackDialog, setShowStackDialog] = useState(false);
 
   const { data: cloneSource, isLoading: isCloneLoading } = useItem(cloneFrom ?? "");
-  const { data: userSettings } = useUserSettings();
+  const { data: userSettings, isLoading: isSettingsLoading } = useUserSettings();
 
   const handleBarcodeScanned = async (barcode: string, source: "db" | "api" | null) => {
     if (source !== "db") {
@@ -121,7 +121,7 @@ export const NewItemPage = ({ cloneFrom }: NewItemPageProps) => {
       ? { content_unit: userSettings.default_unit }
       : undefined;
 
-  if (cloneFrom && isCloneLoading) {
+  if ((cloneFrom && isCloneLoading) || (!cloneFrom && isSettingsLoading)) {
     return (
       <div className="space-y-4">
         <Skeleton className="h-7 w-32" />

--- a/src/components/pages/NewItemPage.tsx
+++ b/src/components/pages/NewItemPage.tsx
@@ -9,6 +9,7 @@ import { ItemForm } from "@/components/organisms/ItemForm";
 import { Button } from "@/components/ui/button";
 import { downloadExternalImageAsFile, uploadItemImage } from "@/hooks/useItemImage";
 import { findActiveItemByBarcode, useCreateItem, useItem } from "@/hooks/useItems";
+import { useUserSettings } from "@/hooks/useUserSettings";
 import { OfflineError } from "@/lib/requireOnline";
 import { useToast } from "@/lib/toast-context";
 import type { Item, ItemFormValues } from "@/types/item";
@@ -31,6 +32,7 @@ export const NewItemPage = ({ cloneFrom }: NewItemPageProps) => {
   const [showStackDialog, setShowStackDialog] = useState(false);
 
   const { data: cloneSource, isLoading: isCloneLoading } = useItem(cloneFrom ?? "");
+  const { data: userSettings } = useUserSettings();
 
   const handleBarcodeScanned = async (barcode: string, source: "db" | "api" | null) => {
     if (source !== "db") {
@@ -115,7 +117,9 @@ export const NewItemPage = ({ cloneFrom }: NewItemPageProps) => {
         expiry_date: "",
         notes: "",
       }
-    : undefined;
+    : userSettings?.default_unit
+      ? { content_unit: userSettings.default_unit }
+      : undefined;
 
   if (cloneFrom && isCloneLoading) {
     return (

--- a/src/routes/-_auth.settings.test.tsx
+++ b/src/routes/-_auth.settings.test.tsx
@@ -178,3 +178,74 @@ describe("SettingsPage - expiryWarningDays validation", () => {
     expect(toastFn).toHaveBeenCalledWith("設定を保存しました", "success");
   });
 });
+
+describe("SettingsPage - default unit", () => {
+  let settingsSpy: ReturnType<typeof spyOn>;
+  let updateSpy: ReturnType<typeof spyOn>;
+  let notifSpy: ReturnType<typeof spyOn>;
+  let updateNotifSpy: ReturnType<typeof spyOn>;
+
+  beforeAll(async () => {
+    await i18n.changeLanguage("ja");
+  });
+
+  beforeEach(() => {
+    settingsSpy = spyOn(useUserSettingsModule, "useUserSettings").mockReturnValue({
+      data: { expiry_warning_days: 3, language: "ja", default_unit: "本" },
+      isLoading: false,
+    } as ReturnType<typeof useUserSettingsModule.useUserSettings>);
+
+    updateSpy = spyOn(useUserSettingsModule, "useUpdateUserSettings").mockReturnValue({
+      mutateAsync: mock(async () => {}),
+      isPending: false,
+    } as unknown as ReturnType<typeof useUserSettingsModule.useUpdateUserSettings>);
+
+    notifSpy = spyOn(useNotifModule, "useNotificationPreferences").mockReturnValue({
+      data: null,
+      isLoading: false,
+    } as ReturnType<typeof useNotifModule.useNotificationPreferences>);
+
+    updateNotifSpy = spyOn(useNotifModule, "useUpdateNotificationPreferences").mockReturnValue({
+      mutateAsync: mock(async () => {}),
+      isPending: false,
+    } as unknown as ReturnType<typeof useNotifModule.useUpdateNotificationPreferences>);
+  });
+
+  afterEach(() => {
+    settingsSpy.mockRestore();
+    updateSpy.mockRestore();
+    notifSpy.mockRestore();
+    updateNotifSpy.mockRestore();
+    cleanup();
+  });
+
+  const findDefaultUnitSelect = (comboboxes: HTMLElement[]) =>
+    comboboxes.find((el) =>
+      Array.from((el as HTMLSelectElement).options).some((o) => o.value === "kg"),
+    ) as HTMLSelectElement;
+
+  it("shows the current default unit as selected", () => {
+    const { stub } = makeToastStub();
+    const { getAllByRole } = render(<SettingsPage />, { wrapper: Wrapper(stub) });
+
+    const select = findDefaultUnitSelect(getAllByRole("combobox"));
+    expect(select.value).toBe("本");
+  });
+
+  it("saves the newly selected default unit", async () => {
+    const mutateAsync = mock(async () => {});
+    updateSpy.mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useUserSettingsModule.useUpdateUserSettings>);
+    const { stub, toastFn } = makeToastStub();
+    const { getAllByRole } = render(<SettingsPage />, { wrapper: Wrapper(stub) });
+
+    const select = findDefaultUnitSelect(getAllByRole("combobox"));
+    fireEvent.change(select, { target: { value: "kg" } });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mutateAsync).toHaveBeenCalledWith({ default_unit: "kg" });
+    expect(toastFn).toHaveBeenCalledWith("設定を保存しました", "success");
+  });
+});

--- a/src/routes/_auth.items.$itemId.consume.tsx
+++ b/src/routes/_auth.items.$itemId.consume.tsx
@@ -12,7 +12,7 @@ import { useConsumeLot, useItemLots } from "@/hooks/useItemLots";
 import { useItem } from "@/hooks/useItems";
 import { parseLocalDate } from "@/lib/dateUtils";
 import { useToast } from "@/lib/toast-context";
-import { computeConsumption, type ConsumptionError, type ItemLot } from "@/types/item";
+import { computeConsumption, type ConsumptionError, type ItemLot, roundFloat } from "@/types/item";
 
 const consumptionErrorKey = {
   insufficientStock: "insufficientStock",
@@ -157,8 +157,10 @@ export const ItemConsumePage = () => {
 
   const totalLotAmount = selectedLot
     ? selectedLot.opened_remaining !== null && selectedLot.opened_remaining !== undefined
-      ? selectedLot.opened_remaining + Math.max(0, selectedLot.units - 1) * item.content_amount
-      : selectedLot.units * item.content_amount
+      ? roundFloat(
+          selectedLot.opened_remaining + Math.max(0, selectedLot.units - 1) * item.content_amount,
+        )
+      : roundFloat(selectedLot.units * item.content_amount)
     : 0;
 
   return (

--- a/src/routes/_auth.settings.tsx
+++ b/src/routes/_auth.settings.tsx
@@ -151,7 +151,7 @@ export const SettingsPage = () => {
             </h2>
             <Select
               className="w-32"
-              value={settings?.default_unit ?? CONTENT_UNITS[0]}
+              value={settings?.default_unit ?? "mL"}
               onChange={(e) => {
                 void handleDefaultUnitChange(e.target.value);
               }}

--- a/src/routes/_auth.settings.tsx
+++ b/src/routes/_auth.settings.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
-import { ArrowLeft, Bell, ChevronRight, Globe, MapPin, Moon, Tag } from "lucide-react";
+import { ArrowLeft, Bell, ChevronRight, Globe, MapPin, Moon, Ruler, Tag } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -10,9 +10,11 @@ import { NotificationSettings } from "@/components/organisms/NotificationSetting
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
 import { useUpdateUserSettings, useUserSettings } from "@/hooks/useUserSettings";
 import { OfflineError } from "@/lib/requireOnline";
 import { useToast } from "@/lib/toast-context";
+import { CONTENT_UNITS } from "@/types/item";
 
 export const SettingsPage = () => {
   const { t } = useTranslation("settings");
@@ -32,6 +34,17 @@ export const SettingsPage = () => {
   const handleLanguageChange = async (lang: "ja" | "en") => {
     try {
       await updateSettings.mutateAsync({ language: lang });
+      toast(t("saveSuccess"), "success");
+    } catch (error) {
+      if (!(error instanceof OfflineError)) {
+        toast(t("common:unknownError"), "error");
+      }
+    }
+  };
+
+  const handleDefaultUnitChange = async (unit: string) => {
+    try {
+      await updateSettings.mutateAsync({ default_unit: unit });
       toast(t("saveSuccess"), "success");
     } catch (error) {
       if (!(error instanceof OfflineError)) {
@@ -128,6 +141,27 @@ export const SettingsPage = () => {
               />
               <Label>{t("daysBefore")}</Label>
             </div>
+          </section>
+
+          {/* Default unit */}
+          <section>
+            <h2 className="mb-1 flex items-center gap-2 text-sm font-semibold text-muted-foreground">
+              <Ruler className="h-4 w-4" />
+              {t("defaultUnit")}
+            </h2>
+            <Select
+              className="w-32"
+              value={settings?.default_unit ?? CONTENT_UNITS[0]}
+              onChange={(e) => {
+                void handleDefaultUnitChange(e.target.value);
+              }}
+            >
+              {CONTENT_UNITS.map((unit) => (
+                <option key={unit} value={unit}>
+                  {unit}
+                </option>
+              ))}
+            </Select>
           </section>
 
           {/* Notification Settings */}

--- a/src/types/item.test.ts
+++ b/src/types/item.test.ts
@@ -7,6 +7,7 @@ import {
   getExpiryStatus,
   itemFormSchema,
   itemLotSchema,
+  roundFloat,
 } from "./item";
 
 // --- itemFormSchema ---
@@ -177,6 +178,20 @@ describe("getExpiryStatus", () => {
   test("custom warningDays", () => {
     expect(getExpiryStatus(fmt(addDays(5)), 7)).toBe("expiring-soon");
     expect(getExpiryStatus(fmt(addDays(8)), 7)).toBe("ok");
+  });
+});
+
+// --- roundFloat ---
+
+describe("roundFloat", () => {
+  test("removes native floating-point noise", () => {
+    expect(0.1 * 3).not.toBe(0.3);
+    expect(roundFloat(0.1 * 3)).toBe(0.3);
+  });
+
+  test("leaves already-precise values unchanged", () => {
+    expect(roundFloat(1.5)).toBe(1.5);
+    expect(roundFloat(0)).toBe(0);
   });
 });
 

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -141,6 +141,9 @@ export const formatRemaining = (
   return total % 1 === 0 ? String(total) : total.toFixed(2).replace(/\.?0+$/, "");
 };
 
+// Round to avoid floating-point noise (DB stores numeric(12,2))
+export const roundFloat = (n: number) => Math.round(n * 1e10) / 1e10;
+
 export const computeConsumption = (
   item: Pick<Item, "units" | "content_amount" | "content_unit" | "opened_remaining">,
   delta: number,
@@ -166,16 +169,14 @@ export const computeConsumption = (
     return { units_after: 0, opened_remaining_after: null, error: "insufficientStock" };
   }
 
-  // Round to avoid floating-point noise (DB stores numeric(12,2))
-  const round = (n: number) => Math.round(n * 1e10) / 1e10;
-  const totalAfter = round(totalBefore - delta);
+  const totalAfter = roundFloat(totalBefore - delta);
 
   if (totalAfter === 0) {
     return { units_after: 0, opened_remaining_after: null };
   }
 
-  const sealedUnits = Math.floor(round(totalAfter / contentAmount));
-  const openedAfter = round(totalAfter - sealedUnits * contentAmount);
+  const sealedUnits = Math.floor(roundFloat(totalAfter / contentAmount));
+  const openedAfter = roundFloat(totalAfter - sealedUnits * contentAmount);
 
   if (openedAfter === 0) {
     return { units_after: sealedUnits, opened_remaining_after: null };


### PR DESCRIPTION
## 概要

コードレビューで発見された、まだ現行 main に残っていた2件のバグを修正します。

Closes #417
Closes #339

### #417: ユーザー設定の `default_unit` が設定 UI・アイテム登録フォームのいずれにも反映されていない

- `src/routes/_auth.settings.tsx`: 「デフォルト単位」セレクト（`CONTENT_UNITS` を使用）を追加し、`useUpdateUserSettings` で保存
- `src/components/pages/NewItemPage.tsx`: アイテム複製時以外は、ユーザーの `default_unit` を新規アイテムの `content_unit` 初期値として使用

### #339: 消費量表示の浮動小数点精度が `computeConsumption` の正規化処理と不一致

- `src/types/item.ts` の `computeConsumption` 内にあった `round` ヘルパーを `roundFloat` として export
- `src/routes/_auth.items.$itemId.consume.tsx` の `totalLotAmount` 計算にも同じ正規化を適用し、`content_amount` が小数の場合の表示崩れ（例: `0.1 * 3 = 0.30000000000000004`）を防止

## 調査メモ（今回のバグ洗い出しで判明したこと）

Issue 一覧を確認した際、以下の Open な Bug Issue は **既に main 上で修正済み（ステイル）** だったため、それぞれ確認コメントを添えてクローズしました。実装は不要です。

- #370, #371, #372, #373, #347, #338, #324, #336

また #337（購入エラー後に `pendingPurchaseId` がクリアされない）は、実装すると **既に修正済みの別バグ（#196 / #201: 購入エラー時にダイアログが即座に閉じてリトライ不可になる）を再度作り込んでしまう**ため、"invalid" としてクローズしました（現状の「エラー時もダイアログを開いたままにする」実装が正）。

## テスト

- `bun run format:check` / `bun run check`（oxlint + eslint + stylelint + tsc）/ `bun test`（190件パス）/ `bun run build` / `bun run knip` すべてグリーン
- `npx i18next-parser` 差分なし（`shopping.json` はキーソート正規化のみで本 PR 範囲外のため revert 済み）
- 新規/追加テスト:
  - `src/types/item.test.ts`: `roundFloat` の単体テスト
  - `src/routes/-_auth.settings.test.tsx`: デフォルト単位セレクトの表示・保存
  - `src/components/pages/NewItemPage.test.tsx`: `default_unit` が新規アイテムフォームの初期値に反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rb8WLUJDXpzcuieryQNF1G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rb8WLUJDXpzcuieryQNF1G)_