### PR TITLE
在庫ゼロのアイテム・ロットを消費入力/期限カレンダーの表示から除外

### DIFF
--- a/src/hooks/useItemLots.ts
+++ b/src/hooks/useItemLots.ts
@@ -4,7 +4,12 @@ import { useTranslation } from "react-i18next";
 import { OfflineError, requireOnline } from "@/lib/requireOnline";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/lib/toast-context";
-import { computeConsumption, type ConsumeLotParams, type ItemLot } from "@/types/item";
+import {
+  computeConsumption,
+  type ConsumeLotParams,
+  getLotRemainingAmount,
+  type ItemLot,
+} from "@/types/item";
 
 export const LOTS_KEY = ["item-lots"] as const;
 
@@ -72,23 +77,39 @@ const updateLot = async (
 
 /** Recompute and update the item aggregate (units, expiry_date, opened_remaining) from its lots. */
 export const syncItemAggregate = async (itemId: string): Promise<void> => {
-  const { data: lots, error: lotsError } = await supabase
-    .from("item_lots")
-    .select("units, expiry_date, opened_remaining")
-    .eq("item_id", itemId);
+  const [{ data: lots, error: lotsError }, { data: itemRow, error: itemError }] = await Promise.all(
+    [
+      supabase
+        .from("item_lots")
+        .select("units, expiry_date, opened_remaining")
+        .eq("item_id", itemId),
+      supabase.from("items").select("content_amount").eq("id", itemId).single(),
+    ],
+  );
   if (lotsError) throw lotsError;
+  if (itemError) throw itemError;
 
   const rows = lots ?? [];
   const totalUnits = rows.reduce((sum, l) => sum + (l.units as number), 0);
 
-  const expiryDates = rows
+  // Only lots with actual remaining stock should count toward the item's
+  // aggregate expiry_date / opened_remaining, otherwise a depleted lot's
+  // leftover expiry_date keeps the item showing up in the expiry calendar.
+  const contentAmount = itemRow.content_amount as number;
+  const activeRows = rows.filter(
+    (l) =>
+      getLotRemainingAmount(l.units as number, contentAmount, l.opened_remaining as number | null) >
+      0,
+  );
+
+  const expiryDates = activeRows
     .map((l) => l.expiry_date as string | null)
     .filter((d): d is string => d !== null);
   const earliestExpiry = expiryDates.length > 0 ? expiryDates.sort()[0] : null;
 
   // Keep opened_remaining on items only when exactly one lot is open,
   // so the card can display an accurate total remaining amount.
-  const openLots = rows.filter((l) => l.opened_remaining !== null);
+  const openLots = activeRows.filter((l) => l.opened_remaining !== null);
   const aggregateOpenedRemaining = openLots.length === 1 ? openLots[0]!.opened_remaining : null;
 
   const { error: updateError } = await supabase

--- a/src/routes/-_auth.items.$itemId.consume.test.tsx
+++ b/src/routes/-_auth.items.$itemId.consume.test.tsx
@@ -161,6 +161,17 @@ describe("ItemConsumePage", () => {
     expect(queryByRole("spinbutton")).toBeNull();
   });
 
+  it("shows no stock message when the only lot has opened_remaining of exactly 0", () => {
+    lotsspy.mockReturnValue({
+      data: [{ ...baseLot, units: 1, opened_remaining: 0 }],
+      isLoading: false,
+      isError: false,
+    } as ReturnType<typeof useItemLotsModule.useItemLots>);
+    const { getByText, queryByRole } = renderPage();
+    expect(getByText(/noStockToConsume|No stock available|在庫がありません/)).toBeDefined();
+    expect(queryByRole("spinbutton")).toBeNull();
+  });
+
   it("shows numeric input when there is one active lot", () => {
     const { getByRole } = renderPage();
     expect(getByRole("spinbutton")).toBeDefined();

--- a/src/routes/_auth.items.$itemId.consume.tsx
+++ b/src/routes/_auth.items.$itemId.consume.tsx
@@ -12,7 +12,12 @@ import { useConsumeLot, useItemLots } from "@/hooks/useItemLots";
 import { useItem } from "@/hooks/useItems";
 import { parseLocalDate } from "@/lib/dateUtils";
 import { useToast } from "@/lib/toast-context";
-import { computeConsumption, type ConsumptionError, type ItemLot } from "@/types/item";
+import {
+  computeConsumption,
+  type ConsumptionError,
+  getLotRemainingAmount,
+  type ItemLot,
+} from "@/types/item";
 
 const consumptionErrorKey = {
   insufficientStock: "insufficientStock",
@@ -36,9 +41,7 @@ export const ItemConsumePage = () => {
 
   const contentAmount = item?.content_amount ?? 0;
   const getLotTotal = (l: ItemLot): number =>
-    l.opened_remaining !== null && l.opened_remaining !== undefined
-      ? l.opened_remaining + Math.max(0, l.units - 1) * contentAmount
-      : l.units * contentAmount;
+    getLotRemainingAmount(l.units, contentAmount, l.opened_remaining ?? null);
   const activeLots = lots.filter((l) => getLotTotal(l) > 0);
   const hasMultipleLots = activeLots.length > 1;
 

--- a/src/routes/_auth.items.$itemId.consume.tsx
+++ b/src/routes/_auth.items.$itemId.consume.tsx
@@ -34,7 +34,12 @@ export const ItemConsumePage = () => {
 
   const isLoading = itemLoading || lotsLoading;
 
-  const activeLots = lots.filter((l) => l.units > 0 || l.opened_remaining !== null);
+  const contentAmount = item?.content_amount ?? 0;
+  const getLotTotal = (l: ItemLot): number =>
+    l.opened_remaining !== null && l.opened_remaining !== undefined
+      ? l.opened_remaining + Math.max(0, l.units - 1) * contentAmount
+      : l.units * contentAmount;
+  const activeLots = lots.filter((l) => getLotTotal(l) > 0);
   const hasMultipleLots = activeLots.length > 1;
 
   const selectedLot: ItemLot | null =
@@ -155,11 +160,7 @@ export const ItemConsumePage = () => {
         })
     : null;
 
-  const totalLotAmount = selectedLot
-    ? selectedLot.opened_remaining !== null && selectedLot.opened_remaining !== undefined
-      ? selectedLot.opened_remaining + Math.max(0, selectedLot.units - 1) * item.content_amount
-      : selectedLot.units * item.content_amount
-    : 0;
+  const totalLotAmount = selectedLot ? getLotTotal(selectedLot) : 0;
 
   return (
     <div className="mx-auto max-w-2xl space-y-6">

--- a/src/types/item.test.ts
+++ b/src/types/item.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_EXPIRY_WARNING_DAYS,
   formatRemaining,
   getExpiryStatus,
+  getLotRemainingAmount,
   itemFormSchema,
   itemLotSchema,
 } from "./item";
@@ -135,6 +136,30 @@ describe("formatRemaining", () => {
   test("decimal result keeps significant digits", () => {
     // 1 × 1.5 opened=0.75 → (0 × 1.5) + 0.75 = 0.75
     expect(formatRemaining(1, 1.5, 0.75)).toBe("0.75");
+  });
+});
+
+// --- getLotRemainingAmount ---
+
+describe("getLotRemainingAmount", () => {
+  test("all sealed: units × content_amount", () => {
+    expect(getLotRemainingAmount(3, 1000, null)).toBe(3000);
+  });
+
+  test("one opened unit: (units-1) × amount + opened_remaining", () => {
+    expect(getLotRemainingAmount(3, 1000, 350)).toBe(2350);
+  });
+
+  test("units=0 and opened_remaining=null => 0 (fully depleted)", () => {
+    expect(getLotRemainingAmount(0, 500, null)).toBe(0);
+  });
+
+  test("units=1 and opened_remaining=0 => 0 (opened package used up)", () => {
+    expect(getLotRemainingAmount(1, 500, 0)).toBe(0);
+  });
+
+  test("units=2 and opened_remaining=0 => remaining sealed unit still counts", () => {
+    expect(getLotRemainingAmount(2, 500, 0)).toBe(500);
   });
 });
 

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -128,16 +128,24 @@ export const getExpiryStatus = (
   return "ok";
 };
 
+/** ロット（またはアイテム）1件の実残量を計算する。opened_remaining がある場合は
+ *  開封中の1個を除いた残りの未開封数量にopened_remainingを加算する。 */
+export const getLotRemainingAmount = (
+  units: number,
+  contentAmount: number,
+  openedRemaining: number | null,
+): number =>
+  openedRemaining !== null
+    ? Math.max(0, units - 1) * contentAmount + openedRemaining
+    : units * contentAmount;
+
 /** カードや一覧で使う「残量」の合計値を文字列として返す。 */
 export const formatRemaining = (
   units: number,
   contentAmount: number,
   openedRemaining: number | null,
 ): string => {
-  const total =
-    openedRemaining !== null
-      ? (units - 1) * contentAmount + openedRemaining
-      : units * contentAmount;
+  const total = getLotRemainingAmount(units, contentAmount, openedRemaining);
   return total % 1 === 0 ? String(total) : total.toFixed(2).replace(/\.?0+$/, "");
 };
 

--- a/supabase/migrations/20260702000001_backfill_item_aggregate_expiry.sql
+++ b/supabase/migrations/20260702000001_backfill_item_aggregate_expiry.sql
@@ -1,0 +1,60 @@
+-- Backfill: items.expiry_date / opened_remaining could keep reflecting a
+-- fully depleted lot (zero remaining stock) because the app's aggregate
+-- sync did not exclude such lots. This caused already-out-of-stock items
+-- to keep showing up in the expiry calendar. Recompute existing rows using
+-- the same "active lot" rule the app now enforces (remaining amount > 0).
+with lot_amounts as (
+  select
+    l.id,
+    l.item_id,
+    l.units,
+    l.opened_remaining,
+    l.expiry_date,
+    case
+      when l.opened_remaining is not null
+        then greatest(0, l.units - 1) * i.content_amount + l.opened_remaining
+      else l.units * i.content_amount
+    end as remaining_amount
+  from item_lots l
+  join items i on i.id = l.item_id
+),
+active_lots as (
+  select * from lot_amounts where remaining_amount > 0
+),
+open_lot_counts as (
+  select item_id, count(*) as open_count
+  from active_lots
+  where opened_remaining is not null
+  group by item_id
+),
+single_open_lot as (
+  select a.item_id, a.opened_remaining
+  from active_lots a
+  join open_lot_counts c on c.item_id = a.item_id and c.open_count = 1
+  where a.opened_remaining is not null
+),
+aggregates as (
+  select
+    i.id as item_id,
+    coalesce(sum(l.units), 0) as total_units,
+    min(al.expiry_date) as earliest_expiry
+  from items i
+  left join item_lots l on l.item_id = i.id
+  left join active_lots al on al.item_id = i.id
+  group by i.id
+)
+update items
+set
+  units = aggregates.total_units,
+  expiry_date = aggregates.earliest_expiry,
+  opened_remaining = single_open_lot.opened_remaining,
+  updated_at = now()
+from aggregates
+left join single_open_lot on single_open_lot.item_id = aggregates.item_id
+where items.id = aggregates.item_id
+  and items.deleted_at is null
+  and (
+    items.units is distinct from aggregates.total_units
+    or items.expiry_date is distinct from aggregates.earliest_expiry
+    or items.opened_remaining is distinct from single_open_lot.opened_remaining
+  );


### PR DESCRIPTION
## Summary

- 消費入力画面（`/items/$itemId/consume`）のロット選択で、`opened_remaining` が `null` ではないだけで在庫ありと判定していたため、実際の残量が **0** のロット（例: 開封済みで使い切った状態 `units: 1, opened_remaining: 0`）が選択候補に表示されてしまう不具合を修正しました。
- **期限カレンダーで在庫ゼロのアイテムが表示され続ける不具合を修正しました。** 原因は `syncItemAggregate`（`item_lots` の内容から `items.expiry_date` / `opened_remaining` / `units` を再計算する処理）が、ロットの残量に関わらず全ロットの `expiry_date` を集計対象にしていたことです。ロットを消費し切って `units: 0, opened_remaining: null` になっても、その古い `expiry_date` がアイテム側に残り続け、カレンダーの「期限切れ」「今週」「今月」リストや月間カレンダーに在庫ゼロのアイテムが表示されてしまっていました。残量が **0 より大きい** ロットのみを集計対象にするよう修正しました。
- ロット単位の実残量計算（`units` と `opened_remaining` から合計量を出す処理）を `getLotRemainingAmount` として `src/types/item.ts` に共通化し、`formatRemaining` / 消費入力画面のロットフィルタ / `syncItemAggregate` で共通利用するようにしました。
- 既存データに残っている可能性のある古い `expiry_date` を修正するため、バックフィル用マイグレーション（`supabase/migrations/20260702000001_backfill_item_aggregate_expiry.sql`）を追加しました。**このマイグレーションは自動適用されていないため、本番DBには別途 `supabase db push` 等で適用してください。**

Closes #467

## Test plan

- [x] `bun test src/routes/-_auth.items.$itemId.consume.test.tsx` — `opened_remaining: 0` のロットのみの場合に「在庫がありません」表示になることを検証（既存12件 + 追加分すべて通過）
- [x] `bun test src/types/item.test.ts` — `getLotRemainingAmount` の単体テストを追加（在庫ゼロ判定のエッジケースを含む）
- [x] `bun run format:check`
- [x] `bun run check`（lint + typecheck）
- [x] `bun test`（全体）— 今回の変更と無関係な `ErrorBoundary.test.tsx` の既存失敗2件を除き全て通過（変更前のベースブランチでも同じ2件が失敗することを確認済み）
