### PR TITLE
fix: ダークモードでの視認性バグを修正 (#488 #489)

### DIFF
--- a/src/components/atoms/ColorPicker.test.tsx
+++ b/src/components/atoms/ColorPicker.test.tsx
@@ -1,0 +1,22 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "bun:test";
+
+import { ColorPicker } from "./ColorPicker";
+
+describe("ColorPicker", () => {
+  it("marks the selected color with aria-pressed and a visible ring", () => {
+    const { getByLabelText } = render(<ColorPicker value="#3b82f6" onChange={() => {}} />);
+    const selected = getByLabelText("#3b82f6");
+    const unselected = getByLabelText("#ef4444");
+
+    expect(selected.getAttribute("aria-pressed")).toBe("true");
+    expect(selected.className).toContain("ring-ring");
+    expect(unselected.getAttribute("aria-pressed")).toBe("false");
+    expect(unselected.className).not.toContain("ring-ring");
+  });
+
+  it("marks no swatch as pressed when value is null", () => {
+    const { getByLabelText } = render(<ColorPicker value={null} onChange={() => {}} />);
+    expect(getByLabelText("#3b82f6").getAttribute("aria-pressed")).toBe("false");
+  });
+});

--- a/src/components/atoms/ColorPicker.tsx
+++ b/src/components/atoms/ColorPicker.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@/lib/utils";
+
 const PALETTE = [
   "#ef4444",
   "#f97316",
@@ -23,12 +25,13 @@ export const ColorPicker = ({ value, onChange }: ColorPickerProps) => (
         key={color}
         type="button"
         aria-label={color}
+        aria-pressed={value === color}
         onClick={() => onChange(color)}
-        className="h-7 w-7 rounded-full border-2 transition-transform hover:scale-110"
-        style={{
-          backgroundColor: color,
-          borderColor: value === color ? "#000" : "transparent",
-        }}
+        className={cn(
+          "h-7 w-7 rounded-full border-2 border-transparent transition-transform hover:scale-110",
+          value === color && "ring-2 ring-ring ring-offset-2 ring-offset-background",
+        )}
+        style={{ backgroundColor: color }}
       />
     ))}
   </div>

--- a/src/components/atoms/ErrorBoundary.test.tsx
+++ b/src/components/atoms/ErrorBoundary.test.tsx
@@ -36,7 +36,10 @@ describe("ErrorBoundary", () => {
       </ErrorBoundary>,
       { wrapper },
     );
-    expect(getByText(UNKNOWN_ERROR_TEXT)).not.toBeNull();
+    const message = getByText(UNKNOWN_ERROR_TEXT);
+    expect(message).not.toBeNull();
+    expect(message.className).toContain("text-muted-foreground");
+    expect(message.className).not.toContain("text-gray-500");
     expect(getByText(RETRY_TEXT)).not.toBeNull();
     consoleSpy.mockRestore();
   });

--- a/src/components/atoms/ErrorBoundary.tsx
+++ b/src/components/atoms/ErrorBoundary.tsx
@@ -17,7 +17,7 @@ const ErrorFallback = ({ onRetry }: { onRetry: () => void }) => {
   const { t } = useTranslation("common");
   return (
     <div className="flex min-h-[200px] flex-col items-center justify-center gap-4 p-6 text-center">
-      <p className="text-sm text-gray-500">{t("unknownError")}</p>
+      <p className="text-sm text-muted-foreground">{t("unknownError")}</p>
       <Button variant="outline" size="sm" onClick={onRetry}>
         {t("retry")}
       </Button>


### PR DESCRIPTION
## 概要

Claude Routines（バグ洗い出し）で起票済みの、ダークモードでの視認性に関する軽微なバグ2件を修正します。

### #488: ColorPicker の選択中インジケータがダークモードでほぼ見えなくなる

`src/components/atoms/ColorPicker.tsx` は選択中の色を固定の黒枠(`borderColor: "#000"`)のみで示していたため、ダークモードの背景(`--background`がほぼ黒)ではコントラストがなく判別できませんでした。`ring-ring`（テーマトークン）によるリングで選択状態を表現するように変更し、`aria-pressed`属性も追加しました。

### #489: ErrorBoundary のフォールバック文言がライトモード専用色をハードコード

`src/components/atoms/ErrorBoundary.tsx` の`<p>`要素が`text-gray-500`を固定指定していたため、ダークモードでも中間グレーのまま表示されていました。`text-muted-foreground`（テーマトークン）に置き換えました。

## テスト

- [x] `bun run format:check`（`npx oxfmt .`で差分なしを確認）
- [x] `bun run check`（lint + typecheck）
- [x] `bun test`（全197件パス、新規/更新テストを含む）
- [x] `bun run build`
- [x] `bun run build-storybook`

`ColorPicker`にはこれまでUnit Testが存在しなかったため新規に`ColorPicker.test.tsx`を追加し、選択状態の`aria-pressed`とリング表示を検証しています。`ErrorBoundary.test.tsx`には`text-muted-foreground`が使われ`text-gray-500`が使われないことを検証するアサーションを追加しました。

Closes #488
Closes #489

---
🤖 Claude Routines（バグ洗い出し・新機能提案）による自動実装


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uw61tA9yAyD1SEfiecmDpB)_