### PR TITLE
fix: ColorDot に対応する Story と Unit Test を追加 (#474)

### DIFF
--- a/src/components/atoms/ColorDot.stories.tsx
+++ b/src/components/atoms/ColorDot.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ColorDot } from "./ColorDot";
+
+const meta = {
+  component: ColorDot,
+  tags: ["autodocs"],
+} satisfies Meta<typeof ColorDot>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { color: "#3b82f6" },
+};
+
+export const NoColor: Story = {
+  args: { color: null },
+};
+
+export const CustomSize: Story = {
+  args: { color: "#ef4444", className: "h-5 w-5" },
+};

--- a/src/components/atoms/ColorDot.test.tsx
+++ b/src/components/atoms/ColorDot.test.tsx
@@ -1,0 +1,24 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "bun:test";
+
+import { ColorDot } from "./ColorDot";
+
+describe("ColorDot", () => {
+  it("renders with the given color", () => {
+    const { container } = render(<ColorDot color="#3b82f6" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.backgroundColor).toBe("#3b82f6");
+  });
+
+  it("falls back to a default color when color is null", () => {
+    const { container } = render(<ColorDot color={null} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.backgroundColor).toBe("#6b7280");
+  });
+
+  it("applies a custom className", () => {
+    const { container } = render(<ColorDot color="#ef4444" className="h-5 w-5" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toContain("h-5 w-5");
+  });
+});


### PR DESCRIPTION
## 概要

Fixes #474

CLAUDE.md は「atoms/molecules/organismsを作るとき、必ず`.stories.tsx`を同時に作成する」と定めているが、`src/components/atoms/ColorDot.tsx` にのみ対応する Story ファイルが存在していなかった（規約違反）。

## 変更内容

- `src/components/atoms/ColorDot.stories.tsx` を追加（Default / NoColor / CustomSize の3状態を網羅、`ColorPicker.stories.tsx` 等の既存規約に準拠した `satisfies Meta<...>` + `tags: ["autodocs"]` 形式）
- `src/components/atoms/ColorDot.test.tsx` を追加（color指定時の反映、null時のフォールバック色、className適用の3ケース）

## 動作確認

- [x] `bun test src/components/atoms/ColorDot.test.tsx` — 3 pass
- [x] `npx oxfmt . ` — 差分なし
- [x] `bun run check`（lint + typecheck）— エラーなし
- [x] `bun run build` — 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JpbqjCq3Gdo8ufbBk83smc)_