### PR TITLE
fix: 複数の軽微なバグ修正 (#439 #442 #434 #457 #455 #452)

### DIFF
--- a/src/components/molecules/ShoppingRow.test.tsx
+++ b/src/components/molecules/ShoppingRow.test.tsx
@@ -171,6 +171,68 @@ describe("ShoppingRow", () => {
     expect(spinner).not.toBeNull();
   });
 
+  it("Enterキーで名前欄が空のまま保存しようとするとブロックされエラーを表示する (#457)", () => {
+    // name="" は「編集中に名前欄を全消去した」状態と等価（editName の初期値は name prop）。
+    const onEditSave = mock(() => {});
+    const { container, getByPlaceholderText } = render(
+      <ShoppingRow
+        id="abc"
+        name=""
+        desiredUnits={2}
+        isEditing
+        onEditSave={onEditSave}
+        onEditCancel={() => {}}
+      />,
+      { wrapper },
+    );
+    const nameInput = getByPlaceholderText(/商品名|item name/i) as HTMLInputElement;
+    fireEvent.keyDown(nameInput, { key: "Enter" });
+
+    expect(onEditSave).not.toHaveBeenCalled();
+    expect(container.textContent).toMatch(/商品名を入力してください|Please enter an item name/);
+  });
+
+  it("Saveボタンは名前欄が空の間disabledになる(ボタン/Enterの非対称解消)", () => {
+    const { getAllByRole } = render(
+      <ShoppingRow
+        id="1"
+        name=""
+        desiredUnits={2}
+        isEditing
+        onEditSave={() => {}}
+        onEditCancel={() => {}}
+      />,
+      { wrapper },
+    );
+    const buttons = getAllByRole("button");
+    const saveBtn = buttons.find((b) => !b.querySelector("svg") && b.className.includes("flex-1"));
+    expect((saveBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("名前欄を再入力すると、エラーが消えて保存できる", async () => {
+    const onEditSave = mock(() => {});
+    const user = userEvent.setup();
+    const { getByRole, queryByText, getByPlaceholderText } = render(
+      <ShoppingRow
+        id="1"
+        name=""
+        desiredUnits={2}
+        isEditing
+        onEditSave={onEditSave}
+        onEditCancel={() => {}}
+      />,
+      { wrapper },
+    );
+    const nameInput = getByPlaceholderText(/商品名|item name/i);
+    fireEvent.keyDown(nameInput, { key: "Enter" });
+    expect(queryByText(/商品名を入力してください|Please enter an item name/)).not.toBeNull();
+
+    await user.type(nameInput, "卵");
+    await user.click(getByRole("button", { name: /保存|Save/i }));
+    expect(queryByText(/商品名を入力してください|Please enter an item name/)).toBeNull();
+    expect(onEditSave).toHaveBeenCalledWith("1", expect.objectContaining({ name: "卵" }));
+  });
+
   it("shows validation error when saving with invalid units", async () => {
     const onEditSave = mock(() => {});
     const user = userEvent.setup();

--- a/src/components/molecules/ShoppingRow.tsx
+++ b/src/components/molecules/ShoppingRow.tsx
@@ -43,12 +43,14 @@ export const ShoppingRow = ({
   const [editName, setEditName] = useState(name);
   const [editUnits, setEditUnits] = useState(String(desiredUnits));
   const [editNote, setEditNote] = useState(note ?? "");
+  const [nameError, setNameError] = useState(false);
   const [unitsError, setUnitsError] = useState<string | null>(null);
 
   const resetEditState = () => {
     setEditName(name);
     setEditUnits(String(desiredUnits));
     setEditNote(note ?? "");
+    setNameError(false);
     setUnitsError(null);
   };
 
@@ -58,6 +60,10 @@ export const ShoppingRow = ({
   };
 
   const handleSave = () => {
+    if (!editName.trim()) {
+      setNameError(true);
+      return;
+    }
     const parsedUnits = parseInt(editUnits, 10);
     if (isNaN(parsedUnits) || parsedUnits <= 0) {
       setUnitsError(t("invalidUnits"));
@@ -65,7 +71,7 @@ export const ShoppingRow = ({
     }
     setUnitsError(null);
     onEditSave?.(id, {
-      name: editName.trim() || name,
+      name: editName.trim(),
       desiredUnits: parsedUnits,
       note: editNote.trim() || null,
     });
@@ -81,15 +87,20 @@ export const ShoppingRow = ({
       <div className="space-y-2 rounded-lg border p-3">
         <Input
           value={editName}
-          onChange={(e) => setEditName(e.target.value)}
+          onChange={(e) => {
+            setEditName(e.target.value);
+            if (nameError) setNameError(false);
+          }}
           placeholder={t("itemNamePlaceholder")}
           autoFocus
           disabled={isSaving}
+          aria-invalid={nameError}
           onKeyDown={(e) => {
             if (e.key === "Enter") handleSave();
             if (e.key === "Escape") handleCancel();
           }}
         />
+        {nameError && <p className="mt-0.5 text-xs text-destructive">{t("nameRequired")}</p>}
         <div className="flex gap-2">
           <div className="flex-1">
             <Input

--- a/src/components/organisms/NotificationSettings.test.tsx
+++ b/src/components/organisms/NotificationSettings.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { type ReactNode } from "react";
+import { I18nextProvider } from "react-i18next";
+
+import * as useNotificationPreferencesModule from "@/hooks/useNotificationPreferences";
+import i18n from "@/lib/i18n";
+import { ToastContext, type ToastContextValue } from "@/lib/toast-context";
+
+import { NotificationSettings } from "./NotificationSettings";
+
+const toastMock = mock<(message: string, variant?: "success" | "error") => void>(() => {});
+
+const wrapper = ({ children }: { children: ReactNode }) => {
+  const stubToast: ToastContextValue = { toasts: [], toast: toastMock, dismiss: () => {} };
+  return (
+    <I18nextProvider i18n={i18n}>
+      <ToastContext.Provider value={stubToast}>{children}</ToastContext.Provider>
+    </I18nextProvider>
+  );
+};
+
+describe("NotificationSettings", () => {
+  let prefsSpy: ReturnType<typeof spyOn>;
+  let updateSpy: ReturnType<typeof spyOn>;
+  const mutateAsync = mock(() => Promise.resolve());
+
+  beforeEach(() => {
+    toastMock.mockClear();
+    mutateAsync.mockClear();
+
+    prefsSpy = spyOn(
+      useNotificationPreferencesModule,
+      "useNotificationPreferences",
+    ).mockReturnValue({
+      data: {
+        user_id: "user-1",
+        push_enabled: false,
+        email_enabled: false,
+        email_address: null,
+        threshold_days: 3,
+        notify_at: "08:00",
+      },
+    } as unknown as ReturnType<typeof useNotificationPreferencesModule.useNotificationPreferences>);
+
+    updateSpy = spyOn(
+      useNotificationPreferencesModule,
+      "useUpdateNotificationPreferences",
+    ).mockReturnValue({
+      mutateAsync,
+    } as unknown as ReturnType<
+      typeof useNotificationPreferencesModule.useUpdateNotificationPreferences
+    >);
+  });
+
+  afterEach(() => {
+    prefsSpy.mockRestore();
+    updateSpy.mockRestore();
+  });
+
+  it("通知日数に31以上を入力してフォーカスアウトするとエラートーストを表示し保存しない (#455)", () => {
+    const { getByLabelText } = render(<NotificationSettings />, { wrapper });
+    const thresholdInput = getByLabelText(/日数前|Days before/i);
+    fireEvent.blur(thresholdInput, { target: { value: "31" } });
+
+    expect(toastMock).toHaveBeenCalledWith(expect.stringMatching(/0.*30|30.*0/), "error");
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("通知日数に負数を入力してフォーカスアウトするとエラートーストを表示し保存しない", () => {
+    const { getByLabelText } = render(<NotificationSettings />, { wrapper });
+    const thresholdInput = getByLabelText(/日数前|Days before/i);
+    fireEvent.blur(thresholdInput, { target: { value: "-1" } });
+
+    expect(toastMock).toHaveBeenCalled();
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("通知日数に有効な値を入力してフォーカスアウトすると保存されエラートーストは出ない", async () => {
+    const { getByLabelText } = render(<NotificationSettings />, { wrapper });
+    const thresholdInput = getByLabelText(/日数前|Days before/i);
+    fireEvent.blur(thresholdInput, { target: { value: "5" } });
+
+    expect(toastMock).not.toHaveBeenCalled();
+    expect(mutateAsync).toHaveBeenCalledWith({ threshold_days: 5 });
+  });
+
+  it("通知時刻を空にしてフォーカスアウトするとエラートーストを表示し保存しない (#455)", () => {
+    const { getByLabelText } = render(<NotificationSettings />, { wrapper });
+    const notifyAtInput = getByLabelText(/通知時刻|Notification time/i);
+    fireEvent.blur(notifyAtInput, { target: { value: "" } });
+
+    expect(toastMock).toHaveBeenCalledWith(expect.any(String), "error");
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/organisms/NotificationSettings.tsx
+++ b/src/components/organisms/NotificationSettings.tsx
@@ -95,7 +95,10 @@ export const NotificationSettings = () => {
 
   const handleThresholdBlur = async (val: string) => {
     const days = parseInt(val, 10);
-    if (isNaN(days) || days < 0 || days > 30) return;
+    if (isNaN(days) || days < 0 || days > 30) {
+      toast(t("invalidThresholdDays"), "error");
+      return;
+    }
     try {
       await updatePrefs.mutateAsync({ threshold_days: days });
     } catch (error) {
@@ -106,7 +109,10 @@ export const NotificationSettings = () => {
   };
 
   const handleNotifyAtBlur = async (val: string) => {
-    if (!val) return;
+    if (!val) {
+      toast(t("invalidNotifyAt"), "error");
+      return;
+    }
     try {
       await updatePrefs.mutateAsync({ notify_at: val });
     } catch (error) {

--- a/src/hooks/useItems.supabase.test.ts
+++ b/src/hooks/useItems.supabase.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { Item } from "@/types/item";
+
+interface SupabaseResponse {
+  data: unknown;
+  error: unknown;
+}
+
+let callLog: Array<{ table: string; method: string; args: unknown[] }> = [];
+const responseQueues: Record<string, SupabaseResponse[]> = {};
+
+const defaultResponse: SupabaseResponse = { data: null, error: null };
+
+const makeBuilder = (table: string, response: SupabaseResponse) => {
+  const builder: Record<string, unknown> = {};
+  const chainMethod =
+    (method: string) =>
+    (...args: unknown[]) => {
+      callLog.push({ table, method, args });
+      return builder;
+    };
+
+  Object.assign(builder, {
+    select: chainMethod("select"),
+    eq: chainMethod("eq"),
+    is: chainMethod("is"),
+    not: chainMethod("not"),
+    or: chainMethod("or"),
+    limit: chainMethod("limit"),
+    order: chainMethod("order"),
+    insert: chainMethod("insert"),
+    update: chainMethod("update"),
+    single: () => {
+      callLog.push({ table, method: "single", args: [] });
+      return Promise.resolve(response);
+    },
+    maybeSingle: () => {
+      callLog.push({ table, method: "maybeSingle", args: [] });
+      return Promise.resolve(response);
+    },
+    then: (resolve: (v: SupabaseResponse) => void, reject?: (e: unknown) => void) =>
+      Promise.resolve(response).then(resolve, reject),
+  });
+  return builder;
+};
+
+const fromMock = mock((table: string) => {
+  const queue = responseQueues[table];
+  const response = queue && queue.length > 0 ? queue.shift()! : defaultResponse;
+  return makeBuilder(table, response);
+});
+
+mock.module("@/lib/supabase", () => ({
+  supabase: { from: fromMock },
+}));
+
+const { fetchItem, tryStackToActiveItem, buildNameOrBarcodeSearchFilter, escapeOrFilterValue } =
+  await import("@/hooks/useItems");
+
+const makeItem = (overrides: Partial<Item> = {}): Item => ({
+  id: "item-1",
+  user_id: "user-1",
+  name: "Test Item",
+  barcode: "123456",
+  category_id: null,
+  storage_location_id: null,
+  units: 1,
+  content_amount: 1,
+  content_unit: "個",
+  opened_remaining: null,
+  purchase_date: null,
+  expiry_date: null,
+  notes: null,
+  image_path: null,
+  deleted_at: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  ...overrides,
+});
+
+beforeEach(() => {
+  callLog = [];
+  for (const key of Object.keys(responseQueues)) delete responseQueues[key];
+});
+
+describe("fetchItem", () => {
+  test("deleted_at IS NULL でフィルタする (#439: ソフトデリート済みアイテムへの直アクセス防止)", async () => {
+    responseQueues.items = [{ data: makeItem(), error: null }];
+    await fetchItem("item-1");
+
+    const isCall = callLog.find((c) => c.table === "items" && c.method === "is");
+    expect(isCall?.args).toEqual(["deleted_at", null]);
+  });
+
+  test("該当行がない(ソフトデリート済み等)場合はエラーをthrowする", async () => {
+    responseQueues.items = [{ data: null, error: { message: "no rows", code: "PGRST116" } }];
+    await expect(fetchItem("item-1")).rejects.toBeTruthy();
+  });
+});
+
+describe("tryStackToActiveItem", () => {
+  test("最終再取得でerrorが返るとthrowする (#442: onSuccess内での未処理例外を防止)", async () => {
+    responseQueues.items = [
+      { data: makeItem(), error: null }, // 1st call: find matching active item
+      { data: null, error: { message: "boom" } }, // 2nd call: refetch after createLot
+    ];
+    responseQueues.item_lots = [
+      { data: { id: "lot-1" }, error: null }, // createLot insert
+      { data: [{ units: 1, expiry_date: null, opened_remaining: null }], error: null }, // syncItemAggregate select
+    ];
+
+    await expect(
+      tryStackToActiveItem("123456", { name: "Test", units: 1 }, "user-1"),
+    ).rejects.toBeTruthy();
+  });
+
+  test("マッチするアイテムがなければnullを返す", async () => {
+    responseQueues.items = [{ data: null, error: null }];
+    const result = await tryStackToActiveItem("000000", { name: "Test", units: 1 }, "user-1");
+    expect(result).toBeNull();
+  });
+});
+
+describe("buildNameOrBarcodeSearchFilter", () => {
+  test("通常の検索語はname/barcode両方のilikeパターンを生成する", () => {
+    expect(buildNameOrBarcodeSearchFilter("milk")).toBe(
+      'name.ilike."%milk%",barcode.ilike."%milk%"',
+    );
+  });
+
+  test("PostgRESTのor()予約文字(カンマ・括弧・ピリオド)を含む検索語でも壊れない (#434)", () => {
+    const filter = buildNameOrBarcodeSearchFilter("1L, 2本入り(お得)");
+    // Reserved chars are safely contained inside a quoted value, not left to break or() parsing.
+    expect(filter).toBe('name.ilike."%1L, 2本入り(お得)%",barcode.ilike."%1L, 2本入り(お得)%"');
+  });
+
+  test("ダブルクォートやバックスラッシュはエスケープされる", () => {
+    expect(escapeOrFilterValue('a"b\\c')).toBe('a\\"b\\\\c');
+  });
+});

--- a/src/hooks/useItems.ts
+++ b/src/hooks/useItems.ts
@@ -39,6 +39,19 @@ const matchesItemFilters = (item: Item, filters: ItemFilters): boolean => {
   return true;
 };
 
+/**
+ * PostgREST の `.or()` フィルタ構文で予約されている文字（`,` `(` `)`）を含む検索語でも
+ * 安全に渡せるよう、値をダブルクォートで囲みエスケープする。
+ * （`\` と `"` はダブルクォート内で意味を持つためエスケープが必要）
+ */
+export const escapeOrFilterValue = (value: string) =>
+  value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+
+export const buildNameOrBarcodeSearchFilter = (search: string): string => {
+  const escaped = escapeOrFilterValue(search);
+  return `name.ilike."%${escaped}%",barcode.ilike."%${escaped}%"`;
+};
+
 const fetchItems = async (
   filters: ItemFilters = {},
   sort: ItemSortKey = "created_at",
@@ -46,7 +59,7 @@ const fetchItems = async (
   let query = supabase.from("items").select("*").is("deleted_at", null);
 
   if (filters.search) {
-    query = query.or(`name.ilike.%${filters.search}%,barcode.ilike.%${filters.search}%`);
+    query = query.or(buildNameOrBarcodeSearchFilter(filters.search));
   }
   if (filters.categoryId) {
     query = query.eq("category_id", filters.categoryId);
@@ -66,8 +79,13 @@ const fetchItems = async (
   return (data ?? []) as Item[];
 };
 
-const fetchItem = async (id: string): Promise<Item> => {
-  const { data, error } = await supabase.from("items").select("*").eq("id", id).single();
+export const fetchItem = async (id: string): Promise<Item> => {
+  const { data, error } = await supabase
+    .from("items")
+    .select("*")
+    .eq("id", id)
+    .is("deleted_at", null)
+    .single();
   if (error) throw error;
   return data as Item;
 };
@@ -137,12 +155,12 @@ export const normalizeUpdateValues = (values: Partial<ItemFormValues>) => {
  * バーコードが一致するアクティブなアイテムを探す。
  * 見つかった場合は新規ロットを追加してそのアイテムを返す。なければ null。
  */
-const tryStackToActiveItem = async (
+export const tryStackToActiveItem = async (
   barcode: string,
   values: ItemFormValues,
   userId: string,
 ): Promise<Item | null> => {
-  const { data } = await supabase
+  const { data, error: findError } = await supabase
     .from("items")
     .select("*")
     .eq("user_id", userId)
@@ -150,6 +168,7 @@ const tryStackToActiveItem = async (
     .is("deleted_at", null)
     .limit(1)
     .maybeSingle();
+  if (findError) throw findError;
   if (!data) return null;
 
   const item = data as Item;
@@ -161,7 +180,12 @@ const tryStackToActiveItem = async (
   });
   await syncItemAggregate(item.id);
 
-  const { data: updated } = await supabase.from("items").select("*").eq("id", item.id).single();
+  const { data: updated, error } = await supabase
+    .from("items")
+    .select("*")
+    .eq("id", item.id)
+    .single();
+  if (error) throw error;
   return updated as Item;
 };
 

--- a/src/locales/en/notifications.json
+++ b/src/locales/en/notifications.json
@@ -3,6 +3,8 @@
   "emailAddress": "Email Address",
   "emailEnabled": "Email Notifications",
   "invalidEmailAddress": "Please enter a valid email address",
+  "invalidNotifyAt": "Please enter a notification time",
+  "invalidThresholdDays": "Please enter a value between 0 and 30",
   "notifyAt": "Notification time",
   "pushEnabled": "Push Notifications",
   "pushNotSupported": "Push notifications are not supported in this browser. Please use email notifications instead.",

--- a/src/locales/en/shopping.json
+++ b/src/locales/en/shopping.json
@@ -20,6 +20,7 @@
   "itemName": "Item name",
   "itemNamePlaceholder": "Enter item name",
   "markPurchased": "Add to Inventory",
+  "nameRequired": "Please enter an item name",
   "noItems": "Shopping list is empty",
   "noPurchased": "No purchased items",
   "note": "Note",

--- a/src/locales/ja/notifications.json
+++ b/src/locales/ja/notifications.json
@@ -3,6 +3,8 @@
   "emailAddress": "メールアドレス",
   "emailEnabled": "メール通知",
   "invalidEmailAddress": "有効なメールアドレスを入力してください",
+  "invalidNotifyAt": "通知時刻を入力してください",
+  "invalidThresholdDays": "0〜30の範囲で入力してください",
   "notifyAt": "通知時刻",
   "pushEnabled": "プッシュ通知",
   "pushNotSupported": "このブラウザはプッシュ通知に対応していません。メール通知をご利用ください。",

--- a/src/locales/ja/shopping.json
+++ b/src/locales/ja/shopping.json
@@ -20,6 +20,7 @@
   "itemName": "商品名",
   "itemNamePlaceholder": "商品名を入力",
   "markPurchased": "在庫に追加",
+  "nameRequired": "商品名を入力してください",
   "noItems": "買い物リストは空です",
   "noPurchased": "購入済みアイテムはありません",
   "note": "メモ",

--- a/src/routes/-_auth.index.test.tsx
+++ b/src/routes/-_auth.index.test.tsx
@@ -5,7 +5,8 @@ import {
   createRouter,
   RouterProvider,
 } from "@tanstack/react-router";
-import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
 import { type ReactNode } from "react";
 import { I18nextProvider } from "react-i18next";
@@ -173,5 +174,28 @@ describe("DashboardPage", () => {
     // filtered には ok アイテムのみが入るが、urgentItems は全アイテムから計算されるため
     // 期限切れアイテムがある警告バナーは引き続き表示されるべき
     expect(queryByText(URGENT_BANNER_RE)).not.toBeNull();
+  });
+
+  it("検索欄への入力はデバウンスされ、キー入力ごとにuseItemsを再クエリしない (#452)", async () => {
+    const user = userEvent.setup();
+    const { getByPlaceholderText } = await renderPage();
+
+    const searchInput = getByPlaceholderText(/search by name|商品名・バーコードで検索/i);
+    await user.type(searchInput, "milk");
+
+    // デバウンス時間(300ms)内はuseItemsに新しいsearchがまだ渡らない
+    const lastCallRightAfterTyping = itemsspy.mock.calls.at(-1)?.[0] as
+      | { search?: string }
+      | undefined;
+    expect(lastCallRightAfterTyping?.search).not.toBe("milk");
+
+    // デバウンス完了後、URLに反映されuseItemsが新しいsearchで呼ばれる
+    await waitFor(
+      () => {
+        const lastCall = itemsspy.mock.calls.at(-1)?.[0] as { search?: string } | undefined;
+        expect(lastCall?.search).toBe("milk");
+      },
+      { timeout: 2000 },
+    );
   });
 });

--- a/src/routes/_auth.index.tsx
+++ b/src/routes/_auth.index.tsx
@@ -27,6 +27,41 @@ const dashboardSearchSchema = z.object({
   expiry: z.string().optional().default(""),
 });
 
+const SEARCH_DEBOUNCE_MS = 300;
+
+interface SearchInputProps {
+  initialValue: string;
+  placeholder: string;
+  onDebouncedChange: (value: string) => void;
+}
+
+/**
+ * キー入力ごとのURL遷移/Supabase再クエリを避けるため、ローカルstateで入力を受けてからデバウンスする。
+ * 親で `key={search}` を指定し、URLのsearchが外部要因(戻る/進む等)で変わったら再マウントで追従させる。
+ */
+const SearchInput = ({ initialValue, placeholder, onDebouncedChange }: SearchInputProps) => {
+  const [value, setValue] = useState(initialValue);
+
+  useEffect(() => {
+    if (value === initialValue) return;
+    const timer = setTimeout(() => onDebouncedChange(value), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  return (
+    <div className="relative flex-1">
+      <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+      <Input
+        className="pl-9"
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    </div>
+  );
+};
+
 export const DashboardPage = () => {
   const { t } = useTranslation("items");
   const { t: tc } = useTranslation("common");
@@ -300,15 +335,12 @@ export const DashboardPage = () => {
 
       {/* Search */}
       <div className="flex gap-2">
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            className="pl-9"
-            placeholder={t("searchPlaceholder")}
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-          />
-        </div>
+        <SearchInput
+          key={search}
+          initialValue={search}
+          placeholder={t("searchPlaceholder")}
+          onDebouncedChange={setSearch}
+        />
         <Button
           variant={showFilters ? "default" : "outline"}
           size="icon"


### PR DESCRIPTION
## 概要

Claude Routines（バグ洗い出し）で発見された、以下6件の軽微なバグを修正します。

### #439: useItem(id) がdeleted_atでフィルタしておらず、削除済みアイテムの詳細ページに直アクセスできる
`fetchItem` に `.is("deleted_at", null)` を追加。該当行がない場合は既存の404相当UI（`itemNotFound`）にフォールバックする。

### #442: tryStackToActiveItemの再取得クエリでerrorを検査していない
最終再取得の `error` を検査し、失敗時は `throw error` するよう修正。`onSuccess` 内での未処理例外を防止。

### #434: fetchItems() の検索クエリが未サニタイズのままPostgRESTの.or()フィルタに連結される
`buildNameOrBarcodeSearchFilter` / `escapeOrFilterValue` を追加し、検索語をダブルクォートで安全に囲んでからPostgRESTへ渡す。

### #457: ShoppingRow: 名前欄を空にしてEnterで保存すると、エラー表示なく元の名前へ静かに巻き戻る
`handleSave` の先頭で名前必須チェックを追加し、Saveボタンの`disabled`と同じ基準でEnterキー経由の保存もブロック。エラーメッセージ（`nameRequired`）を表示する。

### #455: NotificationSettings の期限通知日数・通知時刻のバリデーション失敗時に何のフィードバックもない
`handleThresholdBlur` / `handleNotifyAtBlur` のバリデーション失敗時に `toast` でエラー表示するよう修正。

### #452: ダッシュボード検索欄がデバウンスなしで1文字ごとにURL遷移とSupabase再クエリを発生させる
検索欄を `SearchInput` サブコンポーネントに切り出し、300msのデバウンス後にURL(`q`パラメータ)へ反映するよう変更。`key={search}` で外部要因によるURL変化にも追従。

## テスト

- [x] `bun run format:check`
- [x] `bun run check`（lint + typecheck）
- [x] `bun test`（全210件パス）
- [x] `bun run build`
- [x] `bun run knip`

各修正に対応するユニットテストを追加済み（`useItems.supabase.test.ts` 新規作成、`ShoppingRow.test.tsx` / `NotificationSettings.test.tsx` / `-_auth.index.test.tsx` に追加）。

Closes #439
Closes #442
Closes #434
Closes #457
Closes #455
Closes #452

---
🤖 Claude Routines（バグ洗い出し・新機能提案）による自動実装

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01H7orBVd1YjDpjExJawFrJF