### PR TITLE
fix: send-expiry-notifications に呼び出し元認証を追加 (#444)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,4 @@ VITE_VAPID_PUBLIC_KEY=your-vapid-public-key
 # VAPID_SUBJECT=mailto:you@example.com
 # RESEND_API_KEY=re_xxxxxxxxxxxx
 # RESEND_FROM_ADDRESS=housekeeper <noreply@example.com>
+# CRON_SECRET=xxxxxxxxxxxx  # shared secret required in the X-Cron-Secret header by send-expiry-notifications

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -36,4 +36,5 @@ jobs:
           deno test --no-check \
             supabase/functions/alexa-skill/response.test.ts \
             supabase/functions/alexa-skill/inventory-formatters.test.ts \
-            supabase/functions/alexa-skill/signature-verifier.test.ts
+            supabase/functions/alexa-skill/signature-verifier.test.ts \
+            supabase/functions/send-expiry-notifications/auth.test.ts

--- a/docs/specs/features/notifications.md
+++ b/docs/specs/features/notifications.md
@@ -38,8 +38,13 @@
 - `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` / `VAPID_SUBJECT`
 - `RESEND_API_KEY`（Email プロバイダ）
 - `RESEND_FROM_ADDRESS`
+- `CRON_SECRET`（`send-expiry-notifications` の呼び出し元認証用の共有シークレット）
 
 クライアント側には `VITE_VAPID_PUBLIC_KEY` を埋め込み、購読作成時に使用。
+
+### `send-expiry-notifications` の認証
+
+この Function は `pg_cron` からのみ呼ばれることを想定した非対話的エンドポイントであり、エンドユーザーの JWT を持たない。そのため呼び出し元は `X-Cron-Secret` ヘッダーに Edge Function 側の環境変数 `CRON_SECRET` と同じ値を含める必要があり、一致しない場合は 401 を返す。`pg_cron` からのスケジュール発火は `net.http_post` の `headers` 引数で `X-Cron-Secret` を付与する。
 
 ## 配信ロジック
 

--- a/supabase/functions/send-expiry-notifications/auth.test.ts
+++ b/supabase/functions/send-expiry-notifications/auth.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { isAuthorizedCronRequest } from "./auth.ts";
+
+const makeRequest = (headers: Record<string, string> = {}) =>
+  new Request("https://example.com/send-expiry-notifications", { headers });
+
+Deno.test("isAuthorizedCronRequest - matching secret is authorized", () => {
+  const req = makeRequest({ "X-Cron-Secret": "s3cr3t" });
+  assert.strictEqual(isAuthorizedCronRequest(req, "s3cr3t"), true);
+});
+
+Deno.test("isAuthorizedCronRequest - mismatched secret is rejected", () => {
+  const req = makeRequest({ "X-Cron-Secret": "wrong" });
+  assert.strictEqual(isAuthorizedCronRequest(req, "s3cr3t"), false);
+});
+
+Deno.test("isAuthorizedCronRequest - missing header is rejected", () => {
+  const req = makeRequest();
+  assert.strictEqual(isAuthorizedCronRequest(req, "s3cr3t"), false);
+});
+
+Deno.test("isAuthorizedCronRequest - unconfigured secret always rejects", () => {
+  const req = makeRequest({ "X-Cron-Secret": "anything" });
+  assert.strictEqual(isAuthorizedCronRequest(req, undefined), false);
+});
+
+Deno.test("isAuthorizedCronRequest - empty secret env does not authorize empty header", () => {
+  const req = makeRequest({ "X-Cron-Secret": "" });
+  assert.strictEqual(isAuthorizedCronRequest(req, ""), false);
+});

--- a/supabase/functions/send-expiry-notifications/auth.ts
+++ b/supabase/functions/send-expiry-notifications/auth.ts
@@ -1,0 +1,8 @@
+export const isAuthorizedCronRequest = (
+  req: Request,
+  expectedSecret: string | undefined,
+): boolean => {
+  if (!expectedSecret) return false;
+  const provided = req.headers.get("X-Cron-Secret");
+  return provided === expectedSecret;
+};

--- a/supabase/functions/send-expiry-notifications/index.ts
+++ b/supabase/functions/send-expiry-notifications/index.ts
@@ -1,9 +1,11 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import webpush from "npm:web-push@3";
+import { isAuthorizedCronRequest } from "./auth.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-cron-secret",
 };
 
 interface NotificationPreference {
@@ -29,6 +31,13 @@ interface ExpiringItem {
 Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
+  }
+
+  if (!isAuthorizedCronRequest(req, Deno.env.get("CRON_SECRET"))) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
   }
 
   const supabaseUrl = Deno.env.get("SUPABASE_URL")!;


### PR DESCRIPTION
## 概要

`send-expiry-notifications` Edge Function は `pg_cron` からのみ呼ばれることを想定した非対話的エンドポイントだが、呼び出し元の認証チェックが一切なく、`anon key` を知っている第三者が任意のタイミングで繰り返し呼び出せてしまっていた（Supabase Edge Functions のデフォルト JWT 検証は「有効な署名付きJWTか」しか見ないため、公開されている anon key でも通過する）。

全ユーザーの `notification_preferences` / `push_subscriptions` / `items` を横断的に読み出し、Push/Email 通知を一斉送信する処理が無認証で誰でも起動可能な状態だった（Resend のメール送信クォータ消費・Web Push のスパム・ユーザー体験毀損のリスク）。

Closes #444

## 修正内容

- `supabase/functions/send-expiry-notifications/auth.ts` に `isAuthorizedCronRequest()` を追加し、`X-Cron-Secret` ヘッダーと環境変数 `CRON_SECRET`を照合する認証チェックを実装
- `index.ts` の `Deno.serve` ハンドラの先頭（OPTIONS判定の直後）で認証チェックを行い、不一致・未設定の場合は 401 を返す
- `CORS` の `Access-Control-Allow-Headers` に `x-cron-secret` を追加
- `.env.example` に `CRON_SECRET` の説明を追記
- `docs/specs/features/notifications.md` に認証要件（`pg_cron` は `net.http_post` の `headers` で `X-Cron-Secret` を付与する）を追記
- `.github/workflows/_test.yml` の `deno-test` ジョブに新規テストを登録

## テスト

- `supabase/functions/send-expiry-notifications/auth.test.ts` を新規追加（5件、`isAuthorizedCronRequest` の純粋関数テスト: 一致/不一致/ヘッダー欠如/シークレット未設定/空文字シークレット）
- `bun run format:check` — OK
- `bun run check`（lint + typecheck）— OK
- `bun test` — 184 pass / 0 fail（既存テストへの回帰なし）
- `bun run build` — OK

## 影響範囲・互換性

- `CRON_SECRET` が未設定の環境では本 Function は常に 401 を返すようになる。本番運用では `supabase secrets set CRON_SECRET <値>` の設定と、`pg_cron` トリガー側（別途 #354 で導入予定）で同じ値を `X-Cron-Secret` ヘッダーに付与する設定が必要。

---
🤖 Claude Routines（バグ洗い出し・新機能提案）による自動実装


---
_Generated by [Claude Code](https://claude.ai/code/session_0173XFexaeV4VzDLKyudH2Ea)_