### PR TITLE
fix: theme warning badge colors

### DIFF
--- a/src/components/ui/badge-variants.ts
+++ b/src/components/ui/badge-variants.ts
@@ -11,7 +11,7 @@ export const badgeVariants = cva(
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
         outline: "text-foreground",
-        warning: "border-transparent bg-yellow-100 text-yellow-800 hover:bg-yellow-100/80",
+        warning: "border-transparent bg-warning text-warning-foreground hover:bg-warning/80",
       },
     },
     defaultVariants: {

--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,8 @@
   --color-accent-foreground: hsl(var(--accent-foreground));
   --color-destructive: hsl(var(--destructive));
   --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-warning: hsl(var(--warning));
+  --color-warning-foreground: hsl(var(--warning-foreground));
   --color-border: hsl(var(--border));
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));
@@ -43,6 +45,8 @@
   --accent-foreground: 222.2 47.4% 11.2%;
   --destructive: 0 84.2% 60.2%;
   --destructive-foreground: 210 40% 98%;
+  --warning: 48 96% 89%;
+  --warning-foreground: 32 95% 20%;
   --border: 214.3 31.8% 91.4%;
   --input: 214.3 31.8% 91.4%;
   --ring: 221.2 83.2% 53.3%;
@@ -66,6 +70,8 @@
   --accent-foreground: 210 40% 98%;
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 210 40% 98%;
+  --warning: 45 93% 15%;
+  --warning-foreground: 48 96% 89%;
   --border: 217.2 32.6% 17.5%;
   --input: 217.2 32.6% 17.5%;
   --ring: 224.3 76.3% 48%;


### PR DESCRIPTION
## Summary
- Fixes #487
- Adds warning color tokens for light and dark themes
- Updates the badge warning variant to use theme tokens instead of hard-coded yellow utilities

## Validation
- bun run format:check
- bun run check