### PR TITLE
fix(pwa): 更新直後に古い表示が残るバグを修正（SW キャッシュを NetworkFirst に変更）

### DIFF
--- a/docs/specs/features/pwa.md
+++ b/docs/specs/features/pwa.md
@@ -24,7 +24,9 @@
 3. **strategy**: `injectManifest`（Notifications spec の Service Worker と統合するため）
 4. プリキャッシュ: app shell（HTML/CSS/JS）、アイコン、フォント
 5. ランタイムキャッシュ:
-   - PostgREST GET（items / categories / locations / settings）: `stale-while-revalidate`、TTL 1h、最大 100
+   - PostgREST GET（items / categories / locations / settings）: `network-first`（timeout 5s でキャッシュへフォールバック）、TTL 1h、最大 100
+     - ※ 当初は `stale-while-revalidate` だったが、mutation 直後の TanStack Query refetch に
+       古いキャッシュが返り、更新結果が画面に反映されないバグがあったため network-first に変更
    - 画像（signed URL は短命なので image_path 単位でキャッシュキーを正規化する手法を検討、当面はネットワーク優先）
 6. mutation の抑止: `useOnlineStatus()` で `navigator.onLine` を監視、オフライン時は mutation hook 全体で早期 return + トースト
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,7 +1,7 @@
 import { ExpirationPlugin } from "workbox-expiration";
 import { cleanupOutdatedCaches, precacheAndRoute } from "workbox-precaching";
 import { registerRoute } from "workbox-routing";
-import { StaleWhileRevalidate } from "workbox-strategies";
+import { NetworkFirst } from "workbox-strategies";
 
 declare const self: ServiceWorkerGlobalScope;
 
@@ -10,12 +10,17 @@ cleanupOutdatedCaches();
 // Precache the app shell (injected by vite-plugin-pwa)
 precacheAndRoute(self.__WB_MANIFEST);
 
-// Runtime cache: Supabase PostgREST GET requests with stale-while-revalidate
+// Runtime cache: Supabase PostgREST GET requests with network-first.
+// StaleWhileRevalidate would serve cached (stale) data to the refetch that
+// TanStack Query fires right after a mutation, so the UI would keep showing
+// pre-update values. NetworkFirst always returns fresh data while online and
+// falls back to the cache only when the network is unavailable (offline read).
 registerRoute(
   ({ url }: { url: URL }) =>
     url.hostname.endsWith(".supabase.co") && url.pathname.startsWith("/rest/v1/"),
-  new StaleWhileRevalidate({
+  new NetworkFirst({
     cacheName: "supabase-rest-v1",
+    networkTimeoutSeconds: 5,
     plugins: [
       new ExpirationPlugin({
         maxEntries: 100,


### PR DESCRIPTION
Fixes #508

## 問題

PWA で商品の在庫消費や商品名変更を行うと、成功トースト（緑のモーダル）は表示されるが、画面上の商品情報が更新前のまま残る。DB 上は正しく更新されている。

## 原因

`src/sw.ts` の Service Worker が Supabase PostgREST の GET リクエストを **StaleWhileRevalidate** でキャッシュしていたため:

1. mutation 成功後、TanStack Query が `invalidateQueries` で refetch を実行する
2. その refetch (GET) に対して Service Worker が**古いキャッシュを即座に返す**（裏で再検証はするが、その結果は画面に届かない）
3. さらに `useConsumeItem` は消費後に GET で再取得した値を `setQueryData` するため、mutation レスポンス由来の新しいキャッシュも古いデータで上書きされてしまう

結果として、次回以降のアクセスまで更新が画面に反映されない状態になっていた。

## 修正内容

- `src/sw.ts`: Supabase REST のランタイムキャッシュ戦略を `StaleWhileRevalidate` → `NetworkFirst`（`networkTimeoutSeconds: 5`）に変更
  - オンライン時: 常にネットワークから最新データを取得（バグ解消）
  - オフライン時 / タイムアウト時: 従来どおりキャッシュにフォールバック（PWA 仕様のオフライン参照要件は維持）
- `docs/specs/features/pwa.md`: キャッシュ戦略の記述を実装に合わせて更新し、変更理由を追記

## 確認

- `npx oxfmt .` / `bun run check`（lint + typecheck）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015riGAxDfRZVPfVK5hxnfyE

---
_Generated by [Claude Code](https://claude.ai/code/session_015riGAxDfRZVPfVK5hxnfyE)_