### PR TITLE
fix: move invalidUnits to correct alphabetical position in shopping locale files

### DIFF
--- a/src/locales/en/shopping.json
+++ b/src/locales/en/shopping.json
@@ -15,6 +15,7 @@
   "editItem": "Edit",
   "editSave": "Save",
   "editSuccess": "Updated",
+  "invalidUnits": "Please enter a positive integer",
   "itemName": "Item name",
   "itemNamePlaceholder": "Enter item name",
   "markPurchased": "Add to Inventory",
@@ -27,6 +28,5 @@
   "restock": "Restock",
   "share": "Share",
   "shareShoppingList": "Share Shopping List",
-  "invalidUnits": "Please enter a positive integer",
   "title": "Shopping List"
 }

--- a/src/locales/ja/shopping.json
+++ b/src/locales/ja/shopping.json
@@ -15,6 +15,7 @@
   "editItem": "編集",
   "editSave": "保存",
   "editSuccess": "更新しました",
+  "invalidUnits": "1以上の整数を入力してください",
   "itemName": "商品名",
   "itemNamePlaceholder": "商品名を入力",
   "markPurchased": "在庫に追加",
@@ -27,6 +28,5 @@
   "restock": "再購入",
   "share": "共有",
   "shareShoppingList": "買い物リストを共有",
-  "invalidUnits": "1以上の整数を入力してください",
   "title": "買い物リスト"
 }


### PR DESCRIPTION
## Summary

- Moves `invalidUnits` key from after `shareShoppingList` to after `editSuccess` in both `src/locales/en/shopping.json` and `src/locales/ja/shopping.json`
- The key was at position 29 (alphabetically incorrect) and must be at position 17 (after "editSuccess", before "itemName") to satisfy `oxfmt`'s case-insensitive alphabetical key order enforcement
- Without this fix, any PR that merges with current main will fail the quality/format-check CI job

## Context

`invalidUnits` was added to the shopping locale files on main with the wrong ordering. Since `oxfmt` enforces case-insensitive alphabetical key ordering in JSON files, all open PRs fail the format check when their merge commits include these incorrectly-ordered keys from main.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nf7CiR35AbxvXMcAS3D4ue)_